### PR TITLE
Add deps:outdated command to show outdated dependencies

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,7 @@ async function main() {
   const { internalsResourceHashCommand, internalsResourceIdCommand } =
     await import('./commands/internals.ts')
   const { depsListCommand } = await import('./commands/deps/list.ts')
+  const { depsOutdatedCommand } = await import('./commands/deps/outdated.ts')
   const { depsWhyCommand } = await import('./commands/deps/why.ts')
 
   const commands = {
@@ -77,6 +78,7 @@ async function main() {
     status: statusCommand,
     logs: logsCommand,
     'deps:list': depsListCommand,
+    'deps:outdated': depsOutdatedCommand,
     'deps:why': depsWhyCommand,
     'internals:resource-hash': internalsResourceHashCommand,
     'internals:resource-id': internalsResourceIdCommand,

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -1,0 +1,116 @@
+import { Command } from '../../lib/command.ts'
+
+// ANSI color codes
+const COLORS = {
+  reset: '\x1b[0m',
+  white: '\x1b[37m',
+  grey: '\x1b[90m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  bold: '\x1b[1m',
+}
+
+/**
+ * Parse a semver version string into components.
+ */
+const parseVersion = (
+  version: string,
+): { major: number; minor: number; patch: number } | null => {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)/)
+  if (!match) return null
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+  }
+}
+
+/**
+ * Get the color for a version update based on semver difference.
+ * - white: versions match
+ * - green: patch version update
+ * - yellow: minor version update
+ * - red: major version update
+ */
+const getVersionColor = (current: string, target: string): string => {
+  if (current === target) return COLORS.white
+
+  const currentParsed = parseVersion(current)
+  const targetParsed = parseVersion(target)
+
+  if (!currentParsed || !targetParsed) return COLORS.white
+
+  if (targetParsed.major !== currentParsed.major) {
+    return COLORS.red
+  }
+  if (targetParsed.minor !== currentParsed.minor) {
+    return COLORS.yellow
+  }
+  if (targetParsed.patch !== currentParsed.patch) {
+    return COLORS.green
+  }
+
+  return COLORS.white
+}
+
+export const depsOutdatedCommand = new Command({
+  name: 'deps:outdated',
+  description: 'Show outdated dependencies',
+  usage: 'deps:outdated',
+  example: 'denvig deps:outdated',
+  args: [],
+  flags: [],
+  handler: async ({ project }) => {
+    const outdated = await project.outdatedDependencies()
+    const entries = Object.entries(outdated)
+
+    if (entries.length === 0) {
+      console.log('All dependencies are up to date!')
+      return { success: true, message: 'All dependencies up to date.' }
+    }
+
+    // Sort entries alphabetically
+    const sortedEntries = entries.sort((a, b) => a[0].localeCompare(b[0]))
+
+    // Calculate column widths for nice formatting
+    // Account for "(dev)" suffix in name column
+    const maxNameLen = Math.max(
+      ...entries.map(([name, info]) =>
+        info.isDevDependency ? name.length + 6 : name.length,
+      ),
+      10,
+    )
+    const maxVersionLen = Math.max(
+      ...entries.map(([, info]) =>
+        Math.max(info.current.length, info.wanted.length, info.latest.length),
+      ),
+      7,
+    )
+
+    // Print header
+    console.log(
+      `${'Package'.padEnd(maxNameLen)}  ${'Current'.padEnd(maxVersionLen)}  ${'Wanted'.padEnd(maxVersionLen)}  ${'Latest'.padEnd(maxVersionLen)}`,
+    )
+    console.log('-'.repeat(maxNameLen + maxVersionLen * 3 + 6))
+
+    // Print each dependency
+    for (const [name, info] of sortedEntries) {
+      const wantedColor = getVersionColor(info.current, info.wanted)
+      const latestColor = getVersionColor(info.current, info.latest)
+
+      const devSuffix = info.isDevDependency
+        ? `${COLORS.grey} (dev)${COLORS.reset}`
+        : ''
+      const displayName = info.isDevDependency
+        ? name.padEnd(maxNameLen - 6)
+        : name.padEnd(maxNameLen)
+
+      console.log(
+        `${displayName}${devSuffix}  ${info.current.padEnd(maxVersionLen)}  ${wantedColor}${info.wanted.padEnd(maxVersionLen)}${COLORS.reset}  ${latestColor}${info.latest.padEnd(maxVersionLen)}${COLORS.reset}`,
+      )
+    }
+
+    return { success: true, message: 'Outdated dependencies listed.' }
+  },
+})

--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -1,12 +1,41 @@
 import type { ProjectDependencySchema } from './dependencies'
 import type { DenvigProject } from './project'
 
+/**
+ * Information about an outdated dependency
+ */
+export type OutdatedDependency = {
+  /** Current installed version */
+  current: string
+  /** Latest version compatible with the specifier (semver) */
+  wanted: string
+  /** Absolute latest version available */
+  latest: string
+  /** The version specifier from package.json */
+  specifier: string
+  /** Whether this is a dev dependency */
+  isDevDependency: boolean
+}
+
+/**
+ * Map of package name to outdated dependency info
+ */
+export type OutdatedDependencies = Record<string, OutdatedDependency>
+
 type PluginOptions = {
   name: string
 
   actions: (project: DenvigProject) => Promise<Record<string, string[]>>
 
   dependencies?: (project: DenvigProject) => Promise<ProjectDependencySchema[]>
+
+  /**
+   * Get outdated dependencies for the project.
+   * Returns a map of package name to version info.
+   */
+  outdatedDependencies?: (
+    project: DenvigProject,
+  ) => Promise<OutdatedDependencies>
 }
 
 export const definePlugin = (options: PluginOptions) => {

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -10,8 +10,10 @@ import {
   detectDependencies,
   type ProjectDependencySchema,
 } from './dependencies.ts'
+import plugins from './plugins.ts'
 
 import type { ProjectConfigSchema } from '../schemas/config.ts'
+import type { OutdatedDependencies } from './plugin.ts'
 
 export class DenvigProject {
   slug: string
@@ -58,6 +60,17 @@ export class DenvigProject {
 
   async dependencies(): Promise<ProjectDependencySchema[]> {
     return await detectDependencies(this)
+  }
+
+  async outdatedDependencies(): Promise<OutdatedDependencies> {
+    const allOutdated: OutdatedDependencies = {}
+    for (const plugin of Object.values(plugins)) {
+      if (plugin.outdatedDependencies) {
+        const pluginOutdated = await plugin.outdatedDependencies(this)
+        Object.assign(allOutdated, pluginOutdated)
+      }
+    }
+    return allOutdated
   }
 
   /**

--- a/src/plugins/pnpm.ts
+++ b/src/plugins/pnpm.ts
@@ -5,6 +5,7 @@ import { readPackageJson } from '../lib/packageJson.ts'
 import { definePlugin } from '../lib/plugin.ts'
 
 import type { ProjectDependencySchema } from '../lib/dependencies.ts'
+import type { OutdatedDependencies } from '../lib/plugin.ts'
 import type { DenvigProject } from '../lib/project.ts'
 
 type PnpmLockfileDep = {
@@ -35,6 +36,144 @@ type PnpmLockfile = {
 const stripPeerDeps = (version: string): string => {
   const parenIndex = version.indexOf('(')
   return parenIndex === -1 ? version : version.slice(0, parenIndex)
+}
+
+/**
+ * Parse a semver version string into components.
+ */
+const parseVersion = (
+  version: string,
+): {
+  major: number
+  minor: number
+  patch: number
+  prerelease: string
+} | null => {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/)
+  if (!match) return null
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+    prerelease: match[4] || '',
+  }
+}
+
+/**
+ * Compare two semver versions.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ */
+const compareVersions = (a: string, b: string): number => {
+  const va = parseVersion(a)
+  const vb = parseVersion(b)
+  if (!va || !vb) return 0
+
+  if (va.major !== vb.major) return va.major - vb.major
+  if (va.minor !== vb.minor) return va.minor - vb.minor
+  if (va.patch !== vb.patch) return va.patch - vb.patch
+
+  // Prerelease versions have lower precedence
+  if (va.prerelease && !vb.prerelease) return -1
+  if (!va.prerelease && vb.prerelease) return 1
+
+  return 0
+}
+
+/**
+ * Check if a version satisfies a semver range specifier.
+ * Supports: ^x.y.z, ~x.y.z, x.y.z (exact), >=x.y.z, >x.y.z
+ */
+const satisfiesRange = (version: string, specifier: string): boolean => {
+  const v = parseVersion(version)
+  if (!v) return false
+
+  // Skip prerelease versions for compatibility checks
+  if (v.prerelease) return false
+
+  // Handle caret range (^) - compatible with major version
+  if (specifier.startsWith('^')) {
+    const base = parseVersion(specifier.slice(1))
+    if (!base) return false
+
+    // For ^0.x.y, minor version must match
+    if (base.major === 0) {
+      return v.major === 0 && v.minor === base.minor && v.patch >= base.patch
+    }
+
+    // For ^x.y.z where x > 0, major version must match
+    return (
+      v.major === base.major &&
+      compareVersions(version, specifier.slice(1)) >= 0
+    )
+  }
+
+  // Handle tilde range (~) - compatible with minor version
+  if (specifier.startsWith('~')) {
+    const base = parseVersion(specifier.slice(1))
+    if (!base) return false
+
+    return (
+      v.major === base.major && v.minor === base.minor && v.patch >= base.patch
+    )
+  }
+
+  // Handle >= range
+  if (specifier.startsWith('>=')) {
+    return compareVersions(version, specifier.slice(2)) >= 0
+  }
+
+  // Handle > range
+  if (specifier.startsWith('>') && !specifier.startsWith('>=')) {
+    return compareVersions(version, specifier.slice(1)) > 0
+  }
+
+  // Exact version match
+  const base = parseVersion(specifier)
+  if (!base) return false
+  return (
+    v.major === base.major && v.minor === base.minor && v.patch === base.patch
+  )
+}
+
+/**
+ * Fetch package info from npm registry.
+ */
+const fetchNpmPackageInfo = async (
+  packageName: string,
+): Promise<{ versions: string[]; latest: string } | null> => {
+  try {
+    const response = await fetch(
+      `https://registry.npmjs.org/${encodeURIComponent(packageName)}`,
+      { headers: { Accept: 'application/json' } },
+    )
+    if (!response.ok) return null
+
+    const data = (await response.json()) as {
+      versions: Record<string, unknown>
+      'dist-tags': { latest: string }
+    }
+
+    const versions = Object.keys(data.versions)
+    const latest = data['dist-tags']?.latest || versions[versions.length - 1]
+
+    return { versions, latest }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Find the highest version that satisfies a specifier.
+ */
+const findWantedVersion = (
+  versions: string[],
+  specifier: string,
+): string | null => {
+  const satisfying = versions
+    .filter((v) => satisfiesRange(v, specifier))
+    .sort(compareVersions)
+
+  return satisfying.length > 0 ? satisfying[satisfying.length - 1] : null
 }
 
 const plugin = definePlugin({
@@ -187,6 +326,95 @@ const plugin = definePlugin({
     return Array.from(data.values()).sort((a, b) =>
       a.name.localeCompare(b.name),
     )
+  },
+
+  outdatedDependencies: async (
+    project: DenvigProject,
+  ): Promise<OutdatedDependencies> => {
+    if (!existsSync(`${project.path}/pnpm-lock.yaml`)) {
+      return {}
+    }
+
+    const result: OutdatedDependencies = {}
+
+    // Parse the lockfile to get current versions
+    const lockfilePath = `${project.path}/pnpm-lock.yaml`
+    const lockfileContent = readFileSync(lockfilePath, 'utf-8')
+    const lockfile = parse(lockfileContent) as PnpmLockfile
+
+    // Collect all direct dependencies with their current versions and specifiers
+    type DepInfo = {
+      current: string
+      specifier: string
+      isDevDependency: boolean
+    }
+    const directDeps: Map<string, DepInfo> = new Map()
+
+    if (lockfile?.importers) {
+      for (const importer of Object.values(lockfile.importers)) {
+        // Process dependencies
+        if (importer.dependencies) {
+          for (const [name, depInfo] of Object.entries(importer.dependencies)) {
+            if (depInfo?.specifier && depInfo?.version) {
+              // Only track if not already tracked (first occurrence wins)
+              if (!directDeps.has(name)) {
+                directDeps.set(name, {
+                  current: stripPeerDeps(depInfo.version),
+                  specifier: depInfo.specifier,
+                  isDevDependency: false,
+                })
+              }
+            }
+          }
+        }
+
+        // Process devDependencies
+        if (importer.devDependencies) {
+          for (const [name, depInfo] of Object.entries(
+            importer.devDependencies,
+          )) {
+            if (depInfo?.specifier && depInfo?.version) {
+              if (!directDeps.has(name)) {
+                directDeps.set(name, {
+                  current: stripPeerDeps(depInfo.version),
+                  specifier: depInfo.specifier,
+                  isDevDependency: true,
+                })
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Fetch latest versions from npm registry for each dependency
+    const fetchPromises = Array.from(directDeps.entries()).map(
+      async ([name, info]) => {
+        const npmInfo = await fetchNpmPackageInfo(name)
+        if (!npmInfo) return
+
+        const wanted = findWantedVersion(npmInfo.versions, info.specifier)
+        const latest = npmInfo.latest
+
+        // Only include if there's an update available
+        const hasWantedUpdate = wanted && wanted !== info.current
+        const hasLatestUpdate = latest && latest !== info.current
+
+        if (hasWantedUpdate || hasLatestUpdate) {
+          result[name] = {
+            current: info.current,
+            wanted: wanted || info.current,
+            latest: latest,
+            specifier: info.specifier,
+            isDevDependency: info.isDevDependency,
+          }
+        }
+      },
+    )
+
+    await Promise.all(fetchPromises)
+
+    return result
   },
 })
 


### PR DESCRIPTION
Implement a new command that checks npm registry for newer versions of dependencies and displays them with color-coded semver indicators.

New files:
- src/commands/deps/outdated.ts: Command implementation with colored output

Plugin system changes:
- src/lib/plugin.ts: Add OutdatedDependency type and outdatedDependencies() method to plugin interface
- src/lib/project.ts: Add outdatedDependencies() method that aggregates results from all plugins

pnpm plugin implementation:
- src/plugins/pnpm.ts: Implement outdatedDependencies() with:
  - Semver parsing and comparison functions
  - npm registry fetching for latest versions
  - Support for ^, ~, >=, > and exact version specifiers
  - Parallel fetching for performance

Output features:
- Single combined list with "(dev)" suffix in grey for dev dependencies
- Color coding by semver change type:
  - White: version matches (no update)
  - Green: patch update
  - Yellow: minor update
  - Red: major update
- Shows current, wanted (semver-compatible), and latest versions