### PR TITLE
Add npm registry caching for deps:outdated command

### DIFF
--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -57,12 +57,21 @@ const getVersionColor = (current: string, target: string): string => {
 export const depsOutdatedCommand = new Command({
   name: 'deps:outdated',
   description: 'Show outdated dependencies',
-  usage: 'deps:outdated',
+  usage: 'deps:outdated [--no-cache]',
   example: 'denvig deps:outdated',
   args: [],
-  flags: [],
-  handler: async ({ project }) => {
-    const outdated = await project.outdatedDependencies()
+  flags: [
+    {
+      name: 'no-cache',
+      description: 'Skip cache and fetch fresh data from registry',
+      required: false,
+      type: 'boolean',
+      defaultValue: false,
+    },
+  ],
+  handler: async ({ project, flags }) => {
+    const cache = !(flags['no-cache'] as boolean)
+    const outdated = await project.outdatedDependencies({ cache })
     const entries = Object.entries(outdated)
 
     if (entries.length === 0) {

--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -22,6 +22,14 @@ export type OutdatedDependency = {
  */
 export type OutdatedDependencies = Record<string, OutdatedDependency>
 
+/**
+ * Options for outdatedDependencies method
+ */
+export type OutdatedDependenciesOptions = {
+  /** Use cache for registry requests (default: true) */
+  cache?: boolean
+}
+
 type PluginOptions = {
   name: string
 
@@ -35,6 +43,7 @@ type PluginOptions = {
    */
   outdatedDependencies?: (
     project: DenvigProject,
+    options?: OutdatedDependenciesOptions,
   ) => Promise<OutdatedDependencies>
 }
 

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -13,7 +13,10 @@ import {
 import plugins from './plugins.ts'
 
 import type { ProjectConfigSchema } from '../schemas/config.ts'
-import type { OutdatedDependencies } from './plugin.ts'
+import type {
+  OutdatedDependencies,
+  OutdatedDependenciesOptions,
+} from './plugin.ts'
 
 export class DenvigProject {
   slug: string
@@ -62,11 +65,13 @@ export class DenvigProject {
     return await detectDependencies(this)
   }
 
-  async outdatedDependencies(): Promise<OutdatedDependencies> {
+  async outdatedDependencies(
+    options?: OutdatedDependenciesOptions,
+  ): Promise<OutdatedDependencies> {
     const allOutdated: OutdatedDependencies = {}
     for (const plugin of Object.values(plugins)) {
       if (plugin.outdatedDependencies) {
-        const pluginOutdated = await plugin.outdatedDependencies(this)
+        const pluginOutdated = await plugin.outdatedDependencies(this, options)
         Object.assign(allOutdated, pluginOutdated)
       }
     }


### PR DESCRIPTION
Cache fetched npm package info to ~/.cache/denvig/dependencies/npm/ with a 30-minute TTL based on file modification time. This reduces repeated network requests when checking outdated dependencies.

- Add --no-cache flag to bypass cache and fetch fresh data
- Cache option defaults to true (cache enabled by default)
- Scoped packages (@org/pkg) encoded safely in filenames