### PR TITLE
Add --global flag to services command (#55)

### DIFF
--- a/src/commands/services.test.ts
+++ b/src/commands/services.test.ts
@@ -10,6 +10,6 @@ describe('servicesCommand', () => {
   })
 
   it('should have correct usage', () => {
-    ok(servicesCommand.usage === 'services')
+    ok(servicesCommand.usage === 'services [--global]')
   })
 })

--- a/src/commands/services.ts
+++ b/src/commands/services.ts
@@ -1,14 +1,143 @@
 import { Command } from '../lib/command.ts'
-import { ServiceManager } from '../lib/services/manager.ts'
+import { DenvigProject } from '../lib/project.ts'
+import { listProjects } from '../lib/projects.ts'
+import { type ServiceInfo, ServiceManager } from '../lib/services/manager.ts'
+
+interface GlobalServiceInfo extends ServiceInfo {
+  projectSlug: string
+}
+
+const printServices = async (
+  services: ServiceInfo[] | GlobalServiceInfo[],
+  manager: ServiceManager | null,
+  isGlobal: boolean,
+): Promise<void> => {
+  // Calculate column widths for alignment
+  const nameWidth = Math.max(
+    ...services.map((s) => s.name.length),
+    'NAME'.length,
+  )
+  const commandWidth = Math.min(
+    20,
+    Math.max(...services.map((s) => s.command.length), 'COMMAND'.length),
+  )
+  const projectWidth = isGlobal
+    ? Math.max(
+        ...services.map((s) => (s as GlobalServiceInfo).projectSlug.length),
+        'PROJECT'.length,
+      )
+    : 0
+
+  // Print each service with status
+  for (const service of services) {
+    const domain = service.domain
+      ? `http://${service.domain}`
+      : service.port
+        ? `http://localhost:${service.port}`
+        : '-'
+
+    // Get service status
+    let statusIcon = '◯' // Not running
+    if (manager) {
+      const status = await manager.getServiceStatus(service.name)
+      if (status?.running) {
+        if (status.lastExitCode !== undefined && status.lastExitCode !== 0) {
+          statusIcon = '🔴' // Running but had errors
+        } else {
+          statusIcon = '🟢' // Running successfully
+        }
+      }
+    } else if (isGlobal) {
+      // For global view, create a temporary manager to check status
+      const globalService = service as GlobalServiceInfo
+      const tempProject = new DenvigProject(globalService.projectSlug)
+      const tempManager = new ServiceManager(tempProject)
+      const status = await tempManager.getServiceStatus(service.name)
+      if (status?.running) {
+        if (status.lastExitCode !== undefined && status.lastExitCode !== 0) {
+          statusIcon = '🔴' // Running but had errors
+        } else {
+          statusIcon = '🟢' // Running successfully
+        }
+      }
+    }
+
+    const truncatedCommand =
+      service.command.length > 20
+        ? `${service.command.substring(0, 17)}...`
+        : service.command
+
+    const projectColumn = isGlobal
+      ? `${(service as GlobalServiceInfo).projectSlug.padEnd(projectWidth)}  `
+      : ''
+
+    console.log(
+      `${statusIcon} ${projectColumn}${service.name.padEnd(nameWidth)}  ` +
+        `${truncatedCommand.padEnd(commandWidth)}  ` +
+        `${domain}`,
+    )
+  }
+}
 
 export const servicesCommand = new Command({
   name: 'services',
   description: 'List all services defined in the project configuration',
-  usage: 'services',
+  usage: 'services [--global]',
   example: 'services',
   args: [],
-  flags: [],
-  handler: async ({ project }) => {
+  flags: [
+    {
+      name: 'global',
+      description: 'Show services from all projects',
+      required: false,
+      type: 'boolean',
+      defaultValue: false,
+    },
+  ],
+  handler: async ({ project, flags }) => {
+    const isGlobal = flags.global as boolean
+
+    if (isGlobal) {
+      const projects = listProjects()
+
+      if (projects.length === 0) {
+        console.log('No projects found with .denvig.yml configuration.')
+        return { success: true, message: 'No projects found.' }
+      }
+
+      const allServices: GlobalServiceInfo[] = []
+
+      for (const projectSlug of projects) {
+        const proj = new DenvigProject(projectSlug)
+        const manager = new ServiceManager(proj)
+        const services = await manager.listServices()
+
+        for (const service of services) {
+          allServices.push({
+            ...service,
+            projectSlug,
+          })
+        }
+      }
+
+      if (allServices.length === 0) {
+        console.log('No services configured across any project.')
+        return { success: true, message: 'No services configured.' }
+      }
+
+      console.log('Services across all projects:')
+      console.log('')
+
+      await printServices(allServices, null, true)
+
+      console.log('')
+      console.log(
+        `${allServices.length} service${allServices.length === 1 ? '' : 's'} configured across ${projects.length} project${projects.length === 1 ? '' : 's'}`,
+      )
+
+      return { success: true, message: 'Global services listed successfully.' }
+    }
+
     const manager = new ServiceManager(project)
     const services = await manager.listServices()
 
@@ -24,49 +153,7 @@ export const servicesCommand = new Command({
     console.log(`Services for project: ${project.name}`)
     console.log('')
 
-    // Calculate column widths for alignment
-    const nameWidth = Math.max(
-      ...services.map((s) => s.name.length),
-      'NAME'.length,
-    )
-    const commandWidth = Math.min(
-      20,
-      Math.max(...services.map((s) => s.command.length), 'COMMAND'.length),
-    )
-
-    // Print each service with status
-    for (const service of services) {
-      const domain = service.domain
-        ? `http://${service.domain}`
-        : service.port
-          ? `http://localhost:${service.port}`
-          : '-'
-
-      // Get service status
-      const status = await manager.getServiceStatus(service.name)
-      let statusIcon = '◯' // Not running
-
-      if (status?.running) {
-        // Check if there's a recent exit code indicating an error
-        if (status.lastExitCode !== undefined && status.lastExitCode !== 0) {
-          statusIcon = '🔴' // Running but had errors
-        } else {
-          statusIcon = '🟢' // Running successfully
-        }
-      }
-
-      const truncatedCommand =
-        service.command.length > 20
-          ? `${service.command.substring(0, 17)}...`
-          : service.command
-
-      console.log(
-        `${statusIcon} ${service.name.padEnd(nameWidth)}  ` +
-          // `${service.cwd.padEnd(cwdWidth)}  ` +
-          `${truncatedCommand.padEnd(commandWidth)}  ` +
-          `${domain}`,
-      )
-    }
+    await printServices(services, manager, false)
 
     console.log('')
     console.log(

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs'
+
+import { getGlobalConfig } from './config.ts'
+
+/**
+ * List all projects that have a .denvig.yml configuration file.
+ * Projects are detected at [codeRootDir]/[workspace]/[repo].
+ *
+ * @returns Array of project slugs in the format "workspace/repo"
+ */
+export const listProjects = (): string[] => {
+  const globalConfig = getGlobalConfig()
+  const codeRootDir = globalConfig.codeRootDir
+  const projects: string[] = []
+
+  // Check if codeRootDir exists
+  if (!fs.existsSync(codeRootDir)) {
+    return projects
+  }
+
+  // Get all workspace directories
+  const workspaces = fs.readdirSync(codeRootDir, { withFileTypes: true })
+
+  for (const workspace of workspaces) {
+    if (!workspace.isDirectory()) continue
+    if (workspace.name.startsWith('.')) continue
+
+    const workspacePath = `${codeRootDir}/${workspace.name}`
+
+    // Get all repo directories within the workspace
+    const repos = fs.readdirSync(workspacePath, { withFileTypes: true })
+
+    for (const repo of repos) {
+      if (!repo.isDirectory()) continue
+      if (repo.name.startsWith('.')) continue
+
+      const repoPath = `${workspacePath}/${repo.name}`
+      const configPath = `${repoPath}/.denvig.yml`
+
+      // Only include projects with a .denvig.yml file
+      if (fs.existsSync(configPath)) {
+        projects.push(`${workspace.name}/${repo.name}`)
+      }
+    }
+  }
+
+  return projects.sort()
+}


### PR DESCRIPTION
Add ability to list services across all projects by using the --global flag. Projects are detected by scanning [codeRootDir]/[workspace]/[repo] directories and only including those with a .denvig.yml configuration file.

- Add listProjects() helper in src/lib/projects.ts for code maintainability
- Extend services command with --global boolean flag
- Show project column when listing services globally
- Display service status for each service across all projects