### PR TITLE
Use human-readable plist and log filenames instead of hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ can be supported by using the per project configs.
 
 
 
+## Troubleshooting
+
+### Reset all services
+
+If you encounter issues with services (e.g., stale plist files or naming mismatches), you can fully reset all denvig-managed launchctl entries with:
+
+```shell
+launchctl list | awk '/denvig/ {print $3}' | xargs -I {} sh -c 'launchctl bootout gui/$(id -u)/{} 2>/dev/null; rm -f ~/Library/LaunchAgents/{}.plist'
+```
+
+This will stop and unload all services, then remove their plist files from `~/Library/LaunchAgents/`.
+
+
+
 ## Building from source
 
 You can build a fresh binary from source instead of using the provided methods above

--- a/src/commands/logs.test.ts
+++ b/src/commands/logs.test.ts
@@ -2,29 +2,23 @@ import { ok } from 'node:assert'
 import { describe, it } from 'node:test'
 
 import { DenvigProject } from '../lib/project.ts'
-import { generateDenvigResourceHash } from '../lib/resources.ts'
 import { logsCommand } from './logs.ts'
 
 describe('logsCommand', () => {
   it('should show last N lines using --lines flag', async () => {
-    const project = new DenvigProject('denvig')
+    const project = new DenvigProject('workspace/denvig')
     project.config.services = {
       'test-logs': {
         command: 'echo hi',
       },
     }
 
-    const { hash } = generateDenvigResourceHash({
-      project,
-      resource: 'service/test-logs',
-    })
-
     const home = (await import('node:os')).homedir()
     const path = (await import('node:path')).resolve(
       home,
       '.denvig',
       'logs',
-      `${hash}.log`,
+      'workspace__denvig__test-logs.log',
     )
 
     const fs = await import('node:fs/promises')

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { z } from 'zod'
 
@@ -41,6 +42,11 @@ export const statusCommand = new Command({
     console.log(`Command: ${status.command}`)
     console.log(`CWD:     ${status.cwd.replace(homedir(), '~')}`)
     console.log(`Logs:    ${status.logPath.replace(homedir(), '~')}`)
+
+    const plistPath = manager.getPlistPath(serviceName)
+    if (existsSync(plistPath)) {
+      console.log(`Plist:   ${plistPath.replace(homedir(), '~')}`)
+    }
 
     if (status.lastExitCode !== undefined && !status.running) {
       console.log(`Last exit code: ${status.lastExitCode}`)

--- a/src/lib/services/plist.ts
+++ b/src/lib/services/plist.ts
@@ -63,7 +63,7 @@ export function generatePlist(options: PlistOptions): string {
     <string>/bin/zsh</string>
     <string>-l</string>
     <string>-c</string>
-    <string>${escapeXml(command)}</string>
+    <string>${escapeXml(command.trim())}</string>
   </array>
 
   <key>WorkingDirectory</key>


### PR DESCRIPTION
Replace hash-based naming with normalized human-readable format for service identifiers to improve debuggability and avoid naming mismatches.

New naming format:
- Plist: denvig.[workspace]__[repo]__[service].plist
- Logs: [workspace]__[repo]__[service].log

Changes:
- Add normalizeForLabel() helper to sanitize strings for launchctl
- Update getServiceLabel() to return denvig.[workspace]__[repo]__[service]
- Update getLogPath() to use same normalized format
- Only show plist path in status output if file exists
- Add troubleshooting section to README with reset command
- Update all related tests for new naming convention
- Trim command in plist to remove trailing newlines