### PR TITLE
Add multi-ecosystem support to deps:list and deps:outdated commands

### DIFF
--- a/src/lib/npm/outdated.ts
+++ b/src/lib/npm/outdated.ts
@@ -183,6 +183,7 @@ export const npmOutdated = async (
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        ecosystem: 'npm',
       }
     }
   })

--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -15,6 +15,8 @@ export type OutdatedDependency = {
   specifier: string
   /** Whether this is a dev dependency */
   isDevDependency: boolean
+  /** The ecosystem this dependency belongs to (e.g., npm, rubygems, pypi) */
+  ecosystem: string
 }
 
 /**

--- a/src/lib/rubygems/outdated.ts
+++ b/src/lib/rubygems/outdated.ts
@@ -208,6 +208,7 @@ export const rubygemsOutdated = async (
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        ecosystem: 'rubygems',
       }
     }
   })

--- a/src/lib/uv/outdated.ts
+++ b/src/lib/uv/outdated.ts
@@ -216,6 +216,7 @@ export const uvOutdated = async (
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        ecosystem: 'pypi',
       }
     }
   })


### PR DESCRIPTION
- Add ecosystem field to OutdatedDependency type to track package source
- Update npm, rubygems, and uv outdated functions to include ecosystem
- Refactor deps:list from tree format to table format matching deps:outdated
- Display Ecosystem column when multiple ecosystems are detected
- Sort output by ecosystem first, then alphabetically by package name
- Add --ecosystem flag to filter results to a single ecosystem
- Hide Ecosystem column when filtering to a single ecosystem
- Show helpful messages when no dependencies found for filtered ecosystem