### PR TITLE
Add --format flag to services:restart command

### DIFF
--- a/src/commands/services/restart.test.ts
+++ b/src/commands/services/restart.test.ts
@@ -10,6 +10,17 @@ describe('servicesRestartCommand', () => {
   })
 
   it('should have correct usage', () => {
-    ok(servicesRestartCommand.usage === 'services restart [name]')
+    ok(
+      servicesRestartCommand.usage ===
+        'services restart [name] [--format table|json]',
+    )
+  })
+
+  it('should have format flag', () => {
+    const formatFlag = servicesRestartCommand.flags.find(
+      (f) => f.name === 'format',
+    )
+    ok(formatFlag)
+    ok(formatFlag.defaultValue === 'table')
   })
 })

--- a/src/commands/services/restart.ts
+++ b/src/commands/services/restart.ts
@@ -7,7 +7,7 @@ import { ServiceManager } from '../../lib/services/manager.ts'
 export const servicesRestartCommand = new Command({
   name: 'services:restart',
   description: 'Restart all services or a specific service',
-  usage: 'services restart [name]',
+  usage: 'services restart [name] [--format table|json]',
   example: 'services restart api or services restart marcqualie/api/dev',
   args: [
     {
@@ -18,9 +18,18 @@ export const servicesRestartCommand = new Command({
       type: 'string',
     },
   ],
-  flags: [],
-  handler: async ({ project, args }) => {
+  flags: [
+    {
+      name: 'format',
+      description: 'Output format: table or json (default: table)',
+      required: false,
+      type: 'string',
+      defaultValue: 'table',
+    },
+  ],
+  handler: async ({ project, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
+    const format = flags.format as string
 
     // Restart specific service or all services
     if (serviceArg) {
@@ -33,13 +42,27 @@ export const servicesRestartCommand = new Command({
       const projectPrefix =
         targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
 
-      console.log(`Restarting ${projectPrefix}${serviceName}...`)
+      if (format !== 'json') {
+        console.log(`Restarting ${projectPrefix}${serviceName}...`)
+      }
+
       const result = await manager.restartService(serviceName)
 
       if (!result.success) {
-        console.error(
-          `✗ Failed to restart ${projectPrefix}${serviceName}: ${result.message}`,
-        )
+        if (format === 'json') {
+          console.log(
+            JSON.stringify({
+              success: false,
+              service: serviceName,
+              project: targetProject.slug,
+              message: result.message,
+            }),
+          )
+        } else {
+          console.error(
+            `✗ Failed to restart ${projectPrefix}${serviceName}: ${result.message}`,
+          )
+        }
         return { success: false, message: result.message }
       }
 
@@ -50,20 +73,45 @@ export const servicesRestartCommand = new Command({
       const status = await manager.getServiceStatus(serviceName)
       if (status?.running) {
         const url = manager.getServiceUrl(serviceName)
-        const urlInfo = url ? ` → ${url}` : ''
-        console.log(
-          `✓ ${projectPrefix}${serviceName} restarted successfully${urlInfo}`,
-        )
+        if (format === 'json') {
+          console.log(
+            JSON.stringify({
+              success: true,
+              service: serviceName,
+              project: targetProject.slug,
+              running: true,
+              pid: status.pid,
+              url: url || null,
+            }),
+          )
+        } else {
+          const urlInfo = url ? ` → ${url}` : ''
+          console.log(
+            `✓ ${projectPrefix}${serviceName} restarted successfully${urlInfo}`,
+          )
+        }
         return { success: true, message: 'Service restarted successfully.' }
       }
 
-      // Service failed to start - show logs
-      console.error(`✗ ${projectPrefix}${serviceName} failed to start`)
-      if (status?.logs && status.logs.length > 0) {
-        console.error('')
-        console.error('Recent logs:')
-        for (const line of status.logs) {
-          console.error(`  ${line}`)
+      // Service failed to start
+      if (format === 'json') {
+        console.log(
+          JSON.stringify({
+            success: false,
+            service: serviceName,
+            project: targetProject.slug,
+            running: false,
+            logs: status?.logs || [],
+          }),
+        )
+      } else {
+        console.error(`✗ ${projectPrefix}${serviceName} failed to start`)
+        if (status?.logs && status.logs.length > 0) {
+          console.error('')
+          console.error('Recent logs:')
+          for (const line of status.logs) {
+            console.error(`  ${line}`)
+          }
         }
       }
       return { success: false, message: 'Service failed to start.' }
@@ -74,19 +122,39 @@ export const servicesRestartCommand = new Command({
     const results = await manager.restartAll()
 
     if (results.length === 0) {
-      console.log('No running services to restart.')
+      if (format === 'json') {
+        console.log(JSON.stringify({ success: true, services: [] }))
+      } else {
+        console.log('No running services to restart.')
+      }
       return { success: true, message: 'No services to restart.' }
     }
 
     // Wait for services to start
     await new Promise((resolve) => setTimeout(resolve, 2000))
 
+    const serviceResults: Array<{
+      name: string
+      success: boolean
+      running: boolean
+      url: string | null
+      message?: string
+    }> = []
     let hasErrors = false
 
     for (const result of results) {
       if (!result.success) {
-        console.error(`Restarting ${result.name}... ✗`)
-        console.error(`  ${result.message}`)
+        serviceResults.push({
+          name: result.name,
+          success: false,
+          running: false,
+          url: null,
+          message: result.message,
+        })
+        if (format !== 'json') {
+          console.error(`Restarting ${result.name}... ✗`)
+          console.error(`  ${result.message}`)
+        }
         hasErrors = true
         continue
       }
@@ -95,28 +163,57 @@ export const servicesRestartCommand = new Command({
       const status = await manager.getServiceStatus(result.name)
       if (status?.running) {
         const url = manager.getServiceUrl(result.name)
-        const urlInfo = url ? ` → ${url}` : ''
-        console.log(`Restarting ${result.name}... ✓${urlInfo}`)
+        serviceResults.push({
+          name: result.name,
+          success: true,
+          running: true,
+          url: url || null,
+        })
+        if (format !== 'json') {
+          const urlInfo = url ? ` → ${url}` : ''
+          console.log(`Restarting ${result.name}... ✓${urlInfo}`)
+        }
       } else {
-        console.error(`Restarting ${result.name}... ✗ (failed to start)`)
-        if (status?.logs && status.logs.length > 0) {
-          console.error('  Recent logs:')
-          for (const line of status.logs.slice(-3)) {
-            console.error(`    ${line}`)
+        serviceResults.push({
+          name: result.name,
+          success: false,
+          running: false,
+          url: null,
+          message: 'Failed to start',
+        })
+        if (format !== 'json') {
+          console.error(`Restarting ${result.name}... ✗ (failed to start)`)
+          if (status?.logs && status.logs.length > 0) {
+            console.error('  Recent logs:')
+            for (const line of status.logs.slice(-3)) {
+              console.error(`    ${line}`)
+            }
           }
         }
         hasErrors = true
       }
     }
 
-    console.log('')
-
-    if (hasErrors) {
-      console.log('Some services failed to restart')
-      return { success: false, message: 'Some services failed to restart.' }
+    if (format === 'json') {
+      console.log(
+        JSON.stringify({
+          success: !hasErrors,
+          project: project.slug,
+          services: serviceResults,
+        }),
+      )
+    } else {
+      console.log('')
+      if (hasErrors) {
+        console.log('Some services failed to restart')
+      } else {
+        console.log('All services restarted successfully')
+      }
     }
 
-    console.log('All services restarted successfully')
+    if (hasErrors) {
+      return { success: false, message: 'Some services failed to restart.' }
+    }
     return { success: true, message: 'All services restarted successfully.' }
   },
 })


### PR DESCRIPTION
## Summary
- Add `--format json` option to the `services:restart` command, completing JSON output support across all services subcommands
- Support JSON output for both single service restart and restart-all operations
- Update tests to verify the new flag

## Test plan
- [x] Run `pnpm run lint` - passes
- [x] Run `pnpm run test` - all 82 tests pass
- [x] Verify CLI works with `bin/denvig-dev version`