### PR TITLE
Update documentation for v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,25 @@
 
 - `deps:list` command to list project dependencies (#45)
 - `deps:outdated` command to show outdated dependencies (#47)
+- `--semver` flag to filter `deps:outdated` results by semver level (major, minor, patch) (#53)
+- `--format` flag for `deps:list` and `deps:outdated` commands to output JSON (#61)
 - NPM registry caching for `deps:outdated` command (#48)
+- RubyGems dependency support via Ruby plugin (#57)
+- Python/uv dependency support via uv plugin (#58)
+- Multi-ecosystem support for `deps:list` and `deps:outdated` commands (#59)
 - JSON schema generation from zod schema for IDE validation and autocompletion (#34)
 - Support for services in `.denvig.yml` to launch alongside projects (#37)
+- Services commands: `services:start`, `services:stop`, `services:restart`, `services:status` (#64)
+- `--global` flag for services command to show all denvig-managed services (#55)
+- `--format` flag for services commands to output JSON (#62, #65)
+- `http` config block in services schema (#63)
+- Human-readable plist and log filenames instead of hashes (#56)
 - CI testing against multiple Node.js versions (#50)
 
 ### Changed
 
 - Improved services and logs output (#44)
+- Refactored dependency outputs for consistency (#60)
 - Split out npm outdated helpers for plugin reuse (#49)
 - Cleaned up config schemas (#38)
 - Upgraded dependencies (#33)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,50 @@ denvig outdated
 ```
 
 
+### Dependencies
+
+Inspect and manage project dependencies across multiple ecosystems (npm, pnpm, yarn, Ruby/Bundler, Python/uv):
+
+```shell
+denvig deps:list                     # List all dependencies
+denvig deps:outdated                 # Show outdated dependencies
+denvig deps:outdated --semver patch  # Filter by semver level
+denvig deps:list --format json       # Output as JSON
+```
+
+
+### Services
+
+Manage background services defined in `.denvig.yml`. Services run via launchctl on macOS:
+
+```shell
+denvig services               # List services and their status
+denvig services start         # Start all services
+denvig services stop          # Stop all services
+denvig services restart       # Restart all services
+```
+
+Target a specific service by name:
+
+```shell
+denvig services start api     # Start only the 'api' service
+denvig services status api    # Start only the 'api' service
+denvig services stop api      # Stop only the 'api' service
+denvig services restart api   # Restart only the 'api' service
+```
+
+Manage services globally from any directory:
+
+```shell
+denvig services start marcqualie/denvig/hello   # Start 'api' in marcqualie/denvig project
+denvig services status marcqualie/denvig/hello  # Check status of 'api' service
+```
+
+See [docs/configuration.md](docs/configuration.md) for service configuration options.
+
+All services commands also accept `--format json` for programmatic output.
+
+
 
 ## Languages / Frameworks
 
@@ -58,11 +102,9 @@ can be supported by using the per project configs.
 - [x] Node.js (npm, pnpm, yarn)
 - [ ] Bun
 - [ ] Vite
-- [x] Deno
-- [ ] NextJS
-- [ ] Ruby
-- [ ] Rails
-- [x] Python
+- [ ] Deno
+- [x] Ruby (rubygems)
+- [x] Python (uv)
 
 
 
@@ -72,28 +114,28 @@ can be supported by using the per project configs.
 - [x] YAML configuration at ~/.denvig.yml
 - [x] Per project configuration via ./.denvig.yml
 - [x] Consistent API for all languages/frameworks
+- [x] Dependency management across multiple ecosystems
+- [x] Background service management
 
 
 
 ## Troubleshooting
 
-### Reset all services
-
-If you encounter issues with services (e.g., stale plist files or naming mismatches), you can fully reset all denvig-managed launchctl entries with:
-
-```shell
-launchctl list | awk '/denvig/ {print $3}' | xargs -I {} sh -c 'launchctl bootout gui/$(id -u)/{} 2>/dev/null; rm -f ~/Library/LaunchAgents/{}.plist'
-```
-
-This will stop and unload all services, then remove their plist files from `~/Library/LaunchAgents/`.
+For troubleshooting guides including service management, resource identification, and log browsing, see [docs/troubleshooting.md](docs/troubleshooting.md).
 
 
 
 ## Building from source
 
-You can build a fresh binary from source instead of using the provided methods above
+You can build from source instead of using the provided methods above:
 
 ```shell
-deno task build
-cp dist/denvig /usr/local/bin/denvig
+pnpm install
+pnpm build
+```
+
+After building, the CLI will be available at `dist/cli.cjs`. You can link it globally:
+
+```shell
+npm link
 ```


### PR DESCRIPTION
## Summary

- Update CHANGELOG with all features and changes since v0.3.0
- Update README with new commands documentation (deps, services)
- Add examples for single service and global service management
- Update build instructions from deno to node/pnpm
- Replace inline troubleshooting with link to docs/troubleshooting.md
- Update supported languages list (Ruby, Python now marked as supported)
- Add new goals (dependency management, background services)

## Test plan

- [x] Verify README renders correctly on GitHub
- [x] Verify CHANGELOG format is correct
- [x] Verify documentation links work