### PR TITLE
Add unified ServiceResponse type for consistent service command output

### DIFF
--- a/src/commands/services/start.ts
+++ b/src/commands/services/start.ts
@@ -2,7 +2,10 @@ import { z } from 'zod'
 
 import { Command } from '../../lib/command.ts'
 import { getServiceContext } from '../../lib/services/identifier.ts'
-import { ServiceManager } from '../../lib/services/manager.ts'
+import {
+  ServiceManager,
+  type ServiceResponse,
+} from '../../lib/services/manager.ts'
 
 export const servicesStartCommand = new Command({
   name: 'services:start',
@@ -70,23 +73,16 @@ export const servicesStartCommand = new Command({
       // Wait for service to start
       await new Promise((resolve) => setTimeout(resolve, 2000))
 
-      // Check if service is actually running
-      const status = await manager.getServiceStatus(serviceName)
-      if (status?.running) {
-        const url = manager.getServiceUrl(serviceName)
+      // Get service response
+      const response = await manager.getServiceResponse(serviceName, {
+        includeLogs: true,
+      })
+
+      if (response?.status === 'running') {
         if (format === 'json') {
-          console.log(
-            JSON.stringify({
-              success: true,
-              service: serviceName,
-              project: targetProject.slug,
-              running: true,
-              pid: status.pid,
-              url: url || null,
-            }),
-          )
+          console.log(JSON.stringify(response))
         } else {
-          const urlInfo = url ? ` → ${url}` : ''
+          const urlInfo = response.url ? ` → ${response.url}` : ''
           console.log(
             `✓ ${projectPrefix}${serviceName} started successfully${urlInfo}`,
           )
@@ -96,21 +92,13 @@ export const servicesStartCommand = new Command({
 
       // Service failed to start
       if (format === 'json') {
-        console.log(
-          JSON.stringify({
-            success: false,
-            service: serviceName,
-            project: targetProject.slug,
-            running: false,
-            logs: status?.logs || [],
-          }),
-        )
+        console.log(JSON.stringify(response))
       } else {
         console.error(`✗ ${projectPrefix}${serviceName} failed to start`)
-        if (status?.logs && status.logs.length > 0) {
+        if (response?.logs && response.logs.length > 0) {
           console.error('')
           console.error('Recent logs:')
-          for (const line of status.logs) {
+          for (const line of response.logs) {
             console.error(`  ${line}`)
           }
         }
@@ -124,7 +112,13 @@ export const servicesStartCommand = new Command({
 
     if (services.length === 0) {
       if (format === 'json') {
-        console.log(JSON.stringify({ success: true, services: [] }))
+        console.log(
+          JSON.stringify({
+            success: true,
+            project: project.slug,
+            services: [],
+          }),
+        )
       } else {
         console.log('No services configured in this project.')
       }
@@ -136,64 +130,41 @@ export const servicesStartCommand = new Command({
     // Wait for services to start
     await new Promise((resolve) => setTimeout(resolve, 2000))
 
-    const serviceResults: Array<{
-      name: string
-      success: boolean
-      running: boolean
-      url: string | null
-      message?: string
-    }> = []
+    const serviceResponses: ServiceResponse[] = []
     let hasErrors = false
 
     for (const result of results) {
-      if (!result.success) {
-        serviceResults.push({
-          name: result.name,
-          success: false,
-          running: false,
-          url: null,
-          message: result.message,
-        })
-        if (format !== 'json') {
-          console.error(`Starting ${result.name}... ✗`)
-          console.error(`  ${result.message}`)
-        }
-        hasErrors = true
+      const response = await manager.getServiceResponse(result.name, {
+        includeLogs: !result.success,
+      })
+
+      if (!response) {
         continue
       }
 
-      // Check if service is actually running
-      const status = await manager.getServiceStatus(result.name)
-      if (status?.running) {
-        const url = manager.getServiceUrl(result.name)
-        serviceResults.push({
-          name: result.name,
-          success: true,
-          running: true,
-          url: url || null,
-        })
+      serviceResponses.push(response)
+
+      if (!result.success || response.status !== 'running') {
+        hasErrors = true
         if (format !== 'json') {
-          const urlInfo = url ? ` → ${url}` : ''
-          console.log(`Starting ${result.name}... ✓${urlInfo}`)
-        }
-      } else {
-        serviceResults.push({
-          name: result.name,
-          success: false,
-          running: false,
-          url: null,
-          message: 'Failed to start',
-        })
-        if (format !== 'json') {
-          console.error(`Starting ${result.name}... ✗ (failed to start)`)
-          if (status?.logs && status.logs.length > 0) {
-            console.error('  Recent logs:')
-            for (const line of status.logs.slice(-3)) {
-              console.error(`    ${line}`)
+          if (!result.success) {
+            console.error(`Starting ${result.name}... ✗`)
+            console.error(`  ${result.message}`)
+          } else {
+            console.error(`Starting ${result.name}... ✗ (failed to start)`)
+            if (response.logs && response.logs.length > 0) {
+              console.error('  Recent logs:')
+              for (const line of response.logs.slice(-3)) {
+                console.error(`    ${line}`)
+              }
             }
           }
         }
-        hasErrors = true
+      } else {
+        if (format !== 'json') {
+          const urlInfo = response.url ? ` → ${response.url}` : ''
+          console.log(`Starting ${result.name}... ✓${urlInfo}`)
+        }
       }
     }
 
@@ -202,7 +173,7 @@ export const servicesStartCommand = new Command({
         JSON.stringify({
           success: !hasErrors,
           project: project.slug,
-          services: serviceResults,
+          services: serviceResponses,
         }),
       )
     } else {

--- a/src/lib/parsers/yarn.ts
+++ b/src/lib/parsers/yarn.ts
@@ -13,7 +13,7 @@ type Source = string
  */
 export type VersionMap = Record<Version, Record<Source, Specifier>>
 
-interface Dependency {
+type Dependency = {
   versions: VersionMap
 }
 
@@ -39,11 +39,11 @@ interface Dependency {
  * }
  * ```
  */
-export interface ParsedYarnLock {
+export type ParsedYarnLock = {
   dependencies: Record<string, Dependency>
 }
 
-interface ParsedNativeDependency {
+type ParsedNativeDependency = {
   version: string
   resolved: string
   integrity?: string
@@ -54,7 +54,7 @@ interface ParsedNativeDependency {
  * Native format used by Yarn parser.
  * https://github.com/yarnpkg/yarn/tree/master/packages/lockfile
  */
-interface ParsedNativeLockfile {
+type ParsedNativeLockfile = {
   type: string
   object: Record<string, ParsedNativeDependency>
 }

--- a/src/lib/services/launchctl.ts
+++ b/src/lib/services/launchctl.ts
@@ -6,7 +6,7 @@ const execAsync = promisify(exec)
 /**
  * Parsed output from launchctl print command.
  */
-export interface LaunchctlPrintOutput {
+export type LaunchctlPrintOutput = {
   pid?: number
   status: string
   label: string
@@ -17,7 +17,7 @@ export interface LaunchctlPrintOutput {
 /**
  * Item from launchctl list command.
  */
-export interface LaunchctlListItem {
+export type LaunchctlListItem = {
   pid: number | '-'
   status: number
   label: string

--- a/src/lib/services/plist.ts
+++ b/src/lib/services/plist.ts
@@ -1,7 +1,7 @@
 /**
  * Options for generating a launchd plist file.
  */
-export interface PlistOptions {
+export type PlistOptions = {
   label: string
   command: string
   workingDirectory: string


### PR DESCRIPTION
## Summary

- Add `ServiceResponse` type to unify JSON output across all service commands (`list`, `status`, `start`, `stop`, `restart`)
- Add `getServiceResponse()` helper method to `ServiceManager` for building consistent response objects
- Update all service commands to use the unified type, ensuring predictable JSON structure for parsing

## Test plan

- [x] Run `pnpm run lint` - passes
- [x] Run `pnpm run test` - all 82 tests pass
- [x] Verify CLI works with `bin/denvig-dev version`