### PR TITLE
Add space-separated subcommand support for deps commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ denvig outdated
 Inspect and manage project dependencies across multiple ecosystems (npm, pnpm, yarn, Ruby/Bundler, Python/uv):
 
 ```shell
-denvig deps:list                     # List all dependencies
-denvig deps:outdated                 # Show outdated dependencies
-denvig deps:outdated --semver patch  # Filter by semver level
-denvig deps:list --format json       # Output as JSON
+denvig deps                          # List all dependencies
+denvig deps list                     # List all dependencies (explicit)
+denvig deps outdated                 # Show outdated dependencies
+denvig deps outdated --semver patch  # Filter by semver level
+denvig deps --format json            # Output as JSON
 ```
 
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,6 @@ async function main() {
 
   // Command aliases - map shortcuts to their full commands
   const commandAliases: Record<string, string> = {
-    deps: 'deps:list',
     outdated: 'deps:outdated',
   }
   if (commandAliases[commandName]) {
@@ -52,6 +51,17 @@ async function main() {
     const subcommand = process.argv[3]
     if (subcommand && servicesSubcommands.includes(subcommand)) {
       commandName = `services:${subcommand}`
+      // Remove the subcommand from args so it's not treated as an argument
+      args = [process.argv[2], ...process.argv.slice(4)]
+    }
+  }
+
+  // Handle deps subcommands (e.g., "deps list" -> "deps:list")
+  const depsSubcommands = ['list', 'outdated', 'why']
+  if (commandName === 'deps') {
+    const subcommand = process.argv[3]
+    if (subcommand && depsSubcommands.includes(subcommand)) {
+      commandName = `deps:${subcommand}`
       // Remove the subcommand from args so it's not treated as an argument
       args = [process.argv[2], ...process.argv.slice(4)]
     }
@@ -101,6 +111,7 @@ async function main() {
     'services:restart': servicesRestartCommand,
     'services:status': servicesStatusCommand,
     logs: logsCommand,
+    deps: depsListCommand,
     'deps:list': depsListCommand,
     'deps:outdated': depsOutdatedCommand,
     'deps:why': depsWhyCommand,


### PR DESCRIPTION
## Summary

- Add subcommand handler for `deps` similar to `services`, allowing space-separated syntax
- `denvig deps` now defaults to listing dependencies (same as `denvig deps list`)
- `denvig deps list`, `denvig deps outdated`, and `denvig deps why` now work alongside the colon-separated format
- Update documentation to use space-separated format for consistency with services commands

## Test plan

- [x] Run `pnpm run lint` - passes
- [x] Run `pnpm run test` - all 82 tests pass
- [x] Verify `bin/denvig-dev version` works
- [x] Verify `denvig deps` lists dependencies
- [x] Verify `denvig deps list` lists dependencies
- [x] Verify `denvig deps outdated` shows outdated dependencies