### PR TITLE
Add envFile field to ServiceResponse for JSON output

### DIFF
--- a/src/lib/services/manager.ts
+++ b/src/lib/services/manager.ts
@@ -62,6 +62,7 @@ export type ServiceResponse = {
   command: string
   cwd: string
   logPath: string
+  envFile: string | null
   lastExitCode: number | null
   logs?: string[]
 }
@@ -539,6 +540,9 @@ export class ServiceManager {
       command: config.command,
       cwd: this.resolveServiceCwd(config),
       logPath: this.getLogPath(name, 'stdout'),
+      envFile: config.envFile
+        ? resolve(this.project.path, config.envFile)
+        : null,
       lastExitCode,
     }
 


### PR DESCRIPTION
## Summary
- Add `envFile: string | null` field to the `ServiceResponse` type
- Return the absolute path to the configured env file in JSON output for all services commands (list, status, start, stop, restart)
- Returns `null` when no env file is configured for a service

## Test plan
- [x] Run `pnpm run lint` - passes
- [x] Run `pnpm run test` - all 82 tests pass
- [x] Verify CLI works with `bin/denvig-dev version`