### PR TITLE
Optimize performance with batching, parallelization, and caching

### DIFF
--- a/src/commands/services/restart.ts
+++ b/src/commands/services/restart.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { Command } from '../../lib/command.ts'
 import { getServiceContext } from '../../lib/services/identifier.ts'
+import launchctl from '../../lib/services/launchctl.ts'
 import {
   ServiceManager,
   type ServiceResponse,
@@ -130,9 +131,13 @@ export const servicesRestartCommand = new Command({
     const serviceResponses: ServiceResponse[] = []
     let hasErrors = false
 
+    // Pre-fetch launchctl list once for batch lookup
+    const launchctlList = await launchctl.list('denvig.')
+
     for (const result of results) {
       const response = await manager.getServiceResponse(result.name, {
         includeLogs: !result.success,
+        launchctlList,
       })
 
       if (!response) {

--- a/src/commands/services/start.ts
+++ b/src/commands/services/start.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { Command } from '../../lib/command.ts'
 import { getServiceContext } from '../../lib/services/identifier.ts'
+import launchctl from '../../lib/services/launchctl.ts'
 import {
   ServiceManager,
   type ServiceResponse,
@@ -133,9 +134,13 @@ export const servicesStartCommand = new Command({
     const serviceResponses: ServiceResponse[] = []
     let hasErrors = false
 
+    // Pre-fetch launchctl list once for batch lookup
+    const launchctlList = await launchctl.list('denvig.')
+
     for (const result of results) {
       const response = await manager.getServiceResponse(result.name, {
         includeLogs: !result.success,
+        launchctlList,
       })
 
       if (!response) {

--- a/src/commands/services/stop.ts
+++ b/src/commands/services/stop.ts
@@ -1,5 +1,6 @@
 import { Command } from '../../lib/command.ts'
 import { getServiceContext } from '../../lib/services/identifier.ts'
+import launchctl from '../../lib/services/launchctl.ts'
 import {
   ServiceManager,
   type ServiceResponse,
@@ -99,8 +100,13 @@ export const servicesStopCommand = new Command({
     const serviceResponses: ServiceResponse[] = []
     let hasErrors = false
 
+    // Pre-fetch launchctl list once for batch lookup
+    const launchctlList = await launchctl.list('denvig.')
+
     for (const result of results) {
-      const response = await manager.getServiceResponse(result.name)
+      const response = await manager.getServiceResponse(result.name, {
+        launchctlList,
+      })
 
       if (!response) {
         continue

--- a/src/plugins/pnpm.ts
+++ b/src/plugins/pnpm.ts
@@ -8,6 +8,9 @@ import { definePlugin } from '../lib/plugin.ts'
 import type { ProjectDependencySchema } from '../lib/dependencies.ts'
 import type { DenvigProject } from '../lib/project.ts'
 
+// Cache for parsed dependencies by project path
+const dependenciesCache = new Map<string, ProjectDependencySchema[]>()
+
 type PnpmLockfileDep = {
   specifier: string
   version: string
@@ -74,6 +77,12 @@ const plugin = definePlugin({
   ): Promise<ProjectDependencySchema[]> => {
     if (!existsSync(`${project.path}/pnpm-lock.yaml`)) {
       return []
+    }
+
+    // Return cached result if available
+    const cached = dependenciesCache.get(project.path)
+    if (cached) {
+      return cached
     }
 
     const data: Map<string, ProjectDependencySchema> = new Map()
@@ -187,9 +196,14 @@ const plugin = definePlugin({
       }
     }
 
-    return Array.from(data.values()).sort((a, b) =>
+    const result = Array.from(data.values()).sort((a, b) =>
       a.name.localeCompare(b.name),
     )
+
+    // Cache the result for subsequent calls
+    dependenciesCache.set(project.path, result)
+
+    return result
   },
 
   outdatedDependencies: async (project: DenvigProject, options) => {


### PR DESCRIPTION
## Summary

- Batch launchctl calls in service commands (start, stop, restart) by pre-fetching launchctl list once and passing to getServiceResponse
- Parallelize ServiceManager batch operations (startAll, stopAll, restartAll) using Promise.all instead of sequential loops
- Parallelize plugin dependency detection in detectDependencies()
- Parallelize plugin outdated detection in outdatedDependencies()
- Cache rootFiles getter in DenvigProject to avoid repeated readdirSync calls
- Cache parsed dependencies in pnpm, yarn, ruby, and uv plugins to avoid re-parsing lock files when outdatedDependencies calls dependencies

## Test plan

- [x] Run `pnpm run lint` - passes
- [x] Run `pnpm run test` - all 82 tests pass
- [x] Run `bin/denvig-dev version` - CLI works correctly
- [x] Test `denvig services start` with multiple services
- [x] Test `denvig services stop` with multiple services
- [x] Test `denvig deps outdated` on projects with multiple ecosystems