### PR TITLE
Move `logs` command to `services logs` for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- Moved `logs` command to `services logs` for consistency with other services subcommands
 - Optimized `services` command performance by batching launchctl calls (O(n) to O(1))
 
 ### Fixed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,7 @@ async function main() {
   }
 
   // Handle services subcommands (e.g., "services start" -> "services:start")
-  const servicesSubcommands = ['start', 'stop', 'restart', 'status']
+  const servicesSubcommands = ['start', 'stop', 'restart', 'status', 'logs']
   if (commandName === 'services') {
     const subcommand = process.argv[3]
     if (subcommand && servicesSubcommands.includes(subcommand)) {
@@ -103,7 +103,7 @@ async function main() {
   const { servicesStatusCommand } = await import(
     './commands/services/status.ts'
   )
-  const { logsCommand } = await import('./commands/logs.ts')
+  const { logsCommand } = await import('./commands/services/logs.ts')
   const { internalsResourceHashCommand, internalsResourceIdCommand } =
     await import('./commands/internals.ts')
   const { depsListCommand } = await import('./commands/deps/list.ts')
@@ -123,7 +123,7 @@ async function main() {
     'services:stop': servicesStopCommand,
     'services:restart': servicesRestartCommand,
     'services:status': servicesStatusCommand,
-    logs: logsCommand,
+    'services:logs': logsCommand,
     deps: depsListCommand,
     'deps:list': depsListCommand,
     'deps:outdated': depsOutdatedCommand,

--- a/src/commands/services/logs.test.ts
+++ b/src/commands/services/logs.test.ts
@@ -1,7 +1,7 @@
 import { ok } from 'node:assert'
 import { describe, it } from 'node:test'
 
-import { DenvigProject } from '../lib/project.ts'
+import { DenvigProject } from '../../lib/project.ts'
 import { logsCommand } from './logs.ts'
 
 describe('logsCommand', () => {

--- a/src/commands/services/logs.ts
+++ b/src/commands/services/logs.ts
@@ -1,14 +1,14 @@
 import { spawn } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 
-import { Command } from '../lib/command.ts'
-import { ServiceManager } from '../lib/services/manager.ts'
+import { Command } from '../../lib/command.ts'
+import { ServiceManager } from '../../lib/services/manager.ts'
 
 export const logsCommand = new Command({
-  name: 'logs',
+  name: 'services:logs',
   description: 'Show logs for a service',
-  usage: 'logs <name> [-n <lines>] [--follow]',
-  example: 'logs api -n 50 --follow',
+  usage: 'services logs <name> [-n <lines>] [--follow]',
+  example: 'services logs api -n 50 --follow',
   args: [
     {
       name: 'name',


### PR DESCRIPTION
## Summary

- Moved the `logs` command to be namespaced under `services logs` for consistency with other services subcommands (`start`, `stop`, `restart`, `status`)
- Updated CLI router to handle `services logs` subcommand
- Updated CHANGELOG.md

## Usage Change

```bash
# Before
denvig logs api -n 50 --follow

# After
denvig services logs api -n 50 --follow
```

## Test plan

- [x] All 101 tests pass
- [x] `bin/denvig-dev version` works
- [x] `bin/denvig-dev services logs` shows in help output
- [x] Type checking passes