### PR TITLE
Require service name for start/stop/restart commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- **Breaking:** `services start`, `services stop`, `services restart` now require a service name (removed bulk operations)
 - Moved `logs` command to `services logs` for consistency with other services subcommands
 - Optimized `services` command performance by batching launchctl calls (O(n) to O(1))
 

--- a/README.md
+++ b/README.md
@@ -67,31 +67,24 @@ denvig deps --format json            # Output as JSON
 Manage background services defined in `.denvig.yml`. Services run via launchctl on macOS:
 
 ```shell
-denvig services               # List services and their status
-denvig services start         # Start all services
-denvig services stop          # Stop all services
-denvig services restart       # Restart all services
+denvig services               # List all services and their status
+denvig services start api     # Start a service
+denvig services stop api      # Stop a service
+denvig services restart api   # Restart a service
+denvig services status api    # Check status of a service
+denvig services logs api      # View service logs
 ```
 
-Target a specific service by name:
+Manage services from other projects using the full path:
 
 ```shell
-denvig services start api     # Start only the 'api' service
-denvig services status api    # Start only the 'api' service
-denvig services stop api      # Stop only the 'api' service
-denvig services restart api   # Restart only the 'api' service
-```
-
-Manage services globally from any directory:
-
-```shell
-denvig services start marcqualie/denvig/hello   # Start 'api' in marcqualie/denvig project
-denvig services status marcqualie/denvig/hello  # Check status of 'api' service
+denvig services start marcqualie/denvig/dev    # Start 'dev' service in marcqualie/denvig project
+denvig services status marcqualie/denvig/hello # Check status of 'hello' in marcqualie/denvig project
 ```
 
 See [docs/configuration.md](docs/configuration.md) for service configuration options.
 
-All services commands also accept `--format json` for programmatic output.
+All services commands accept `--format json` for programmatic output.
 
 
 
@@ -123,6 +116,36 @@ can be supported by using the per project configs.
 ## Troubleshooting
 
 For troubleshooting guides including service management, resource identification, and log browsing, see [docs/troubleshooting.md](docs/troubleshooting.md).
+
+
+
+## SDK
+
+Denvig can be used programmatically in TypeScript projects:
+
+```ts
+import { DenvigSDK } from 'denvig'
+
+const denvig = new DenvigSDK()
+
+// Services
+const services = await denvig.services.list()
+await denvig.services.start('api')
+await denvig.services.stop('api')
+
+// Dependencies
+const deps = await denvig.deps.list()
+const outdated = await denvig.deps.outdated({ semver: 'minor' })
+
+// Execute in context of another project
+await denvig.deps.outdated({ project: 'marcqualie/denvig' })
+```
+
+All response types are exported for TypeScript consumers:
+
+```ts
+import type { ServiceResponse, Dependency, OutdatedDependency } from 'denvig'
+```
 
 
 

--- a/src/commands/services/restart.ts
+++ b/src/commands/services/restart.ts
@@ -2,23 +2,18 @@ import { z } from 'zod'
 
 import { Command } from '../../lib/command.ts'
 import { getServiceContext } from '../../lib/services/identifier.ts'
-import launchctl from '../../lib/services/launchctl.ts'
-import {
-  ServiceManager,
-  type ServiceResponse,
-} from '../../lib/services/manager.ts'
 
 export const servicesRestartCommand = new Command({
   name: 'services:restart',
-  description: 'Restart all services or a specific service',
-  usage: 'services restart [name] [--format table|json]',
-  example: 'services restart api or services restart marcqualie/api/dev',
+  description: 'Restart a service',
+  usage: 'services restart <name> [--format table|json]',
+  example: 'services restart api',
   args: [
     {
       name: 'name',
       description:
-        'Service name or project/service path (e.g., hello or marcqualie/api/dev)',
-      required: false,
+        'Service name or project/service path (e.g., api or marcqualie/denvig/hello)',
+      required: true,
       type: 'string',
     },
   ],
@@ -35,161 +30,72 @@ export const servicesRestartCommand = new Command({
     const serviceArg = z.string().parse(args.name)
     const format = flags.format as string
 
-    // Restart specific service or all services
-    if (serviceArg) {
-      const {
-        manager,
-        serviceName,
-        project: targetProject,
-      } = getServiceContext(serviceArg, project)
+    const {
+      manager,
+      serviceName,
+      project: targetProject,
+    } = getServiceContext(serviceArg, project)
 
-      const projectPrefix =
-        targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
+    const projectPrefix =
+      targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
 
-      if (format !== 'json') {
-        console.log(`Restarting ${projectPrefix}${serviceName}...`)
-      }
-
-      const result = await manager.restartService(serviceName)
-
-      if (!result.success) {
-        if (format === 'json') {
-          console.log(
-            JSON.stringify({
-              success: false,
-              service: serviceName,
-              project: targetProject.slug,
-              message: result.message,
-            }),
-          )
-        } else {
-          console.error(
-            `✗ Failed to restart ${projectPrefix}${serviceName}: ${result.message}`,
-          )
-        }
-        return { success: false, message: result.message }
-      }
-
-      // Wait for service to start
-      await new Promise((resolve) => setTimeout(resolve, 2000))
-
-      // Get service response
-      const response = await manager.getServiceResponse(serviceName, {
-        includeLogs: true,
-      })
-
-      if (response?.status === 'running') {
-        if (format === 'json') {
-          console.log(JSON.stringify(response))
-        } else {
-          const urlInfo = response.url ? ` → ${response.url}` : ''
-          console.log(
-            `✓ ${projectPrefix}${serviceName} restarted successfully${urlInfo}`,
-          )
-        }
-        return { success: true, message: 'Service restarted successfully.' }
-      }
-
-      // Service failed to start
-      if (format === 'json') {
-        console.log(JSON.stringify(response))
-      } else {
-        console.error(`✗ ${projectPrefix}${serviceName} failed to start`)
-        if (response?.logs && response.logs.length > 0) {
-          console.error('')
-          console.error('Recent logs:')
-          for (const line of response.logs) {
-            console.error(`  ${line}`)
-          }
-        }
-      }
-      return { success: false, message: 'Service failed to start.' }
+    if (format !== 'json') {
+      console.log(`Restarting ${projectPrefix}${serviceName}...`)
     }
 
-    // Restart all running services in current project
-    const manager = new ServiceManager(project)
-    const results = await manager.restartAll()
+    const result = await manager.restartService(serviceName)
 
-    if (results.length === 0) {
+    if (!result.success) {
       if (format === 'json') {
         console.log(
           JSON.stringify({
-            success: true,
-            project: project.slug,
-            services: [],
+            success: false,
+            service: serviceName,
+            project: targetProject.slug,
+            message: result.message,
           }),
         )
       } else {
-        console.log('No running services to restart.')
+        console.error(
+          `✗ Failed to restart ${projectPrefix}${serviceName}: ${result.message}`,
+        )
       }
-      return { success: true, message: 'No services to restart.' }
+      return { success: false, message: result.message }
     }
 
-    // Wait for services to start
+    // Wait for service to start
     await new Promise((resolve) => setTimeout(resolve, 2000))
 
-    const serviceResponses: ServiceResponse[] = []
-    let hasErrors = false
+    // Get service response
+    const response = await manager.getServiceResponse(serviceName, {
+      includeLogs: true,
+    })
 
-    // Pre-fetch launchctl list once for batch lookup
-    const launchctlList = await launchctl.list('denvig.')
-
-    for (const result of results) {
-      const response = await manager.getServiceResponse(result.name, {
-        includeLogs: !result.success,
-        launchctlList,
-      })
-
-      if (!response) {
-        continue
-      }
-
-      serviceResponses.push(response)
-
-      if (!result.success || response.status !== 'running') {
-        hasErrors = true
-        if (format !== 'json') {
-          if (!result.success) {
-            console.error(`Restarting ${result.name}... ✗`)
-            console.error(`  ${result.message}`)
-          } else {
-            console.error(`Restarting ${result.name}... ✗ (failed to start)`)
-            if (response.logs && response.logs.length > 0) {
-              console.error('  Recent logs:')
-              for (const line of response.logs.slice(-3)) {
-                console.error(`    ${line}`)
-              }
-            }
-          }
-        }
+    if (response?.status === 'running') {
+      if (format === 'json') {
+        console.log(JSON.stringify(response))
       } else {
-        if (format !== 'json') {
-          const urlInfo = response.url ? ` → ${response.url}` : ''
-          console.log(`Restarting ${result.name}... ✓${urlInfo}`)
-        }
+        const urlInfo = response.url ? ` → ${response.url}` : ''
+        console.log(
+          `✓ ${projectPrefix}${serviceName} restarted successfully${urlInfo}`,
+        )
       }
+      return { success: true, message: 'Service restarted successfully.' }
     }
 
+    // Service failed to start
     if (format === 'json') {
-      console.log(
-        JSON.stringify({
-          success: !hasErrors,
-          project: project.slug,
-          services: serviceResponses,
-        }),
-      )
+      console.log(JSON.stringify(response))
     } else {
-      console.log('')
-      if (hasErrors) {
-        console.log('Some services failed to restart')
-      } else {
-        console.log('All services restarted successfully')
+      console.error(`✗ ${projectPrefix}${serviceName} failed to restart`)
+      if (response?.logs && response.logs.length > 0) {
+        console.error('')
+        console.error('Recent logs:')
+        for (const line of response.logs) {
+          console.error(`  ${line}`)
+        }
       }
     }
-
-    if (hasErrors) {
-      return { success: false, message: 'Some services failed to restart.' }
-    }
-    return { success: true, message: 'All services restarted successfully.' }
+    return { success: false, message: 'Service failed to restart.' }
   },
 })

--- a/src/commands/services/start.ts
+++ b/src/commands/services/start.ts
@@ -2,23 +2,18 @@ import { z } from 'zod'
 
 import { Command } from '../../lib/command.ts'
 import { getServiceContext } from '../../lib/services/identifier.ts'
-import launchctl from '../../lib/services/launchctl.ts'
-import {
-  ServiceManager,
-  type ServiceResponse,
-} from '../../lib/services/manager.ts'
 
 export const servicesStartCommand = new Command({
   name: 'services:start',
-  description: 'Start all services or a specific service',
-  usage: 'services start [name] [--format table|json]',
-  example: 'services start api or services start marcqualie/api/dev',
+  description: 'Start a service',
+  usage: 'services start <name> [--format table|json]',
+  example: 'services start api',
   args: [
     {
       name: 'name',
       description:
-        'Service name or project/service path (e.g., hello or marcqualie/api/dev)',
-      required: false,
+        'Service name or project/service path (e.g., api or marcqualie/denvig/hello)',
+      required: true,
       type: 'string',
     },
   ],
@@ -32,167 +27,75 @@ export const servicesStartCommand = new Command({
     },
   ],
   handler: async ({ project, args, flags }) => {
-    // Parse service name from args (ensures it's a string)
     const serviceArg = z.string().parse(args.name)
     const format = flags.format as string
 
-    // Start specific service or all services
-    if (serviceArg) {
-      const {
-        manager,
-        serviceName,
-        project: targetProject,
-      } = getServiceContext(serviceArg, project)
+    const {
+      manager,
+      serviceName,
+      project: targetProject,
+    } = getServiceContext(serviceArg, project)
 
-      const projectPrefix =
-        targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
+    const projectPrefix =
+      targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
 
-      if (format !== 'json') {
-        console.log(`Starting ${projectPrefix}${serviceName}...`)
-      }
-
-      const result = await manager.startService(serviceName)
-
-      if (!result.success) {
-        if (format === 'json') {
-          console.log(
-            JSON.stringify({
-              success: false,
-              service: serviceName,
-              project: targetProject.slug,
-              message: result.message,
-            }),
-          )
-        } else {
-          console.error(
-            `✗ Failed to start ${projectPrefix}${serviceName}: ${result.message}`,
-          )
-        }
-        return { success: false, message: result.message }
-      }
-
-      // Wait for service to start
-      await new Promise((resolve) => setTimeout(resolve, 2000))
-
-      // Get service response
-      const response = await manager.getServiceResponse(serviceName, {
-        includeLogs: true,
-      })
-
-      if (response?.status === 'running') {
-        if (format === 'json') {
-          console.log(JSON.stringify(response))
-        } else {
-          const urlInfo = response.url ? ` → ${response.url}` : ''
-          console.log(
-            `✓ ${projectPrefix}${serviceName} started successfully${urlInfo}`,
-          )
-        }
-        return { success: true, message: 'Service started successfully.' }
-      }
-
-      // Service failed to start
-      if (format === 'json') {
-        console.log(JSON.stringify(response))
-      } else {
-        console.error(`✗ ${projectPrefix}${serviceName} failed to start`)
-        if (response?.logs && response.logs.length > 0) {
-          console.error('')
-          console.error('Recent logs:')
-          for (const line of response.logs) {
-            console.error(`  ${line}`)
-          }
-        }
-      }
-      return { success: false, message: 'Service failed to start.' }
+    if (format !== 'json') {
+      console.log(`Starting ${projectPrefix}${serviceName}...`)
     }
 
-    // Start all services in current project
-    const manager = new ServiceManager(project)
-    const services = await manager.listServices()
+    const result = await manager.startService(serviceName)
 
-    if (services.length === 0) {
+    if (!result.success) {
       if (format === 'json') {
         console.log(
           JSON.stringify({
-            success: true,
-            project: project.slug,
-            services: [],
+            success: false,
+            service: serviceName,
+            project: targetProject.slug,
+            message: result.message,
           }),
         )
       } else {
-        console.log('No services configured in this project.')
+        console.error(
+          `✗ Failed to start ${projectPrefix}${serviceName}: ${result.message}`,
+        )
       }
-      return { success: true, message: 'No services to start.' }
+      return { success: false, message: result.message }
     }
 
-    const results = await manager.startAll()
-
-    // Wait for services to start
+    // Wait for service to start
     await new Promise((resolve) => setTimeout(resolve, 2000))
 
-    const serviceResponses: ServiceResponse[] = []
-    let hasErrors = false
+    // Get service response
+    const response = await manager.getServiceResponse(serviceName, {
+      includeLogs: true,
+    })
 
-    // Pre-fetch launchctl list once for batch lookup
-    const launchctlList = await launchctl.list('denvig.')
-
-    for (const result of results) {
-      const response = await manager.getServiceResponse(result.name, {
-        includeLogs: !result.success,
-        launchctlList,
-      })
-
-      if (!response) {
-        continue
-      }
-
-      serviceResponses.push(response)
-
-      if (!result.success || response.status !== 'running') {
-        hasErrors = true
-        if (format !== 'json') {
-          if (!result.success) {
-            console.error(`Starting ${result.name}... ✗`)
-            console.error(`  ${result.message}`)
-          } else {
-            console.error(`Starting ${result.name}... ✗ (failed to start)`)
-            if (response.logs && response.logs.length > 0) {
-              console.error('  Recent logs:')
-              for (const line of response.logs.slice(-3)) {
-                console.error(`    ${line}`)
-              }
-            }
-          }
-        }
+    if (response?.status === 'running') {
+      if (format === 'json') {
+        console.log(JSON.stringify(response))
       } else {
-        if (format !== 'json') {
-          const urlInfo = response.url ? ` → ${response.url}` : ''
-          console.log(`Starting ${result.name}... ✓${urlInfo}`)
-        }
+        const urlInfo = response.url ? ` → ${response.url}` : ''
+        console.log(
+          `✓ ${projectPrefix}${serviceName} started successfully${urlInfo}`,
+        )
       }
+      return { success: true, message: 'Service started successfully.' }
     }
 
+    // Service failed to start
     if (format === 'json') {
-      console.log(
-        JSON.stringify({
-          success: !hasErrors,
-          project: project.slug,
-          services: serviceResponses,
-        }),
-      )
+      console.log(JSON.stringify(response))
     } else {
-      console.log('')
-      if (hasErrors) {
-        console.log('Some services failed to start')
-      } else {
-        console.log('All services started successfully')
+      console.error(`✗ ${projectPrefix}${serviceName} failed to start`)
+      if (response?.logs && response.logs.length > 0) {
+        console.error('')
+        console.error('Recent logs:')
+        for (const line of response.logs) {
+          console.error(`  ${line}`)
+        }
       }
     }
-
-    if (hasErrors) {
-      return { success: false, message: 'Some services failed to start.' }
-    }
-    return { success: true, message: 'All services started successfully.' }
+    return { success: false, message: 'Service failed to start.' }
   },
 })

--- a/src/commands/services/status.ts
+++ b/src/commands/services/status.ts
@@ -9,12 +9,12 @@ export const servicesStatusCommand = new Command({
   name: 'services:status',
   description: 'Show status of a specific service',
   usage: 'services status <name> [--format table|json]',
-  example: 'services status api or services status marcqualie/api/dev',
+  example: 'services status api or services status marcqualie/denvig/hello',
   args: [
     {
       name: 'name',
       description:
-        'Service name or project/service path (e.g., hello or marcqualie/api/dev)',
+        'Service name or project/service path (e.g., hello or marcqualie/denvig/hello)',
       required: true,
       type: 'string',
     },

--- a/src/commands/services/stop.ts
+++ b/src/commands/services/stop.ts
@@ -1,22 +1,19 @@
+import { z } from 'zod'
+
 import { Command } from '../../lib/command.ts'
 import { getServiceContext } from '../../lib/services/identifier.ts'
-import launchctl from '../../lib/services/launchctl.ts'
-import {
-  ServiceManager,
-  type ServiceResponse,
-} from '../../lib/services/manager.ts'
 
 export const servicesStopCommand = new Command({
   name: 'services:stop',
-  description: 'Stop all services or a specific service',
-  usage: 'services stop [name] [--format table|json]',
-  example: 'services stop api or services stop marcqualie/api/dev',
+  description: 'Stop a service',
+  usage: 'services stop <name> [--format table|json]',
+  example: 'services stop api',
   args: [
     {
       name: 'name',
       description:
-        'Service name or project/service path (e.g., hello or marcqualie/api/dev)',
-      required: false,
+        'Service name or project/service path (e.g., api or marcqualie/denvig/hello)',
+      required: true,
       type: 'string',
     },
   ],
@@ -30,123 +27,50 @@ export const servicesStopCommand = new Command({
     },
   ],
   handler: async ({ project, args, flags }) => {
+    const serviceArg = z.string().parse(args.name)
     const format = flags.format as string
 
-    // Stop specific service or all services
-    if (typeof args.name === 'string' && args.name) {
-      const {
-        manager,
-        serviceName,
-        project: targetProject,
-      } = getServiceContext(args.name, project)
+    const {
+      manager,
+      serviceName,
+      project: targetProject,
+    } = getServiceContext(serviceArg, project)
 
-      const projectPrefix =
-        targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
+    const projectPrefix =
+      targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
 
-      if (format !== 'json') {
-        console.log(`Stopping ${projectPrefix}${serviceName}...`)
-      }
-
-      const result = await manager.stopService(serviceName)
-
-      if (!result.success) {
-        if (format === 'json') {
-          console.log(
-            JSON.stringify({
-              success: false,
-              service: serviceName,
-              project: targetProject.slug,
-              message: result.message,
-            }),
-          )
-        } else {
-          console.error(
-            `✗ Failed to stop ${projectPrefix}${serviceName}: ${result.message}`,
-          )
-        }
-        return { success: false, message: result.message }
-      }
-
-      // Get service response after stopping
-      const response = await manager.getServiceResponse(serviceName)
-
-      if (format === 'json') {
-        console.log(JSON.stringify(response))
-      } else {
-        console.log(`✓ ${projectPrefix}${serviceName} stopped successfully`)
-      }
-      return { success: true, message: 'Service stopped successfully.' }
+    if (format !== 'json') {
+      console.log(`Stopping ${projectPrefix}${serviceName}...`)
     }
 
-    // Stop all services in current project
-    const manager = new ServiceManager(project)
-    const results = await manager.stopAll()
+    const result = await manager.stopService(serviceName)
 
-    if (results.length === 0) {
+    if (!result.success) {
       if (format === 'json') {
         console.log(
           JSON.stringify({
-            success: true,
-            project: project.slug,
-            services: [],
+            success: false,
+            service: serviceName,
+            project: targetProject.slug,
+            message: result.message,
           }),
         )
       } else {
-        console.log('No running services to stop.')
+        console.error(
+          `✗ Failed to stop ${projectPrefix}${serviceName}: ${result.message}`,
+        )
       }
-      return { success: true, message: 'No services to stop.' }
+      return { success: false, message: result.message }
     }
 
-    const serviceResponses: ServiceResponse[] = []
-    let hasErrors = false
-
-    // Pre-fetch launchctl list once for batch lookup
-    const launchctlList = await launchctl.list('denvig.')
-
-    for (const result of results) {
-      const response = await manager.getServiceResponse(result.name, {
-        launchctlList,
-      })
-
-      if (!response) {
-        continue
-      }
-
-      serviceResponses.push(response)
-
-      if (!result.success) {
-        hasErrors = true
-        if (format !== 'json') {
-          console.error(`Stopping ${result.name}... ✗`)
-          console.error(`  ${result.message}`)
-        }
-      } else {
-        if (format !== 'json') {
-          console.log(`Stopping ${result.name}... ✓`)
-        }
-      }
-    }
+    // Get service response after stopping
+    const response = await manager.getServiceResponse(serviceName)
 
     if (format === 'json') {
-      console.log(
-        JSON.stringify({
-          success: !hasErrors,
-          project: project.slug,
-          services: serviceResponses,
-        }),
-      )
+      console.log(JSON.stringify(response))
     } else {
-      console.log('')
-      if (hasErrors) {
-        console.log('Some services failed to stop')
-      } else {
-        console.log('All services stopped successfully')
-      }
+      console.log(`✓ ${projectPrefix}${serviceName} stopped successfully`)
     }
-
-    if (hasErrors) {
-      return { success: false, message: 'Some services failed to stop.' }
-    }
-    return { success: true, message: 'All services stopped successfully.' }
+    return { success: true, message: 'Service stopped successfully.' }
   },
 })

--- a/src/lib/services/identifier.ts
+++ b/src/lib/services/identifier.ts
@@ -10,8 +10,8 @@ export type ServiceIdentifier = {
  * Parse a service identifier string into project slug and service name.
  *
  * If the identifier contains a `/`, it's treated as `project/service` format
- * where project can be multi-level (e.g., `marcqualie/api/dev` means project
- * `marcqualie/api` and service `dev`).
+ * where project can be multi-level (e.g., `marcqualie/denvig/hello` means project
+ * `marcqualie/denvig` and service `hello`).
  *
  * If no `/`, uses the current project.
  */

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -25,15 +25,6 @@ import type {
 const execAsync = promisify(exec)
 
 /**
- * Response when starting/stopping/restarting all services in a project.
- */
-export type ServiceBulkResponse = {
-  success: boolean
-  project: string
-  services: ServiceResponse[]
-}
-
-/**
  * Response when a service operation fails.
  */
 export type ServiceOperationError = {
@@ -262,47 +253,40 @@ export class DenvigSDK {
     },
 
     /**
-     * Start a service or all services.
-     * @param name - Service name to start, or omit to start all services in the project
+     * Start a service.
+     * @param name - Service name to start
      */
     start: async (
-      name?: string,
+      name: string,
       options?: ServiceOperationOptions,
-    ): Promise<ServiceResponse | ServiceBulkResponse> => {
+    ): Promise<ServiceResponse> => {
       const flags = options ? this.buildFlags(options) : ''
-      const nameArg = name ?? ''
-      return this.run<ServiceResponse | ServiceBulkResponse>(
-        `services start ${nameArg} ${flags}`.trim(),
-      )
+      return this.run<ServiceResponse>(`services start ${name} ${flags}`.trim())
     },
 
     /**
-     * Stop a service or all services.
-     * @param name - Service name to stop, or omit to stop all services in the project
+     * Stop a service.
+     * @param name - Service name to stop
      */
     stop: async (
-      name?: string,
+      name: string,
       options?: ServiceOperationOptions,
-    ): Promise<ServiceResponse | ServiceBulkResponse> => {
+    ): Promise<ServiceResponse> => {
       const flags = options ? this.buildFlags(options) : ''
-      const nameArg = name ?? ''
-      return this.run<ServiceResponse | ServiceBulkResponse>(
-        `services stop ${nameArg} ${flags}`.trim(),
-      )
+      return this.run<ServiceResponse>(`services stop ${name} ${flags}`.trim())
     },
 
     /**
-     * Restart a service or all services.
-     * @param name - Service name to restart, or omit to restart all services in the project
+     * Restart a service.
+     * @param name - Service name to restart
      */
     restart: async (
-      name?: string,
+      name: string,
       options?: ServiceOperationOptions,
-    ): Promise<ServiceResponse | ServiceBulkResponse> => {
+    ): Promise<ServiceResponse> => {
       const flags = options ? this.buildFlags(options) : ''
-      const nameArg = name ?? ''
-      return this.run<ServiceResponse | ServiceBulkResponse>(
-        `services restart ${nameArg} ${flags}`.trim(),
+      return this.run<ServiceResponse>(
+        `services restart ${name} ${flags}`.trim(),
       )
     },
   }


### PR DESCRIPTION
## Summary

**BREAKING CHANGE:** Service commands now require a service name argument. Bulk operations on all services have been removed for simplicity.

### CLI Changes

```shell
# Before (optional name)
denvig services start         # Started all services
denvig services start api     # Started one service

# After (required name)
denvig services start api     # Start a specific service
denvig services stop api      # Stop a specific service
denvig services restart api   # Restart a specific service
```

### SDK Changes

- `start(name)`, `stop(name)`, `restart(name)` - name parameter is now required
- Return type simplified to `ServiceResponse` (removed `ServiceBulkResponse` union type)
- Added `project` option to `deps.list()` and `deps.outdated()` for cross-project queries

### Documentation

- Updated README with new service command syntax
- Added SDK usage section to README
- Updated CHANGELOG with breaking change notice

## Test plan

- [x] Build succeeds with `pnpm run build`
- [x] All 101 tests pass with `pnpm run test`
- [x] CLI requires name: `denvig services start` shows "Missing required argument: name"
- [x] CLI works with name: `denvig services start api` works correctly