### PR TITLE
Add `projects list` command with service status indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 
+- `projects list` command to list all projects on the system with optional `--format json` and `--with-config` flags
 - `services teardown` command to stop all services and remove them from launchctl (factory reset)
 - `--global` flag for `services teardown` to teardown all denvig services across all projects
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,6 +85,17 @@ async function main() {
     }
   }
 
+  // Handle projects subcommands (e.g., "projects list" -> "projects:list")
+  const projectsSubcommands = ['list']
+  if (commandName === 'projects') {
+    const subcommand = process.argv[3]
+    if (subcommand && projectsSubcommands.includes(subcommand)) {
+      commandName = `projects:${subcommand}`
+      // Remove the subcommand from args so it's not treated as an argument
+      args = [process.argv[2], ...process.argv.slice(4)]
+    }
+  }
+
   // Quick actions
   const quickActions = [
     ...(globalConfig.quickActions || []),
@@ -120,6 +131,7 @@ async function main() {
   const { depsOutdatedCommand } = await import('./commands/deps/outdated.ts')
   const { depsWhyCommand } = await import('./commands/deps/why.ts')
   const { configVerifyCommand } = await import('./commands/config/verify.ts')
+  const { projectsListCommand } = await import('./commands/projects/list.ts')
 
   const commands = {
     run: runCommand,
@@ -141,6 +153,8 @@ async function main() {
     'deps:why': depsWhyCommand,
     'internals:resource-hash': internalsResourceHashCommand,
     'internals:resource-id': internalsResourceIdCommand,
+    projects: projectsListCommand,
+    'projects:list': projectsListCommand,
   } as Record<string, GenericCommand>
 
   const command = commands[commandName]

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -1,0 +1,144 @@
+import { Command } from '../../lib/command.ts'
+import { formatTable } from '../../lib/formatters/table.ts'
+import { prettyPath } from '../../lib/path.ts'
+import { DenvigProject } from '../../lib/project.ts'
+import { listProjects } from '../../lib/projects.ts'
+import launchctl from '../../lib/services/launchctl.ts'
+import { ServiceManager } from '../../lib/services/manager.ts'
+
+import type { ProjectResponse } from '../../types/responses.ts'
+
+type ProjectWithStatus = ProjectResponse & {
+  serviceStatus: 'running' | 'stopped' | 'none'
+}
+
+const getStatusIcon = (status: 'running' | 'stopped' | 'none'): string => {
+  switch (status) {
+    case 'running':
+      return '🟢'
+    case 'stopped':
+      return '◯'
+    default:
+      return ''
+  }
+}
+
+export const projectsListCommand = new Command({
+  name: 'projects',
+  description: 'List all projects on the system',
+  usage: 'projects [list] [--format table|json] [--with-config]',
+  example: 'projects --format json',
+  args: [],
+  flags: [
+    {
+      name: 'format',
+      description: 'Output format: table or json (default: table)',
+      required: false,
+      type: 'string',
+      defaultValue: 'table',
+    },
+    {
+      name: 'with-config',
+      description: 'Only show projects with a .denvig.yml configuration file',
+      required: false,
+      type: 'boolean',
+      defaultValue: false,
+    },
+  ],
+  handler: async ({ project, flags }) => {
+    const format = flags.format as string
+    const withConfig = flags['with-config'] as boolean
+    const currentProjectSlug = project.slug
+    const projectSlugs = listProjects({ withConfig })
+
+    if (projectSlugs.length === 0) {
+      if (format === 'json') {
+        console.log(JSON.stringify([]))
+      } else {
+        console.log('No projects found.')
+      }
+      return { success: true, message: 'No projects found.' }
+    }
+
+    // Pre-fetch launchctl list once to avoid N shell calls
+    const launchctlList = await launchctl.list('denvig.')
+
+    const projects: ProjectWithStatus[] = []
+
+    for (const slug of projectSlugs) {
+      const proj = new DenvigProject(slug)
+      const hasConfig = proj.config.$sources.length > 0
+
+      // Extract config without internal $sources property
+      const { $sources: _, ...configWithoutSources } = proj.config
+
+      // Determine service status
+      let serviceStatus: 'running' | 'stopped' | 'none' = 'none'
+      const services = proj.config.services || {}
+      const serviceNames = Object.keys(services)
+
+      if (serviceNames.length > 0) {
+        // Check if any service is running
+        const manager = new ServiceManager(proj)
+        let hasRunningService = false
+
+        for (const serviceName of serviceNames) {
+          const response = await manager.getServiceResponse(serviceName, {
+            launchctlList,
+          })
+          if (response?.status === 'running') {
+            hasRunningService = true
+            break
+          }
+        }
+
+        serviceStatus = hasRunningService ? 'running' : 'stopped'
+      }
+
+      projects.push({
+        slug,
+        name: proj.name,
+        path: proj.path,
+        config: hasConfig ? configWithoutSources : null,
+        serviceStatus,
+      })
+    }
+
+    // Sort: current project first, then alphabetically by slug
+    const sortedProjects = projects.sort((a, b) => {
+      const aIsCurrent = a.slug === currentProjectSlug
+      const bIsCurrent = b.slug === currentProjectSlug
+
+      if (aIsCurrent && !bIsCurrent) return -1
+      if (!aIsCurrent && bIsCurrent) return 1
+
+      return a.slug.localeCompare(b.slug)
+    })
+
+    // JSON output
+    if (format === 'json') {
+      console.log(JSON.stringify(sortedProjects))
+      return { success: true, message: 'Projects listed successfully.' }
+    }
+
+    const lines = formatTable({
+      columns: [
+        { header: '', accessor: (p) => getStatusIcon(p.serviceStatus) },
+        { header: 'Name', accessor: (p) => p.config?.name || p.slug },
+        { header: 'Path', accessor: (p) => prettyPath(p.path) },
+      ],
+      data: sortedProjects,
+    })
+
+    for (const line of lines) {
+      console.log(line)
+    }
+
+    console.log('')
+    console.log(
+      `${projects.length} project${projects.length === 1 ? '' : 's'} found`,
+    )
+
+    return { success: true, message: 'Projects listed successfully.' }
+  },
+})

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -2,16 +2,23 @@ import fs from 'node:fs'
 
 import { getGlobalConfig } from './config.ts'
 
+export type ListProjectsOptions = {
+  /** Only include projects with a .denvig.yml configuration file */
+  withConfig?: boolean
+}
+
 /**
- * List all projects that have a .denvig.yml configuration file.
+ * List all projects in the codeRootDir.
  * Projects are detected at [codeRootDir]/[workspace]/[repo].
  *
+ * @param options - Optional filters for project listing
  * @returns Array of project slugs in the format "workspace/repo"
  */
-export const listProjects = (): string[] => {
+export const listProjects = (options?: ListProjectsOptions): string[] => {
   const globalConfig = getGlobalConfig()
   const codeRootDir = globalConfig.codeRootDir
   const projects: string[] = []
+  const withConfig = options?.withConfig ?? false
 
   // Check if codeRootDir exists
   if (!fs.existsSync(codeRootDir)) {
@@ -35,12 +42,15 @@ export const listProjects = (): string[] => {
       if (repo.name.startsWith('.')) continue
 
       const repoPath = `${workspacePath}/${repo.name}`
-      const configPath = `${repoPath}/.denvig.yml`
 
-      // Only include projects with a .denvig.yml file
-      if (fs.existsSync(configPath)) {
-        projects.push(`${workspace.name}/${repo.name}`)
+      if (withConfig) {
+        const configPath = `${repoPath}/.denvig.yml`
+        if (!fs.existsSync(configPath)) {
+          continue
+        }
       }
+
+      projects.push(`${workspace.name}/${repo.name}`)
     }
   }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,6 +1,7 @@
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 
+export type { ProjectConfigSchema } from './schemas/config.ts'
 /**
  * Re-exported types from shared types file.
  * These are the single source of truth for CLI JSON responses.
@@ -10,6 +11,7 @@ export type {
   Dependency,
   DependencyVersion,
   OutdatedDependency,
+  ProjectResponse,
   ServiceInfo,
   ServiceResponse,
   ServiceResult,
@@ -19,6 +21,7 @@ export type {
 import type {
   Dependency,
   OutdatedDependency,
+  ProjectResponse,
   ServiceResponse,
 } from './types/responses.ts'
 
@@ -88,6 +91,11 @@ export type DepsOutdatedOptions = {
   semver?: 'patch' | 'minor'
   /** Filter to a specific ecosystem (e.g., npm, rubygems, pypi) */
   ecosystem?: string
+}
+
+export type ProjectsListOptions = {
+  /** Only include projects with a .denvig.yml configuration file */
+  withConfig?: boolean
 }
 
 /**
@@ -311,6 +319,19 @@ export class DenvigSDK {
     ): Promise<OutdatedDependency[]> => {
       const flags = options ? this.buildFlags(options) : ''
       return this.run<OutdatedDependency[]>(`deps outdated ${flags}`.trim())
+    },
+  }
+
+  /**
+   * Project management commands.
+   */
+  projects = {
+    /**
+     * List all projects on the system.
+     */
+    list: async (options?: ProjectsListOptions): Promise<ProjectResponse[]> => {
+      const flags = options ? this.buildFlags(options) : ''
+      return this.run<ProjectResponse[]>(`projects list ${flags}`.trim())
     },
   }
 }

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -4,6 +4,8 @@
  * @module
  */
 
+import type { ProjectConfigSchema } from '../schemas/config.ts'
+
 /**
  * Service information for display.
  */
@@ -89,4 +91,14 @@ export type OutdatedDependency = Dependency & {
   latest: string
   specifier: string
   isDevDependency: boolean
+}
+
+/**
+ * A project from projects:list command.
+ */
+export type ProjectResponse = {
+  slug: string
+  name: string
+  path: string
+  config: ProjectConfigSchema | null
 }


### PR DESCRIPTION
## Summary

- Adds `projects` and `projects list` commands to list all projects on the system
- Table output shows service status indicator (🟢 running, ◯ stopped, empty = no services)
- Displays project name from config (or slug if no name configured) and path with `~` for home directory
- Supports `--format json` for programmatic access and `--with-config` to filter to configured projects only
- Pre-fetches launchctl status upfront for performance optimization
- Adds `ProjectResponse` type and SDK `projects.list()` method for programmatic access

## Test plan

- [x] Run `pnpm run test` - all tests pass
- [x] Run `bin/denvig-dev version` - CLI works
- [x] Run `bin/denvig-dev projects` - table displays correctly with status, name, and path columns