### PR TITLE
Remove debug logging from zsh completions

### DIFF
--- a/src/commands/zsh/__complete__.ts
+++ b/src/commands/zsh/__complete__.ts
@@ -1,6 +1,3 @@
-import * as fs from 'node:fs'
-import * as path from 'node:path'
-
 import { Command } from '../../lib/command.ts'
 import { getCommands } from '../../lib/zsh/commands.ts'
 import { zshCompletionsFor } from '../../lib/zsh/completions.ts'
@@ -21,20 +18,6 @@ export const zshCompleteCommand = new Command({
 
     // Get completions
     const completions = await zshCompletionsFor(words, { project, commands })
-
-    // Log to debug file
-    const logDir = path.join(process.cwd(), 'logs')
-    const logFile = path.join(logDir, 'zsh-completions-debug.txt')
-
-    // Ensure logs directory exists
-    if (!fs.existsSync(logDir)) {
-      fs.mkdirSync(logDir, { recursive: true })
-    }
-
-    // Append debug info
-    const timestamp = new Date().toISOString()
-    const debugLine = `[${timestamp}] words: ${JSON.stringify(words)} -> completions: ${JSON.stringify(completions)}\n`
-    fs.appendFileSync(logFile, debugLine)
 
     // Output completions for zsh (one per line)
     // Escape colons as they are used as delimiters in zsh completions


### PR DESCRIPTION
## Summary

- Remove file-based debug logging from the zsh `__complete__` command
- The debug logs were being written to `logs/zsh-completions-debug.txt` in the current working directory, which polluted the user's workspace
- A proper debug system will be added later

## Test plan

- [x] All tests pass
- [x] CLI still works (`bin/denvig-dev version`)
- [x] Verify zsh completions work without creating log files