### PR TITLE
Fix services restarting after reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - `--format` flag is now a global flag instead of being defined on each command
 
+### Fixed
+
+- Fixed services restarting after reboot by removing plist file when stopping a service
+
 
 ## [v0.4.2] - 2026-01-17
 

--- a/src/lib/services/manager.ts
+++ b/src/lib/services/manager.ts
@@ -212,6 +212,13 @@ export class ServiceManager {
       }
     }
 
+    // Remove plist file so service doesn't restart on reboot
+    try {
+      await unlink(this.getPlistPath(name))
+    } catch {
+      // Ignore errors removing plist file (may not exist)
+    }
+
     // Append Service Stopped entry to stdout log
     try {
       const timestamp = new Date().toISOString()


### PR DESCRIPTION
## Summary

- Remove plist file from `~/Library/LaunchAgents` when stopping a service
- Previously, the plist file was left behind after `launchctl bootout`, causing macOS to reload and restart the service on reboot (due to `KeepAlive: true` default)
- Aligns `stopService` behavior with `teardownAll` which already removes plist files

## Test plan

- [x] Run `denvig services start <name>` to start a service
- [x] Run `denvig services stop <name>` to stop it
- [x] Verify plist file is removed from `~/Library/LaunchAgents`
- [x] Reboot machine and verify service stays stopped