### PR TITLE
Suppress config validation warnings to fix JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Fixed services restarting after reboot by removing plist file when stopping a service
+- Suppressed config validation warnings to prevent polluting JSON output when using `--format=json`
 
 
 ## [v0.4.2] - 2026-01-17

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -1,7 +1,11 @@
 import { match, strictEqual } from 'node:assert'
+import { dirname, resolve } from 'node:path'
 import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 import { runTestCommand } from '../test/utils/runTestCommand.ts'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 describe('commands / config', () => {
   it('should return the global and project config without errors', async () => {
@@ -11,5 +15,33 @@ describe('commands / config', () => {
     match(result.stdout, /Global:/)
     match(result.stdout, /Project:/)
     strictEqual(result.stderr, '')
+  })
+
+  it('should not output config warnings when using --format=json with invalid config', async () => {
+    const testExamplesDir = resolve(__dirname, '../test/examples')
+    const invalidConfigDir = resolve(testExamplesDir, 'invalid-config')
+
+    const result = await runTestCommand('denvig version --format=json', {
+      cwd: invalidConfigDir,
+      env: {
+        DENVIG_CODE_ROOT_DIR: testExamplesDir,
+      },
+    })
+
+    strictEqual(result.code, 0)
+    strictEqual(
+      result.stderr,
+      '',
+      'stderr should be empty (no config warnings)',
+    )
+
+    // Verify the output is valid JSON
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(result.stdout)
+    } catch {
+      throw new Error(`stdout is not valid JSON: ${result.stdout}`)
+    }
+    strictEqual(typeof parsed, 'object', 'JSON output should be an object')
   })
 })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -84,15 +84,9 @@ export const getProjectConfig = (
         ...ProjectConfigSchema.parse(parse(configRaw)),
         $sources: [configPath],
       }
-    } catch (e: unknown) {
-      console.warn(
-        `Error parsing project config for ${projectSlug} at ${configPath}.`,
-      )
-      if (e instanceof Error) {
-        console.warn(e.message)
-      } else {
-        console.warn('Unknown error:', e)
-      }
+    } catch {
+      // Silently ignore config parsing errors here.
+      // Users can run `denvig config verify` to diagnose config issues.
     }
   }
   return {

--- a/src/test/examples/invalid-config/.denvig.yml
+++ b/src/test/examples/invalid-config/.denvig.yml
@@ -1,0 +1,5 @@
+name: invalid-config-example
+invalidProperty: this-should-not-be-recognized
+actions:
+  test:
+    command: echo "test"


### PR DESCRIPTION
## Summary

- Remove `console.warn` calls from `getProjectConfig()` that were polluting stdout/stderr when a project had an invalid config file
- This was breaking JSON parsing when using `--format=json` flags since warnings would appear before the JSON output
- Users can still diagnose config issues using `denvig config verify`

## Test plan

- [x] Added test example with invalid config property (`src/test/examples/invalid-config/.denvig.yml`)
- [x] Added test to verify JSON output is clean with invalid configs
- [x] All existing tests pass (288/288)
- [x] Verified `denvig config verify` still correctly detects and reports invalid config properties