### PR TITLE
Fix deps subcommands displaying with colons in help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fixed services restarting after reboot by removing plist file when stopping a service
 - Suppressed config validation warnings to prevent polluting JSON output when using `--format=json`
+- Fixed `deps` subcommands displaying with colons instead of spaces in help output (e.g., `deps:list` → `deps list`)
 
 
 ## [v0.4.2] - 2026-01-17

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -248,6 +248,8 @@ async function main() {
     console.log('Available commands:')
     Object.keys(commands).forEach((cmd) => {
       if (cmd.startsWith('internals:') || cmd === 'zsh:__complete__') return
+      // Skip alias entries that duplicate another command
+      if (cmd === 'deps' || cmd === 'projects') return
       console.log(
         `  - ${commands[cmd].usage.padEnd(padLength, ' ')} ${commands[cmd].description}`,
       )

--- a/src/commands/deps/list.ts
+++ b/src/commands/deps/list.ts
@@ -5,8 +5,8 @@ import { COLORS, formatTable } from '../../lib/formatters/table.ts'
 export const depsListCommand = new Command({
   name: 'deps:list',
   description: 'List all dependencies detected by plugins',
-  usage: 'deps:list [--depth <n>] [--ecosystem <name>]',
-  example: 'denvig deps:list --depth 1',
+  usage: 'deps list [--depth <n>] [--ecosystem <name>]',
+  example: 'denvig deps list --depth 1',
   args: [],
   flags: [
     {

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -26,8 +26,8 @@ export const depsOutdatedCommand = new Command({
   name: 'deps:outdated',
   description: 'Show outdated dependencies',
   usage:
-    'deps:outdated [--no-cache] [--semver patch|minor] [--ecosystem <name>]',
-  example: 'denvig deps:outdated --semver patch',
+    'deps outdated [--no-cache] [--semver patch|minor] [--ecosystem <name>]',
+  example: 'denvig deps outdated --semver patch',
   args: [],
   flags: [
     {

--- a/src/commands/deps/why.ts
+++ b/src/commands/deps/why.ts
@@ -14,8 +14,8 @@ import type { ProjectDependencySchema } from '../../lib/dependencies.ts'
 export const depsWhyCommand = new Command({
   name: 'deps:why',
   description: 'Show why a dependency is installed',
-  usage: 'deps:why <dependency>',
-  example: 'denvig deps:why yaml',
+  usage: 'deps why <dependency>',
+  example: 'denvig deps why yaml',
   args: [
     {
       name: 'dependency',


### PR DESCRIPTION
## Summary

- Changed the `usage` strings for `deps` subcommands to use spaces instead of colons (e.g., `deps:list` → `deps list`) to be consistent with other subcommands like `services start`
- Filtered out duplicate alias entries (`deps` and `projects`) from the help output
- Updated example commands to match the new format

## Test plan

- [x] Run `denvig` (no args) and verify `deps list`, `deps outdated`, and `deps why` display with spaces
- [x] Verify no duplicate entries appear in help output
- [x] Run `pnpm run test` - all tests pass
- [x] Run `bin/denvig-dev version` - CLI works correctly