### PR TITLE
Fix deps why not displaying full dependency chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - `deps why` now correctly resolves dependency chains through scoped packages (e.g. `@serverless/dashboard-plugin`)
 - `deps why` now shows transitive chains for packages that are also direct dependencies
+- `deps why` now resolves pnpm aliased dependencies (e.g. `wrap-ansi-cjs: wrap-ansi@7.0.0`) to their real package name
 
 ## [0.6.2] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - `deps why` now correctly resolves dependency chains through scoped packages (e.g. `@serverless/dashboard-plugin`)
+- `deps why` now shows transitive chains for packages that are also direct dependencies
 
 ## [0.6.2] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Denvig Changelog
 
 
+## [Unreleased]
+
+### Fixed
+
+- `deps why` now correctly resolves dependency chains through scoped packages (e.g. `@serverless/dashboard-plugin`)
+
 ## [0.6.2] - 2026-04-03
 
 ### Added

--- a/src/lib/deps/tree.test.ts
+++ b/src/lib/deps/tree.test.ts
@@ -1,7 +1,9 @@
 import { deepStrictEqual, strictEqual } from 'node:assert'
 import { describe, it } from 'node:test'
 
-import { parseParentFromSource } from './tree.ts'
+import { buildReverseChain, parseParentFromSource } from './tree.ts'
+
+import type { ProjectDependencySchema } from '../dependencies.ts'
 
 describe('parseParentFromSource()', () => {
   it('should return null for non-lockfile sources', () => {
@@ -58,6 +60,186 @@ describe('parseParentFromSource()', () => {
     deepStrictEqual(parseParentFromSource('uv.lock:requests@2.31.0'), {
       name: 'requests',
       version: '2.31.0',
+    })
+  })
+})
+
+describe('buildReverseChain()', () => {
+  const makeDep = (
+    name: string,
+    versions: { resolved: string; source: string }[],
+  ): ProjectDependencySchema => ({
+    id: `npm:${name}`,
+    name,
+    ecosystem: 'npm',
+    versions: versions.map((v) => ({ ...v, specifier: v.resolved })),
+  })
+
+  it('should return single node for direct dependencies', () => {
+    const depsMap = new Map<string, ProjectDependencySchema>()
+    depsMap.set(
+      'react',
+      makeDep('react', [{ resolved: '19.0.0', source: '.#dependencies' }]),
+    )
+
+    const result = buildReverseChain(
+      'react',
+      '19.0.0',
+      '.#dependencies',
+      depsMap,
+    )
+    deepStrictEqual(result, {
+      name: 'react',
+      version: '19.0.0',
+      children: [],
+    })
+  })
+
+  it('should build chain through unscoped transitive dependencies', () => {
+    const depsMap = new Map<string, ProjectDependencySchema>()
+    depsMap.set(
+      'serverless',
+      makeDep('serverless', [{ resolved: '3.38.0', source: '.#dependencies' }]),
+    )
+    depsMap.set(
+      'simple-git',
+      makeDep('simple-git', [
+        { resolved: '3.30.0', source: 'pnpm-lock.yaml:serverless@3.38.0' },
+      ]),
+    )
+
+    const result = buildReverseChain(
+      'simple-git',
+      '3.30.0',
+      'pnpm-lock.yaml:serverless@3.38.0',
+      depsMap,
+    )
+    deepStrictEqual(result, {
+      name: 'serverless',
+      version: '3.38.0',
+      children: [
+        {
+          name: 'simple-git',
+          version: '3.30.0',
+          children: [],
+        },
+      ],
+    })
+  })
+
+  it('should build chain through scoped transitive dependencies', () => {
+    const depsMap = new Map<string, ProjectDependencySchema>()
+    depsMap.set(
+      'serverless',
+      makeDep('serverless', [{ resolved: '3.38.0', source: '.#dependencies' }]),
+    )
+    depsMap.set(
+      '@serverless/dashboard-plugin',
+      makeDep('@serverless/dashboard-plugin', [
+        { resolved: '7.2.3', source: 'pnpm-lock.yaml:serverless@3.38.0' },
+      ]),
+    )
+    depsMap.set(
+      'simple-git',
+      makeDep('simple-git', [
+        {
+          resolved: '3.30.0',
+          source: 'pnpm-lock.yaml:@serverless/dashboard-plugin@7.2.3',
+        },
+      ]),
+    )
+
+    const result = buildReverseChain(
+      'simple-git',
+      '3.30.0',
+      'pnpm-lock.yaml:@serverless/dashboard-plugin@7.2.3',
+      depsMap,
+    )
+    deepStrictEqual(result, {
+      name: 'serverless',
+      version: '3.38.0',
+      children: [
+        {
+          name: '@serverless/dashboard-plugin',
+          version: '7.2.3',
+          children: [
+            {
+              name: 'simple-git',
+              version: '3.30.0',
+              children: [],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('should build chain through scoped dependencies with peer qualifiers', () => {
+    const depsMap = new Map<string, ProjectDependencySchema>()
+    depsMap.set(
+      'serverless',
+      makeDep('serverless', [{ resolved: '3.38.0', source: '.#dependencies' }]),
+    )
+    depsMap.set(
+      '@serverless/dashboard-plugin',
+      makeDep('@serverless/dashboard-plugin', [
+        { resolved: '7.2.3', source: 'pnpm-lock.yaml:serverless@3.38.0' },
+      ]),
+    )
+    depsMap.set(
+      'axios',
+      makeDep('axios', [
+        {
+          resolved: '1.13.2',
+          source:
+            'pnpm-lock.yaml:@serverless/dashboard-plugin@7.2.3(serverless@3.38.0)',
+        },
+      ]),
+    )
+
+    const result = buildReverseChain(
+      'axios',
+      '1.13.2',
+      'pnpm-lock.yaml:@serverless/dashboard-plugin@7.2.3(serverless@3.38.0)',
+      depsMap,
+    )
+    deepStrictEqual(result, {
+      name: 'serverless',
+      version: '3.38.0',
+      children: [
+        {
+          name: '@serverless/dashboard-plugin',
+          version: '7.2.3',
+          children: [
+            {
+              name: 'axios',
+              version: '1.13.2',
+              children: [],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('should return null when chain is empty', () => {
+    const depsMap = new Map<string, ProjectDependencySchema>()
+    const result = buildReverseChain(
+      'unknown',
+      '1.0.0',
+      'pnpm-lock.yaml:missing@1.0.0',
+      depsMap,
+    )
+    deepStrictEqual(result, {
+      name: 'missing',
+      version: '1.0.0',
+      children: [
+        {
+          name: 'unknown',
+          version: '1.0.0',
+          children: [],
+        },
+      ],
     })
   })
 })

--- a/src/lib/deps/tree.test.ts
+++ b/src/lib/deps/tree.test.ts
@@ -1,0 +1,63 @@
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { parseParentFromSource } from './tree.ts'
+
+describe('parseParentFromSource()', () => {
+  it('should return null for non-lockfile sources', () => {
+    strictEqual(parseParentFromSource('.#dependencies'), null)
+    strictEqual(parseParentFromSource('.#devDependencies'), null)
+    strictEqual(parseParentFromSource('packages/app#dependencies'), null)
+  })
+
+  it('should parse unscoped pnpm lockfile sources', () => {
+    deepStrictEqual(parseParentFromSource('pnpm-lock.yaml:tsup@8.5.0'), {
+      name: 'tsup',
+      version: '8.5.0',
+    })
+  })
+
+  it('should parse scoped pnpm lockfile sources', () => {
+    deepStrictEqual(
+      parseParentFromSource(
+        'pnpm-lock.yaml:@serverless/dashboard-plugin@7.2.3',
+      ),
+      { name: '@serverless/dashboard-plugin', version: '7.2.3' },
+    )
+  })
+
+  it('should parse sources with peer dependency qualifiers', () => {
+    deepStrictEqual(
+      parseParentFromSource('pnpm-lock.yaml:tsup@8.5.0(typescript@5.9.3)'),
+      { name: 'tsup', version: '8.5.0' },
+    )
+    deepStrictEqual(
+      parseParentFromSource(
+        'pnpm-lock.yaml:@serverless/dashboard-plugin@7.2.3(serverless@3.38.0)',
+      ),
+      { name: '@serverless/dashboard-plugin', version: '7.2.3' },
+    )
+  })
+
+  it('should parse yarn lockfile sources', () => {
+    deepStrictEqual(parseParentFromSource('yarn.lock:webpack@5.90.0'), {
+      name: 'webpack',
+      version: '5.90.0',
+    })
+    deepStrictEqual(parseParentFromSource('yarn.lock:@babel/core@7.24.0'), {
+      name: '@babel/core',
+      version: '7.24.0',
+    })
+  })
+
+  it('should parse other lockfile sources', () => {
+    deepStrictEqual(parseParentFromSource('Gemfile.lock:rails@7.1.0'), {
+      name: 'rails',
+      version: '7.1.0',
+    })
+    deepStrictEqual(parseParentFromSource('uv.lock:requests@2.31.0'), {
+      name: 'requests',
+      version: '2.31.0',
+    })
+  })
+})

--- a/src/lib/deps/tree.ts
+++ b/src/lib/deps/tree.ts
@@ -41,8 +41,8 @@ export const parseParentFromSource = (
   for (const prefix of LOCKFILE_PREFIXES) {
     if (source.startsWith(prefix)) {
       const ref = source.slice(prefix.length)
-      // Parse "package@version" or "package@version(peer@1.0.0)"
-      const match = ref.match(/^([^@]+)@([^(@]+)/)
+      // Parse "package@version", "@scope/package@version", or with peer deps
+      const match = ref.match(/^((?:@[^@/]+\/)?[^@]+)@([^(@]+)/)
       if (match) {
         return { name: match[1], version: match[2] }
       }

--- a/src/plugins/pnpm.test.ts
+++ b/src/plugins/pnpm.test.ts
@@ -141,6 +141,32 @@ describe('pnpm plugin', () => {
       )
     })
 
+    it('should include transitive entries for dependencies that are also direct', async () => {
+      const project = createMockProjectFromPath(turborepoExamplePath)
+      ok(pnpmPlugin.dependencies, 'dependencies function should exist')
+      const deps = await pnpmPlugin.dependencies(project)
+
+      // minimist is both a direct dependency (package3) and transitive (via denvig@0.3.0)
+      const minimistDep = deps.find((d) => d.name === 'minimist')
+      ok(minimistDep, 'minimist should be detected')
+      strictEqual(minimistDep.ecosystem, 'npm')
+
+      const directVersion = minimistDep.versions.find(
+        (v) => v.source === 'packages/package3#dependencies',
+      )
+      ok(directVersion, 'should have direct dependency entry from package3')
+      strictEqual(directVersion.resolved, '1.2.8')
+
+      const transitiveVersion = minimistDep.versions.find(
+        (v) => v.source === 'pnpm-lock.yaml:denvig@0.3.0',
+      )
+      ok(
+        transitiveVersion,
+        'should have transitive dependency entry via denvig',
+      )
+      strictEqual(transitiveVersion.resolved, '1.2.8')
+    })
+
     it('should return all expected dependencies from turborepo example', async () => {
       const project = createMockProjectFromPath(turborepoExamplePath)
       ok(pnpmPlugin.dependencies, 'dependencies function should exist')

--- a/src/plugins/pnpm.test.ts
+++ b/src/plugins/pnpm.test.ts
@@ -167,6 +167,31 @@ describe('pnpm plugin', () => {
       strictEqual(transitiveVersion.resolved, '1.2.8')
     })
 
+    it('should resolve aliased dependencies to their real package name', async () => {
+      const project = createMockProjectFromPath(turborepoExamplePath)
+      ok(pnpmPlugin.dependencies, 'dependencies function should exist')
+      const deps = await pnpmPlugin.dependencies(project)
+
+      // minimist-cjs: minimist@1.2.8 in lockfile should resolve to minimist, not minimist-cjs
+      const minimistCjsDep = deps.find((d) => d.name === 'minimist-cjs')
+      strictEqual(
+        minimistCjsDep,
+        undefined,
+        'minimist-cjs should not exist as a separate dep',
+      )
+
+      const minimistDep = deps.find((d) => d.name === 'minimist')
+      ok(minimistDep, 'minimist should exist')
+      const aliasVersion = minimistDep.versions.find(
+        (v) =>
+          v.source === 'pnpm-lock.yaml:denvig@0.3.0' && v.resolved === '1.2.8',
+      )
+      ok(
+        aliasVersion,
+        'aliased entry should be resolved under the real package name',
+      )
+    })
+
     it('should return all expected dependencies from turborepo example', async () => {
       const project = createMockProjectFromPath(turborepoExamplePath)
       ok(pnpmPlugin.dependencies, 'dependencies function should exist')

--- a/src/plugins/pnpm.ts
+++ b/src/plugins/pnpm.ts
@@ -93,8 +93,6 @@ const plugin = definePlugin({
     }
 
     const data: Map<string, ProjectDependencySchema> = new Map()
-    const directDependencies: Set<string> = new Set()
-
     // Helper to add a dependency version entry
     const addDependency = (
       id: string,
@@ -144,7 +142,6 @@ const plugin = definePlugin({
         if (importer.dependencies) {
           for (const [name, depInfo] of Object.entries(importer.dependencies)) {
             if (depInfo?.specifier && depInfo?.version) {
-              directDependencies.add(name)
               addDependency(
                 `npm:${name}`,
                 name,
@@ -163,7 +160,6 @@ const plugin = definePlugin({
             importer.devDependencies,
           )) {
             if (depInfo?.specifier && depInfo?.version) {
-              directDependencies.add(name)
               addDependency(
                 `npm:${name}`,
                 name,
@@ -187,18 +183,16 @@ const plugin = definePlugin({
           ...snapshot.dependencies,
         }
         for (const [depName, depVersion] of Object.entries(transitiveDeps)) {
-          if (!directDependencies.has(depName)) {
-            const cleanVersion = stripPeerDeps(depVersion)
-            const source = `pnpm-lock.yaml:${snapshotKey}`
-            addDependency(
-              `npm:${depName}`,
-              depName,
-              'npm',
-              cleanVersion,
-              source,
-              cleanVersion,
-            )
-          }
+          const cleanVersion = stripPeerDeps(depVersion)
+          const source = `pnpm-lock.yaml:${snapshotKey}`
+          addDependency(
+            `npm:${depName}`,
+            depName,
+            'npm',
+            cleanVersion,
+            source,
+            cleanVersion,
+          )
         }
       }
     }

--- a/src/plugins/pnpm.ts
+++ b/src/plugins/pnpm.ts
@@ -48,6 +48,24 @@ const stripPeerDeps = (version: string): string => {
   return parenIndex === -1 ? version : version.slice(0, parenIndex)
 }
 
+/**
+ * Resolve pnpm dependency aliases where the version field references another package.
+ * e.g., depName="wrap-ansi-cjs", depVersion="wrap-ansi@7.0.0" -> { name: "wrap-ansi", version: "7.0.0" }
+ * Returns null if not an alias.
+ */
+const resolveAlias = (
+  depVersion: string,
+): { name: string; version: string } | null => {
+  // Aliases look like "package@version" where it starts with a letter or @scope
+  // Normal versions start with a digit
+  if (/^\d/.test(depVersion)) return null
+  const match = depVersion.match(/^((?:@[^@/]+\/)?[^@]+)@(.+)$/)
+  if (match) {
+    return { name: match[1], version: match[2] }
+  }
+  return null
+}
+
 const plugin = definePlugin({
   name: 'pnpm',
 
@@ -183,11 +201,13 @@ const plugin = definePlugin({
           ...snapshot.dependencies,
         }
         for (const [depName, depVersion] of Object.entries(transitiveDeps)) {
-          const cleanVersion = stripPeerDeps(depVersion)
+          const alias = resolveAlias(depVersion)
+          const actualName = alias ? alias.name : depName
+          const cleanVersion = stripPeerDeps(alias ? alias.version : depVersion)
           const source = `pnpm-lock.yaml:${snapshotKey}`
           addDependency(
-            `npm:${depName}`,
-            depName,
+            `npm:${actualName}`,
+            actualName,
             'npm',
             cleanVersion,
             source,

--- a/src/test/examples/turborepo/packages/package3/package.json
+++ b/src/test/examples/turborepo/packages/package3/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "react": "^18"
+    "react": "^18",
+    "minimist": "^1.2.0"
   }
 }

--- a/src/test/examples/turborepo/pnpm-lock.yaml
+++ b/src/test/examples/turborepo/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   packages/package3:
     dependencies:
+      minimist:
+        specifier: ^1.2.0
+        version: 1.2.8
       react:
         specifier: ^18
         version: 18.3.1

--- a/src/test/examples/turborepo/pnpm-lock.yaml
+++ b/src/test/examples/turborepo/pnpm-lock.yaml
@@ -797,6 +797,7 @@ snapshots:
   denvig@0.3.0:
     dependencies:
       minimist: 1.2.8
+      minimist-cjs: minimist@1.2.8
       yaml: 2.8.2
       zod: 4.3.5
 


### PR DESCRIPTION
## Summary

- Fixed `parseParentFromSource` regex to handle scoped npm packages (e.g. `@serverless/dashboard-plugin`) — the previous regex `[^@]+` rejected the leading `@` in scoped names, breaking chain resolution
- Removed `directDependencies` filter in the pnpm plugin that was suppressing all transitive lockfile entries for packages that also appeared as direct dependencies, causing `deps why` to show flat entries instead of full chains
- Added `resolveAlias` to handle pnpm dependency aliases (e.g. `wrap-ansi-cjs: wrap-ansi@7.0.0`) where the version field is a package reference rather than a version string
- Added comprehensive tests for `buildReverseChain` and the pnpm plugin covering scoped packages, peer dependency qualifiers, direct + transitive scenarios, and aliased dependencies

## Test plan

- [x] `parseParentFromSource` tests cover unscoped, scoped, and peer-qualified lockfile sources
- [x] `buildReverseChain` tests verify chain resolution through scoped and unscoped transitive deps
- [x] pnpm plugin test verifies both direct and transitive entries are recorded for the same package
- [x] pnpm plugin test verifies aliased dependencies resolve to their real package name
- [x] Full test suite passes (542 tests)
- [x] Manually verified with `denvig deps why simple-git`, `denvig deps why form-data`, and `denvig deps why wrap-ansi`