### PR TITLE
Fix deps outdated --semver patch missing patches behind minor bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `deps outdated --semver patch` now detects patch updates even when a minor or major version is also available
 
 ## [0.6.3] - 2026-04-08
 

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -1,6 +1,9 @@
 import { Command } from '../../lib/command.ts'
 import { COLORS, formatTable } from '../../lib/formatters/table.ts'
-import { getSemverLevel, matchesSemverFilter } from '../../lib/semver.ts'
+import {
+  getSemverLevel,
+  outdatedMatchesSemverFilter,
+} from '../../lib/semver.ts'
 
 /**
  * Get the color for a version update based on semver difference.
@@ -83,12 +86,20 @@ export const depsOutdatedCommand = new Command({
       entries = entries.filter((dep) => dep.ecosystem === ecosystemFilter)
     }
 
-    // Filter by semver level if specified (compare against latest version)
+    // Filter by semver level if specified. We check both `wanted` and
+    // `latest` so that a patch-level update is still detected even when a
+    // higher minor/major version exists alongside it (see issue #154).
     if (semverFilter) {
-      entries = entries.filter((dep) => {
-        const level = getSemverLevel(getCurrent(dep), dep.latest)
-        return matchesSemverFilter(level, semverFilter)
-      })
+      entries = entries.filter((dep) =>
+        outdatedMatchesSemverFilter(
+          {
+            currentVersion: getCurrent(dep),
+            wantedVersion: dep.wanted,
+            latestVersion: dep.latest,
+          },
+          semverFilter,
+        ),
+      )
     }
 
     if (entries.length === 0) {

--- a/src/lib/semver.test.ts
+++ b/src/lib/semver.test.ts
@@ -5,6 +5,7 @@ import {
   filterDependenciesBySemver,
   getSemverLevel,
   matchesSemverFilter,
+  outdatedMatchesSemverFilter,
 } from './semver.ts'
 
 describe('getSemverLevel()', () => {
@@ -177,5 +178,49 @@ describe('filterDependenciesBySemver()', () => {
     ]
     const result = filterDependenciesBySemver(majorOnly, 'patch')
     deepStrictEqual(result, [])
+  })
+})
+
+describe('outdatedMatchesSemverFilter()', () => {
+  // Regression for https://github.com/marcqualie/denvig/issues/154
+  // esbuild has both a patch (0.27.7) and a minor (0.28.0) available; the
+  // patch filter must still include it because a patch update does exist.
+  const esbuild = {
+    currentVersion: '0.27.4',
+    wantedVersion: '0.27.7',
+    latestVersion: '0.28.0',
+  }
+
+  it('should include a dep with a patch in wanted when filter is "patch"', () => {
+    strictEqual(outdatedMatchesSemverFilter(esbuild, 'patch'), true)
+  })
+
+  it('should include a dep with a patch in wanted when filter is "minor"', () => {
+    strictEqual(outdatedMatchesSemverFilter(esbuild, 'minor'), true)
+  })
+
+  it('should exclude a dep with only a minor available when filter is "major"', () => {
+    strictEqual(outdatedMatchesSemverFilter(esbuild, 'major'), false)
+  })
+
+  it('should match based on latest when wanted equals current', () => {
+    const dep = {
+      currentVersion: '20.19.27',
+      wantedVersion: '20.19.27',
+      latestVersion: '25.0.8',
+    }
+    strictEqual(outdatedMatchesSemverFilter(dep, 'major'), true)
+    strictEqual(outdatedMatchesSemverFilter(dep, 'patch'), false)
+  })
+
+  it('should match a pure patch dep in both patch and minor filters', () => {
+    const dep = {
+      currentVersion: '19.2.1',
+      wantedVersion: '19.2.3',
+      latestVersion: '19.2.3',
+    }
+    strictEqual(outdatedMatchesSemverFilter(dep, 'patch'), true)
+    strictEqual(outdatedMatchesSemverFilter(dep, 'minor'), true)
+    strictEqual(outdatedMatchesSemverFilter(dep, 'major'), false)
   })
 })

--- a/src/lib/semver.ts
+++ b/src/lib/semver.ts
@@ -70,3 +70,28 @@ export const filterDependenciesBySemver = <T extends DependencyWithVersions>(
     return matchesSemverFilter(level, filter)
   })
 }
+
+export type OutdatedDependencyVersions = {
+  currentVersion: string
+  wantedVersion: string
+  latestVersion: string
+}
+
+/**
+ * Check if an outdated dependency matches a semver filter.
+ *
+ * A dependency matches when either `wanted` or `latest` represents an update
+ * at the requested level. This ensures a patch update (e.g., `0.27.7`) is
+ * still detected when a higher minor/major version (e.g., `0.28.0`) exists
+ * alongside it — previously the filter only compared against `latest`, so the
+ * patch would be hidden behind the minor bump.
+ */
+export const outdatedMatchesSemverFilter = (
+  dep: OutdatedDependencyVersions,
+  filter: SemverFilter,
+): boolean => {
+  const wantedLevel = getSemverLevel(dep.currentVersion, dep.wantedVersion)
+  if (matchesSemverFilter(wantedLevel, filter)) return true
+  const latestLevel = getSemverLevel(dep.currentVersion, dep.latestVersion)
+  return matchesSemverFilter(latestLevel, filter)
+}


### PR DESCRIPTION
## Summary

- The `deps outdated --semver patch` filter only compared `current → latest`, so a patch update was hidden whenever a higher minor or major version also existed. With install `esbuild 0.27.4`, latest patch `0.27.7`, latest minor `0.28.0`, the filter saw a `minor` diff and excluded the package entirely.
- Added `outdatedMatchesSemverFilter()` in `src/lib/semver.ts` that checks both `wanted` and `latest`, so a patch-level update is detected even when a minor/major version is also available.
- Wired the helper into `src/commands/deps/outdated.ts` and added regression tests in `src/lib/semver.test.ts` using the exact versions from the issue.

Fixes #154

## Test plan

- [x] `pnpm run check-types`
- [x] `pnpm run test` (547 pass)
- [x] `pnpm run codegen`
- [x] `pnpm run build`
- [x] `bin/denvig-dev version`
- [x] Manually verify against a real project: `denvig deps outdated --semver patch` lists patch updates that sit behind a minor/major bump