### PR TITLE
Fix GitHub slug detection for multi-remote projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- GitHub slug detection now checks the `github` remote as a fallback when `origin` is not a GitHub URL
+
 ## [0.6.4] - 2026-04-12
 
 ### Fixed

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -318,6 +318,85 @@ describe('getGitHubSlug()', () => {
     }
   })
 
+  it('should fall back to github remote when origin is non-GitHub', async () => {
+    const tempDir = createTempDir()
+    try {
+      createGitConfig(
+        tempDir,
+        `
+[remote "origin"]
+	url = git@gitea.example.com:owner/repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "github"]
+	url = https://github.com/owner/repo.git
+	fetch = +refs/heads/*:refs/remotes/github/*
+`,
+      )
+      const result = await getGitHubSlug(tempDir)
+      strictEqual(result, 'owner/repo')
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
+  })
+
+  it('should prefer origin over github remote when both are GitHub', async () => {
+    const tempDir = createTempDir()
+    try {
+      createGitConfig(
+        tempDir,
+        `
+[remote "origin"]
+	url = git@github.com:origin-owner/repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "github"]
+	url = git@github.com:github-owner/repo.git
+	fetch = +refs/heads/*:refs/remotes/github/*
+`,
+      )
+      const result = await getGitHubSlug(tempDir)
+      strictEqual(result, 'origin-owner/repo')
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
+  })
+
+  it('should use github remote when origin does not exist', async () => {
+    const tempDir = createTempDir()
+    try {
+      createGitConfig(
+        tempDir,
+        `
+[remote "github"]
+	url = git@github.com:owner/repo.git
+	fetch = +refs/heads/*:refs/remotes/github/*
+`,
+      )
+      const result = await getGitHubSlug(tempDir)
+      strictEqual(result, 'owner/repo')
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
+  })
+
+  it('should return null when neither origin nor github remote has GitHub URL', async () => {
+    const tempDir = createTempDir()
+    try {
+      createGitConfig(
+        tempDir,
+        `
+[remote "origin"]
+	url = git@gitea.example.com:owner/repo.git
+[remote "github"]
+	url = git@gitlab.com:owner/repo.git
+`,
+      )
+      const result = await getGitHubSlug(tempDir)
+      strictEqual(result, null)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
+  })
+
   it('should return null for non-existent directory', async () => {
     const result = await getGitHubSlug('/non/existent/path/that/does/not/exist')
     strictEqual(result, null)
@@ -376,6 +455,25 @@ describe('getProjectSlug()', () => {
       const result = await getProjectSlug(tempDir)
       ok(result.startsWith('local:'))
       ok(result.includes(tempDir))
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
+  })
+
+  it('should return github: slug via github remote fallback', async () => {
+    const tempDir = createTempDir()
+    try {
+      createGitConfig(
+        tempDir,
+        `
+[remote "origin"]
+	url = git@gitea.example.com:owner/repo.git
+[remote "github"]
+	url = git@github.com:owner/repo.git
+`,
+      )
+      const result = await getProjectSlug(tempDir)
+      strictEqual(result, 'github:owner/repo')
     } finally {
       fs.rmSync(tempDir, { recursive: true })
     }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -42,15 +42,16 @@ export const getGitHubSlug = async (
   try {
     const gitConfig = await readFile(gitConfigPath, 'utf-8')
 
-    // Parse git config to find remotes
-    // Look for [remote "origin"] section and its url
-    const remoteOriginMatch = gitConfig.match(
-      /\[remote "origin"\][^[]*url\s*=\s*([^\s\n]+)/,
-    )
+    // Check remotes in priority order: origin first, then github
+    for (const remoteName of ['origin', 'github']) {
+      const remoteMatch = gitConfig.match(
+        new RegExp(`\\[remote "${remoteName}"\\][^[]*url\\s*=\\s*([^\\s\\n]+)`),
+      )
 
-    if (remoteOriginMatch) {
-      const remoteUrl = remoteOriginMatch[1]
-      return parseGitHubRemoteUrl(remoteUrl)
+      if (remoteMatch) {
+        const slug = parseGitHubRemoteUrl(remoteMatch[1])
+        if (slug) return slug
+      }
     }
 
     return null


### PR DESCRIPTION
## Summary

- When a project's `origin` remote points to a non-GitHub provider (e.g. Gitea, GitLab), the GitHub slug detection now falls back to checking a `github` remote
- Remotes are checked in priority order: `origin` first, then `github` — so existing projects with GitHub as origin are unaffected
- Projects like `synthelica` (origin on Gitea, mirror on GitHub) now correctly resolve as `github:owner/repo` instead of `local:/path`

## Test plan

- [x] All 552 existing tests pass
- [x] 5 new test cases cover: fallback to github remote, origin priority, github-only remote, neither remote being GitHub, and `getProjectSlug` integration
- [x] Verified `denvig info --project ~/src/marcqualie/synthelica` shows `github:marcqualie/synthelica`
- [x] Verified `bin/denvig-dev version` works correctly