### PR TITLE
Fix all lint warnings and promote noNonNullAssertion to error

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "noNonNullAssertion": "error"
+      }
     }
   },
   "javascript": {

--- a/src/commands/gateway/status.ts
+++ b/src/commands/gateway/status.ts
@@ -145,10 +145,11 @@ export const gatewayStatusCommand = new Command({
     console.log('')
 
     for (const [name, config] of gatewayServices) {
-      const domain = config.http!.domain!
-      const cnames = config.http!.cnames || []
+      const domain = config.http?.domain
+      if (!domain) continue
+      const cnames = config.http?.cnames || []
       const allDomains = [domain, ...cnames]
-      const secure = config.http!.secure ?? false
+      const secure = config.http?.secure ?? false
 
       const certDir = secure ? await findCertForDomain(domain) : null
       const sslPaths = certDir ? await resolveSslPaths(certDir) : null
@@ -165,7 +166,7 @@ export const gatewayStatusCommand = new Command({
 
       console.log(`  ${name}:`)
       console.log(`    Domains: ${allDomains.join(', ')}`)
-      console.log(`    Port:    ${config.http!.port || '(not set)'}`)
+      console.log(`    Port:    ${config.http?.port || '(not set)'}`)
       console.log(`    Certs:   ${certStatus} ${certLabel}`)
       console.log(
         `    Nginx:   ${nginxStatus} ${nginxExists ? 'configured' : 'not generated'}`,

--- a/src/lib/gateway/certs.ts
+++ b/src/lib/gateway/certs.ts
@@ -3,7 +3,6 @@ import { resolve } from 'node:path'
 
 import {
   generateDomainCert,
-  getCertDir,
   getCertsDir,
   isCaInitialized,
   loadCaCert,
@@ -91,7 +90,7 @@ export function groupDomainsForCertGeneration(
     if (!parentMap.has(parent)) {
       parentMap.set(parent, [])
     }
-    parentMap.get(parent)!.push(domain)
+    parentMap.get(parent)?.push(domain)
   }
 
   const result = new Map<string, string[]>()

--- a/src/schemas/config.test.ts
+++ b/src/schemas/config.test.ts
@@ -60,8 +60,8 @@ describe('GlobalConfigSchema', () => {
     ok(result.success)
     if (result.success) {
       ok(result.data.services)
-      ok(result.data.services!.redis)
-      ok(result.data.services!.postgres)
+      ok(result.data.services?.redis)
+      ok(result.data.services?.postgres)
     }
   })
 


### PR DESCRIPTION
## Summary

- Replace all non-null assertions (`!`) with optional chaining (`?.`) across 3 files (`gateway/status.ts`, `gateway/certs.ts`, `config.test.ts`)
- Remove unused `getCertDir` import from `src/lib/gateway/certs.ts`
- Promote `noNonNullAssertion` biome lint rule from warning to error to prevent future usage

## Test plan

- [x] `pnpm run lint` passes with 0 warnings
- [x] `pnpm run test` passes with all tests green