### PR TITLE
Show release age in deps outdated output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `deps outdated` now shows how long ago the wanted and latest versions were released (e.g. `1.2.3 (3d)`)
+
 ### Fixed
 
 - GitHub slug detection now checks the `github` remote as a fallback when `origin` is not a GitHub URL

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -1,4 +1,5 @@
 import { Command } from '../../lib/command.ts'
+import { relativeFormattedTime } from '../../lib/formatters/relative-time.ts'
 import { COLORS, formatTable } from '../../lib/formatters/table.ts'
 import {
   getSemverLevel,
@@ -159,7 +160,12 @@ export const depsOutdatedCommand = new Command({
         { header: 'Current', accessor: (dep) => getCurrent(dep) },
         {
           header: 'Wanted',
-          accessor: (dep) => dep.wanted,
+          accessor: (dep) => {
+            if (dep.wantedDate) {
+              return `${dep.wanted} (${relativeFormattedTime(dep.wantedDate)})`
+            }
+            return dep.wanted
+          },
           format: (value, dep) => {
             const color = getVersionColor(getCurrent(dep), dep.wanted)
             return `${color}${value}${COLORS.reset}`
@@ -167,7 +173,12 @@ export const depsOutdatedCommand = new Command({
         },
         {
           header: 'Latest',
-          accessor: (dep) => dep.latest,
+          accessor: (dep) => {
+            if (dep.latestDate) {
+              return `${dep.latest} (${relativeFormattedTime(dep.latestDate)})`
+            }
+            return dep.latest
+          },
           format: (value, dep) => {
             const color = getVersionColor(getCurrent(dep), dep.latest)
             return `${color}${value}${COLORS.reset}`

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -168,6 +168,10 @@ export const depsOutdatedCommand = new Command({
           },
           format: (value, dep) => {
             const color = getVersionColor(getCurrent(dep), dep.wanted)
+            if (dep.wantedDate) {
+              const age = `(${relativeFormattedTime(dep.wantedDate)})`
+              return `${color}${dep.wanted}${COLORS.reset} ${COLORS.grey}${age}${COLORS.reset}`
+            }
             return `${color}${value}${COLORS.reset}`
           },
         },
@@ -181,6 +185,10 @@ export const depsOutdatedCommand = new Command({
           },
           format: (value, dep) => {
             const color = getVersionColor(getCurrent(dep), dep.latest)
+            if (dep.latestDate) {
+              const age = `(${relativeFormattedTime(dep.latestDate)})`
+              return `${color}${dep.latest}${COLORS.reset} ${COLORS.grey}${age}${COLORS.reset}`
+            }
             return `${color}${value}${COLORS.reset}`
           },
         },

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -169,8 +169,10 @@ export const depsOutdatedCommand = new Command({
           format: (value, dep) => {
             const color = getVersionColor(getCurrent(dep), dep.wanted)
             if (dep.wantedDate) {
-              const age = `(${relativeFormattedTime(dep.wantedDate)})`
-              return `${color}${dep.wanted}${COLORS.reset} ${COLORS.grey}${age}${COLORS.reset}`
+              const versionEnd = value.indexOf(' (')
+              const versionPart = value.slice(0, versionEnd)
+              const rest = value.slice(versionEnd)
+              return `${color}${versionPart}${COLORS.reset}${COLORS.grey}${rest}${COLORS.reset}`
             }
             return `${color}${value}${COLORS.reset}`
           },
@@ -186,8 +188,10 @@ export const depsOutdatedCommand = new Command({
           format: (value, dep) => {
             const color = getVersionColor(getCurrent(dep), dep.latest)
             if (dep.latestDate) {
-              const age = `(${relativeFormattedTime(dep.latestDate)})`
-              return `${color}${dep.latest}${COLORS.reset} ${COLORS.grey}${age}${COLORS.reset}`
+              const versionEnd = value.indexOf(' (')
+              const versionPart = value.slice(0, versionEnd)
+              const rest = value.slice(versionEnd)
+              return `${color}${versionPart}${COLORS.reset}${COLORS.grey}${rest}${COLORS.reset}`
             }
             return `${color}${value}${COLORS.reset}`
           },

--- a/src/lib/dependencies.ts
+++ b/src/lib/dependencies.ts
@@ -56,6 +56,14 @@ export const OutdatedDependencyZodSchema = ProjectDependencyZodSchema.extend({
   latest: z.string().describe('Absolute latest version available'),
   specifier: z.string().describe('The version specifier from package manifest'),
   isDevDependency: z.boolean().describe('Whether this is a dev dependency'),
+  wantedDate: z
+    .string()
+    .optional()
+    .describe('ISO date when the wanted version was published'),
+  latestDate: z
+    .string()
+    .optional()
+    .describe('ISO date when the latest version was published'),
 })
 
 /**

--- a/src/lib/formatters/relative-time.test.ts
+++ b/src/lib/formatters/relative-time.test.ts
@@ -1,0 +1,59 @@
+import { strictEqual } from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { relativeFormattedTime } from './relative-time.ts'
+
+describe('relativeFormattedTime()', () => {
+  const now = new Date('2026-04-20T12:00:00.000Z')
+
+  it('should return seconds for very recent dates', () => {
+    strictEqual(relativeFormattedTime('2026-04-20T11:59:30.000Z', now), '30s')
+    strictEqual(relativeFormattedTime('2026-04-20T11:59:55.000Z', now), '5s')
+  })
+
+  it('should return minutes for dates less than an hour ago', () => {
+    strictEqual(relativeFormattedTime('2026-04-20T11:30:00.000Z', now), '30m')
+    strictEqual(relativeFormattedTime('2026-04-20T11:55:00.000Z', now), '5m')
+  })
+
+  it('should return hours for dates less than a day ago', () => {
+    strictEqual(relativeFormattedTime('2026-04-20T11:00:00.000Z', now), '1h')
+    strictEqual(relativeFormattedTime('2026-04-20T00:00:00.000Z', now), '12h')
+    strictEqual(relativeFormattedTime('2026-04-19T18:00:00.000Z', now), '18h')
+  })
+
+  it('should return days for dates less than a week ago', () => {
+    strictEqual(relativeFormattedTime('2026-04-19T12:00:00.000Z', now), '1d')
+    strictEqual(relativeFormattedTime('2026-04-17T12:00:00.000Z', now), '3d')
+    strictEqual(relativeFormattedTime('2026-04-14T12:00:00.000Z', now), '6d')
+  })
+
+  it('should return weeks for dates less than a month ago', () => {
+    strictEqual(relativeFormattedTime('2026-04-13T12:00:00.000Z', now), '1w')
+    strictEqual(relativeFormattedTime('2026-04-06T12:00:00.000Z', now), '2w')
+    strictEqual(relativeFormattedTime('2026-03-23T12:00:00.000Z', now), '4w')
+  })
+
+  it('should return months for dates less than a year ago', () => {
+    strictEqual(relativeFormattedTime('2026-03-20T12:00:00.000Z', now), '1mo')
+    strictEqual(relativeFormattedTime('2026-01-20T12:00:00.000Z', now), '3mo')
+    strictEqual(relativeFormattedTime('2025-10-20T12:00:00.000Z', now), '6mo')
+  })
+
+  it('should return years for dates more than a year ago', () => {
+    strictEqual(relativeFormattedTime('2025-04-01T12:00:00.000Z', now), '1y')
+    strictEqual(relativeFormattedTime('2024-04-01T12:00:00.000Z', now), '2y')
+    strictEqual(relativeFormattedTime('2021-04-01T12:00:00.000Z', now), '5y')
+  })
+
+  it('should round to the nearest whole number', () => {
+    // 10 days = 1.43 weeks, rounds to 1w
+    strictEqual(relativeFormattedTime('2026-04-10T12:00:00.000Z', now), '1w')
+    // 20 days = 2.86 weeks, rounds to 3w
+    strictEqual(relativeFormattedTime('2026-03-31T12:00:00.000Z', now), '3w')
+  })
+
+  it('should return 0s for future dates', () => {
+    strictEqual(relativeFormattedTime('2026-04-21T12:00:00.000Z', now), '0s')
+  })
+})

--- a/src/lib/formatters/relative-time.ts
+++ b/src/lib/formatters/relative-time.ts
@@ -1,0 +1,29 @@
+/**
+ * Format a date as a short relative time string.
+ * Examples: "1h", "3d", "4w", "2mo", "1y"
+ */
+export const relativeFormattedTime = (
+  isoDate: string,
+  now: Date = new Date(),
+): string => {
+  const date = new Date(isoDate)
+  const diffMs = now.getTime() - date.getTime()
+
+  if (diffMs < 0) return '0s'
+
+  const seconds = diffMs / 1000
+  const minutes = seconds / 60
+  const hours = minutes / 60
+  const days = hours / 24
+  const weeks = days / 7
+  const months = days / 30.44
+  const years = days / 365.25
+
+  if (years >= 1) return `${Math.round(years)}y`
+  if (months >= 1) return `${Math.round(months)}mo`
+  if (weeks >= 1) return `${Math.round(weeks)}w`
+  if (days >= 1) return `${Math.round(days)}d`
+  if (hours >= 1) return `${Math.round(hours)}h`
+  if (minutes >= 1) return `${Math.round(minutes)}m`
+  return `${Math.round(seconds)}s`
+}

--- a/src/lib/jsr/info.ts
+++ b/src/lib/jsr/info.ts
@@ -33,6 +33,7 @@ const isCacheValid = async (filePath: string): Promise<boolean> => {
 export type JsrPackageInfo = {
   versions: string[]
   latest: string
+  versionDates?: Record<string, string>
 }
 
 /** Read cached package info */
@@ -87,7 +88,7 @@ export const fetchJsrPackageInfo = async (
 
     const data = (await response.json()) as {
       latest: string
-      versions: Record<string, { yanked?: boolean }>
+      versions: Record<string, { yanked?: boolean; createdAt?: string }>
     }
 
     const versions = Object.entries(data.versions)
@@ -95,7 +96,20 @@ export const fetchJsrPackageInfo = async (
       .map(([version]) => version)
     const latest = data.latest
 
-    const result = { versions, latest }
+    // Extract publish dates if available
+    const versionDates: Record<string, string> = {}
+    for (const [version, info] of Object.entries(data.versions)) {
+      if (info.createdAt) {
+        versionDates[version] = info.createdAt
+      }
+    }
+
+    const result: JsrPackageInfo = {
+      versions,
+      latest,
+      versionDates:
+        Object.keys(versionDates).length > 0 ? versionDates : undefined,
+    }
     await writeCache(packageName, result)
 
     return result

--- a/src/lib/jsr/outdated.ts
+++ b/src/lib/jsr/outdated.ts
@@ -44,12 +44,15 @@ export const jsrOutdated = async (
     const hasLatestUpdate = latest && latest !== info.current
 
     if (hasWantedUpdate || hasLatestUpdate) {
+      const wantedVersion = wanted || info.current
       result.push({
         ...dep,
-        wanted: wanted || info.current,
+        wanted: wantedVersion,
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        wantedDate: jsrInfo.versionDates?.[wantedVersion],
+        latestDate: jsrInfo.versionDates?.[latest],
       })
     }
   })

--- a/src/lib/npm/info.ts
+++ b/src/lib/npm/info.ts
@@ -63,6 +63,7 @@ const isCacheValid = async (filePath: string): Promise<boolean> => {
 export type NpmPackageInfo = {
   versions: string[]
   latest: string
+  versionDates?: Record<string, string>
 }
 
 /** Read cached package info */
@@ -75,7 +76,10 @@ const readCache = async (
   }
   try {
     const content = await readFile(filePath, 'utf-8')
-    return JSON.parse(content) as NpmPackageInfo
+    const data = JSON.parse(content) as NpmPackageInfo
+    // Invalidate cache entries missing versionDates
+    if (!data.versionDates) return null
+    return data
   } catch {
     return null
   }
@@ -119,12 +123,23 @@ export const fetchNpmPackageInfo = async (
     const data = (await response.json()) as {
       versions: Record<string, unknown>
       'dist-tags': { latest: string }
+      time?: Record<string, string>
     }
 
     const versions = Object.keys(data.versions)
     const latest = data['dist-tags']?.latest || versions[versions.length - 1]
 
-    const result = { versions, latest }
+    // Extract publish dates for each version
+    const versionDates: Record<string, string> = {}
+    if (data.time) {
+      for (const [version, date] of Object.entries(data.time)) {
+        if (version !== 'created' && version !== 'modified') {
+          versionDates[version] = date
+        }
+      }
+    }
+
+    const result: NpmPackageInfo = { versions, latest, versionDates }
 
     // Write to cache
     await writeCache(packageName, result)

--- a/src/lib/npm/outdated.ts
+++ b/src/lib/npm/outdated.ts
@@ -174,12 +174,15 @@ export const npmOutdated = async (
     const hasLatestUpdate = latest && latest !== info.current
 
     if (hasWantedUpdate || hasLatestUpdate) {
+      const wantedVersion = wanted || info.current
       result.push({
         ...dep,
-        wanted: wanted || info.current,
+        wanted: wantedVersion,
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        wantedDate: npmInfo.versionDates?.[wantedVersion],
+        latestDate: npmInfo.versionDates?.[latest],
       })
     }
   })

--- a/src/lib/rubygems/info.ts
+++ b/src/lib/rubygems/info.ts
@@ -56,6 +56,7 @@ const isCacheValid = async (filePath: string): Promise<boolean> => {
 export type RubygemInfo = {
   versions: string[]
   latest: string
+  versionDates?: Record<string, string>
 }
 
 /** Read cached gem info */
@@ -66,7 +67,9 @@ const readCache = async (gemName: string): Promise<RubygemInfo | null> => {
   }
   try {
     const content = await readFile(filePath, 'utf-8')
-    return JSON.parse(content) as RubygemInfo
+    const data = JSON.parse(content) as RubygemInfo
+    if (!data.versionDates) return null
+    return data
   } catch {
     return null
   }
@@ -112,6 +115,7 @@ export const fetchRubygemInfo = async (
     const data = (await response.json()) as Array<{
       number: string
       prerelease: boolean
+      created_at?: string
     }>
 
     // Extract version numbers, filtering out prereleases for the versions list
@@ -123,7 +127,15 @@ export const fetchRubygemInfo = async (
       .map((v) => v.number)
     const latest = stableVersions[0] || allVersions[0]
 
-    const result = { versions: allVersions, latest }
+    // Extract publish dates
+    const versionDates: Record<string, string> = {}
+    for (const v of data) {
+      if (v.created_at) {
+        versionDates[v.number] = v.created_at
+      }
+    }
+
+    const result: RubygemInfo = { versions: allVersions, latest, versionDates }
 
     // Write to cache
     await writeCache(gemName, result)

--- a/src/lib/rubygems/outdated.ts
+++ b/src/lib/rubygems/outdated.ts
@@ -199,12 +199,15 @@ export const rubygemsOutdated = async (
     const hasLatestUpdate = latest && latest !== info.current
 
     if (hasWantedUpdate || hasLatestUpdate) {
+      const wantedVersion = wanted || info.current
       result.push({
         ...dep,
-        wanted: wanted || info.current,
+        wanted: wantedVersion,
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        wantedDate: gemInfo.versionDates?.[wantedVersion],
+        latestDate: gemInfo.versionDates?.[latest],
       })
     }
   })

--- a/src/lib/uv/info.ts
+++ b/src/lib/uv/info.ts
@@ -61,6 +61,7 @@ const isCacheValid = async (filePath: string): Promise<boolean> => {
 export type PyPIPackageInfo = {
   versions: string[]
   latest: string
+  versionDates?: Record<string, string>
 }
 
 /** Read cached package info */
@@ -73,7 +74,9 @@ const readCache = async (
   }
   try {
     const content = await readFile(filePath, 'utf-8')
-    return JSON.parse(content) as PyPIPackageInfo
+    const data = JSON.parse(content) as PyPIPackageInfo
+    if (!data.versionDates) return null
+    return data
   } catch {
     return null
   }
@@ -119,7 +122,7 @@ export const fetchPyPIPackageInfo = async (
     if (!response.ok) return null
 
     const data = (await response.json()) as {
-      releases: Record<string, unknown[]>
+      releases: Record<string, Array<{ upload_time_iso_8601?: string }>>
       info: { version: string }
     }
 
@@ -130,7 +133,15 @@ export const fetchPyPIPackageInfo = async (
 
     const latest = data.info?.version || versions[versions.length - 1]
 
-    const result = { versions, latest }
+    // Extract publish dates from the first file of each release
+    const versionDates: Record<string, string> = {}
+    for (const [version, files] of Object.entries(data.releases)) {
+      if (files.length > 0 && files[0].upload_time_iso_8601) {
+        versionDates[version] = files[0].upload_time_iso_8601
+      }
+    }
+
+    const result: PyPIPackageInfo = { versions, latest, versionDates }
 
     // Write to cache
     await writeCache(normalizedName, result)

--- a/src/lib/uv/outdated.ts
+++ b/src/lib/uv/outdated.ts
@@ -207,12 +207,15 @@ export const uvOutdated = async (
     const hasLatestUpdate = latest && latest !== info.current
 
     if (hasWantedUpdate || hasLatestUpdate) {
+      const wantedVersion = wanted || info.current
       result.push({
         ...dep,
-        wanted: wanted || info.current,
+        wanted: wantedVersion,
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        wantedDate: pypiInfo.versionDates?.[wantedVersion],
+        latestDate: pypiInfo.versionDates?.[latest],
       })
     }
   })

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -102,6 +102,8 @@ export type OutdatedDependency = Dependency & {
   latest: string
   specifier: string
   isDevDependency: boolean
+  wantedDate?: string
+  latestDate?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

- `deps outdated` now displays how long ago the wanted and latest versions were published (e.g. `1.2.3 (3d)`)
- Fetches publish dates from npm, PyPI, RubyGems, and JSR registries and caches them alongside version data
- Release age is styled in grey to visually separate it from the version number
- Adds `relativeFormattedTime()` utility with tests that converts ISO dates to short strings (`1h`, `3d`, `4w`, `2mo`, `1y`)

## Test plan

- [x] All 561 existing tests pass
- [x] New `relativeFormattedTime` test suite (9 tests) passes
- [x] Lint passes
- [x] Verified column alignment with real project output
- [x] Verified dates appear for all npm packages after cache refresh