### PR TITLE
Add --release-latency flag to deps outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 - `deps outdated` now shows how long ago the wanted and latest versions were released (e.g. `1.2.3 (3d)`)
+- `deps outdated --release-latency` flag to filter out recently-released versions (e.g. `--release-latency 7d`). Defaults to `auto`, which reads pnpm's `minimumReleaseAge` from `pnpm-workspace.yaml` when available
 
 ### Fixed
 

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -1,6 +1,8 @@
 import { Command } from '../../lib/command.ts'
+import { parseDuration } from '../../lib/formatters/duration.ts'
 import { relativeFormattedTime } from '../../lib/formatters/relative-time.ts'
 import { COLORS, formatTable } from '../../lib/formatters/table.ts'
+import { readPnpmMinimumReleaseAge } from '../../lib/pnpm-config.ts'
 import {
   getSemverLevel,
   outdatedMatchesSemverFilter,
@@ -30,8 +32,8 @@ export const depsOutdatedCommand = new Command({
   name: 'deps:outdated',
   description: 'Show outdated dependencies',
   usage:
-    'deps outdated [--no-cache] [--semver patch|minor|major] [--ecosystem <name>]',
-  example: 'denvig deps outdated --semver patch',
+    'deps outdated [--no-cache] [--semver patch|minor|major] [--ecosystem <name>] [--release-latency <duration>]',
+  example: 'denvig deps outdated --release-latency 7d',
   args: [],
   flags: [
     {
@@ -56,11 +58,20 @@ export const depsOutdatedCommand = new Command({
       type: 'string',
       defaultValue: undefined,
     },
+    {
+      name: 'release-latency',
+      description:
+        'Only show updates released longer ago than this duration (e.g., "3h", "7d", "2w"). Use "auto" to read from pnpm minimumReleaseAge, or "0" to disable.',
+      required: false,
+      type: 'string',
+      defaultValue: 'auto',
+    },
   ],
   handler: async ({ project, flags }) => {
     const cache = !(flags['no-cache'] as boolean)
     const semverFilter = flags.semver as 'patch' | 'minor' | 'major' | undefined
     const ecosystemFilter = flags.ecosystem as string | undefined
+    const releaseLatencyFlag = flags['release-latency'] as string | undefined
 
     // Validate semver flag
     if (
@@ -101,6 +112,57 @@ export const depsOutdatedCommand = new Command({
           semverFilter,
         ),
       )
+    }
+
+    // Resolve release latency threshold
+    let releaseLatencyMs: number | null = null
+    const latencyValue = releaseLatencyFlag ?? 'auto'
+    if (latencyValue === '0') {
+      // Explicitly disabled
+      releaseLatencyMs = null
+    } else if (latencyValue === 'auto') {
+      // Read from pnpm-workspace.yaml if available
+      releaseLatencyMs = await readPnpmMinimumReleaseAge(project.path)
+    } else {
+      releaseLatencyMs = parseDuration(latencyValue)
+      if (releaseLatencyMs === null) {
+        console.error(
+          `Invalid --release-latency value: "${latencyValue}". Use a duration like "3h", "7d", "2w", or "auto".`,
+        )
+        return { success: false, message: 'Invalid --release-latency value.' }
+      }
+    }
+
+    // Filter by release latency: hide entries where all update versions
+    // were released more recently than the threshold
+    if (releaseLatencyMs !== null) {
+      const now = Date.now()
+      entries = entries.filter((dep) => {
+        const current = getCurrent(dep)
+        const wantedIsUpdate = dep.wanted !== current
+        const latestIsUpdate = dep.latest !== current
+
+        // Check if wanted version is old enough
+        const wantedOldEnough =
+          wantedIsUpdate && dep.wantedDate
+            ? now - new Date(dep.wantedDate).getTime() >= releaseLatencyMs
+            : false
+
+        // Check if latest version is old enough
+        const latestOldEnough =
+          latestIsUpdate && dep.latestDate
+            ? now - new Date(dep.latestDate).getTime() >= releaseLatencyMs
+            : false
+
+        // Keep if any available update is old enough, or if dates are missing
+        // (we don't filter out entries with unknown release dates)
+        const hasDateInfo =
+          (wantedIsUpdate && dep.wantedDate) ||
+          (latestIsUpdate && dep.latestDate)
+        if (!hasDateInfo) return true
+
+        return wantedOldEnough || latestOldEnough
+      })
     }
 
     if (entries.length === 0) {

--- a/src/lib/formatters/duration.test.ts
+++ b/src/lib/formatters/duration.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { parseDuration } from './duration.ts'
+
+describe('parseDuration', () => {
+  it('parses seconds', () => {
+    assert.equal(parseDuration('30s'), 30_000)
+  })
+
+  it('parses minutes', () => {
+    assert.equal(parseDuration('5m'), 300_000)
+  })
+
+  it('parses hours', () => {
+    assert.equal(parseDuration('3h'), 10_800_000)
+  })
+
+  it('parses days', () => {
+    assert.equal(parseDuration('7d'), 604_800_000)
+  })
+
+  it('parses weeks', () => {
+    assert.equal(parseDuration('2w'), 1_209_600_000)
+  })
+
+  it('parses plain number as minutes (pnpm format)', () => {
+    assert.equal(parseDuration('1440'), 86_400_000) // 24 hours
+  })
+
+  it('returns null for invalid input', () => {
+    assert.equal(parseDuration('abc'), null)
+    assert.equal(parseDuration(''), null)
+    assert.equal(parseDuration('7x'), null)
+    assert.equal(parseDuration('d7'), null)
+  })
+})

--- a/src/lib/formatters/duration.ts
+++ b/src/lib/formatters/duration.ts
@@ -1,0 +1,32 @@
+/**
+ * Parse a human-readable duration string into milliseconds.
+ * Supported formats: "30s", "5m", "3h", "7d", "2w"
+ * Also supports plain numbers as minutes (for pnpm compatibility).
+ */
+export const parseDuration = (input: string): number | null => {
+  // Plain number = minutes (pnpm minimumReleaseAge format)
+  if (/^\d+$/.test(input)) {
+    return Number.parseInt(input, 10) * 60 * 1000
+  }
+
+  const match = input.match(/^(\d+)(s|m|h|d|w)$/)
+  if (!match) return null
+
+  const value = Number.parseInt(match[1], 10)
+  const unit = match[2]
+
+  switch (unit) {
+    case 's':
+      return value * 1000
+    case 'm':
+      return value * 60 * 1000
+    case 'h':
+      return value * 60 * 60 * 1000
+    case 'd':
+      return value * 24 * 60 * 60 * 1000
+    case 'w':
+      return value * 7 * 24 * 60 * 60 * 1000
+    default:
+      return null
+  }
+}

--- a/src/lib/pnpm-config.ts
+++ b/src/lib/pnpm-config.ts
@@ -1,0 +1,31 @@
+import { readFile } from 'node:fs/promises'
+import { parse } from 'yaml'
+
+import { parseDuration } from './formatters/duration.ts'
+
+type PnpmWorkspaceConfig = {
+  minimumReleaseAge?: number | string
+}
+
+/**
+ * Read the minimumReleaseAge from pnpm-workspace.yaml and return it as milliseconds.
+ * Returns null if the file doesn't exist or the setting isn't configured.
+ * pnpm stores this value as minutes (e.g., 1440 = 24 hours).
+ */
+export const readPnpmMinimumReleaseAge = async (
+  projectPath: string,
+): Promise<number | null> => {
+  try {
+    const content = await readFile(
+      `${projectPath}/pnpm-workspace.yaml`,
+      'utf-8',
+    )
+    const config = parse(content) as PnpmWorkspaceConfig
+    if (config?.minimumReleaseAge == null) return null
+
+    const value = String(config.minimumReleaseAge)
+    return parseDuration(value)
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `--release-latency` flag to `deps outdated` that filters out dependencies whose update versions were released more recently than a specified threshold
- Defaults to `auto`, which reads pnpm's `minimumReleaseAge` from `pnpm-workspace.yaml` when available (value in minutes, e.g. `1440` = 24h)
- Supports human-readable durations: `3h`, `7d`, `2w`
- Use `--release-latency=0` to disable filtering entirely

## Test plan

- [x] `denvig outdated --project upvio/api` — auto mode filters packages < 24h old (e.g. `@cloudflare/workers-types` at 17h)
- [x] `denvig outdated --project upvio/api --release-latency=0` — shows all packages including recent ones
- [x] `denvig outdated --project marcqualie/marcqualie.com` — no pnpm config, shows everything
- [x] `denvig outdated --project marcqualie/marcqualie.com --release-latency=7d` — filters packages < 7d old
- [x] Duration parser unit tests pass (7 tests)
- [x] Full test suite passes (568 tests)