### PR TITLE
Show release date for current version in deps outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- `deps outdated` now shows how long ago the wanted and latest versions were released (e.g. `1.2.3 (3d)`)
+- `deps outdated` now shows how long ago the wanted, latest, and current versions were released (e.g. `1.2.3 (3d)`)
 - `deps outdated --release-latency` flag to filter out recently-released versions (e.g. `--release-latency 7d`). Defaults to `auto`, which reads pnpm's `minimumReleaseAge` from `pnpm-workspace.yaml` when available
 
 ### Fixed

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -219,7 +219,24 @@ export const depsOutdatedCommand = new Command({
           accessor: (e) =>
             e.isDevDependency ? `${COLORS.grey}(dev)${COLORS.reset}` : '    ',
         },
-        { header: 'Current', accessor: (dep) => getCurrent(dep) },
+        {
+          header: 'Current',
+          accessor: (dep) => {
+            if (dep.currentDate) {
+              return `${getCurrent(dep)} (${relativeFormattedTime(dep.currentDate)})`
+            }
+            return getCurrent(dep)
+          },
+          format: (value, dep) => {
+            if (dep.currentDate) {
+              const versionEnd = value.indexOf(' (')
+              const versionPart = value.slice(0, versionEnd)
+              const rest = value.slice(versionEnd)
+              return `${versionPart}${COLORS.grey}${rest}${COLORS.reset}`
+            }
+            return value
+          },
+        },
         {
           header: 'Wanted',
           accessor: (dep) => {

--- a/src/lib/dependencies.ts
+++ b/src/lib/dependencies.ts
@@ -56,6 +56,10 @@ export const OutdatedDependencyZodSchema = ProjectDependencyZodSchema.extend({
   latest: z.string().describe('Absolute latest version available'),
   specifier: z.string().describe('The version specifier from package manifest'),
   isDevDependency: z.boolean().describe('Whether this is a dev dependency'),
+  currentDate: z
+    .string()
+    .optional()
+    .describe('ISO date when the current version was published'),
   wantedDate: z
     .string()
     .optional()

--- a/src/lib/jsr/outdated.ts
+++ b/src/lib/jsr/outdated.ts
@@ -51,6 +51,7 @@ export const jsrOutdated = async (
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        currentDate: jsrInfo.versionDates?.[info.current],
         wantedDate: jsrInfo.versionDates?.[wantedVersion],
         latestDate: jsrInfo.versionDates?.[latest],
       })

--- a/src/lib/npm/outdated.ts
+++ b/src/lib/npm/outdated.ts
@@ -181,6 +181,7 @@ export const npmOutdated = async (
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        currentDate: npmInfo.versionDates?.[info.current],
         wantedDate: npmInfo.versionDates?.[wantedVersion],
         latestDate: npmInfo.versionDates?.[latest],
       })

--- a/src/lib/rubygems/outdated.ts
+++ b/src/lib/rubygems/outdated.ts
@@ -206,6 +206,7 @@ export const rubygemsOutdated = async (
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        currentDate: gemInfo.versionDates?.[info.current],
         wantedDate: gemInfo.versionDates?.[wantedVersion],
         latestDate: gemInfo.versionDates?.[latest],
       })

--- a/src/lib/uv/outdated.ts
+++ b/src/lib/uv/outdated.ts
@@ -214,6 +214,7 @@ export const uvOutdated = async (
         latest: latest,
         specifier: info.specifier,
         isDevDependency: info.isDevDependency,
+        currentDate: pypiInfo.versionDates?.[info.current],
         wantedDate: pypiInfo.versionDates?.[wantedVersion],
         latestDate: pypiInfo.versionDates?.[latest],
       })

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -102,6 +102,7 @@ export type OutdatedDependency = Dependency & {
   latest: string
   specifier: string
   isDevDependency: boolean
+  currentDate?: string
   wantedDate?: string
   latestDate?: string
 }


### PR DESCRIPTION
## Summary

- Adds `currentDate` field to `OutdatedDependency` type, populated from registry version dates across all ecosystems (npm, rubygems, pypi, jsr)
- Displays the release age in the Current column with grey styling, so users can compare when their installed version was released vs available updates
- Example: `express 4.21.2 (1y) → 5.2.1 (5mo)` makes it clear the current version is a year old

## Test plan

- [x] `denvig outdated --project upvio/api` shows dates in Current column
- [x] Type checks pass
- [x] Full test suite passes (568 tests)
- [x] Build succeeds