### PR TITLE
Support minimumReleaseAgeExclude in release latency filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - `deps outdated` now shows how long ago the wanted, latest, and current versions were released (e.g. `1.2.3 (3d)`)
 - `deps outdated --release-latency` flag to filter out recently-released versions (e.g. `--release-latency 7d`). Defaults to `auto`, which reads pnpm's `minimumReleaseAge` from `pnpm-workspace.yaml` when available
+- `--release-latency=auto` now respects pnpm's `minimumReleaseAgeExclude` list, allowing excluded packages to bypass the latency filter
 
 ### Fixed
 

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -2,7 +2,7 @@ import { Command } from '../../lib/command.ts'
 import { parseDuration } from '../../lib/formatters/duration.ts'
 import { relativeFormattedTime } from '../../lib/formatters/relative-time.ts'
 import { COLORS, formatTable } from '../../lib/formatters/table.ts'
-import { readPnpmMinimumReleaseAge } from '../../lib/pnpm-config.ts'
+import { readPnpmReleaseAgeConfig } from '../../lib/pnpm-config.ts'
 import {
   getSemverLevel,
   outdatedMatchesSemverFilter,
@@ -116,13 +116,18 @@ export const depsOutdatedCommand = new Command({
 
     // Resolve release latency threshold
     let releaseLatencyMs: number | null = null
+    let releaseLatencyExclude: string[] = []
     const latencyValue = releaseLatencyFlag ?? 'auto'
     if (latencyValue === '0') {
       // Explicitly disabled
       releaseLatencyMs = null
     } else if (latencyValue === 'auto') {
       // Read from pnpm-workspace.yaml if available
-      releaseLatencyMs = await readPnpmMinimumReleaseAge(project.path)
+      const pnpmConfig = await readPnpmReleaseAgeConfig(project.path)
+      if (pnpmConfig) {
+        releaseLatencyMs = pnpmConfig.minimumReleaseAgeMs
+        releaseLatencyExclude = pnpmConfig.exclude
+      }
     } else {
       releaseLatencyMs = parseDuration(latencyValue)
       if (releaseLatencyMs === null) {
@@ -138,6 +143,9 @@ export const depsOutdatedCommand = new Command({
     if (releaseLatencyMs !== null) {
       const now = Date.now()
       entries = entries.filter((dep) => {
+        // Skip filtering for excluded packages
+        if (releaseLatencyExclude.includes(dep.name)) return true
+
         const current = getCurrent(dep)
         const wantedIsUpdate = dep.wanted !== current
         const latestIsUpdate = dep.latest !== current

--- a/src/lib/pnpm-config.ts
+++ b/src/lib/pnpm-config.ts
@@ -5,16 +5,23 @@ import { parseDuration } from './formatters/duration.ts'
 
 type PnpmWorkspaceConfig = {
   minimumReleaseAge?: number | string
+  minimumReleaseAgeExclude?: string[]
+}
+
+export type PnpmReleaseAgeConfig = {
+  minimumReleaseAgeMs: number
+  exclude: string[]
 }
 
 /**
- * Read the minimumReleaseAge from pnpm-workspace.yaml and return it as milliseconds.
+ * Read release age configuration from pnpm-workspace.yaml.
+ * Returns the minimumReleaseAge as milliseconds and the exclude list.
  * Returns null if the file doesn't exist or the setting isn't configured.
- * pnpm stores this value as minutes (e.g., 1440 = 24 hours).
+ * pnpm stores the age value as minutes (e.g., 1440 = 24 hours).
  */
-export const readPnpmMinimumReleaseAge = async (
+export const readPnpmReleaseAgeConfig = async (
   projectPath: string,
-): Promise<number | null> => {
+): Promise<PnpmReleaseAgeConfig | null> => {
   try {
     const content = await readFile(
       `${projectPath}/pnpm-workspace.yaml`,
@@ -24,7 +31,13 @@ export const readPnpmMinimumReleaseAge = async (
     if (config?.minimumReleaseAge == null) return null
 
     const value = String(config.minimumReleaseAge)
-    return parseDuration(value)
+    const ms = parseDuration(value)
+    if (ms === null) return null
+
+    return {
+      minimumReleaseAgeMs: ms,
+      exclude: config.minimumReleaseAgeExclude ?? [],
+    }
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary

- `--release-latency=auto` now respects pnpm's `minimumReleaseAgeExclude` list from `pnpm-workspace.yaml`
- Excluded packages bypass the latency filter entirely, always showing their latest available version regardless of release age
- Refactors `readPnpmMinimumReleaseAge` into `readPnpmReleaseAgeConfig` which returns both the threshold and exclude list

## Test plan

- [x] Verified `readPnpmReleaseAgeConfig` returns correct exclude list from upvio/api (`["denvig"]`)
- [x] Packages not in the exclude list are still filtered (e.g. `@cloudflare/workers-types` at 19h filtered by 24h threshold)
- [x] Full test suite passes (568 tests)
- [x] Build succeeds