### PR TITLE
Show dash for wanted version when it matches current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `deps outdated` now shows how long ago the wanted, latest, and current versions were released (e.g. `1.2.3 (3d)`)
 - `deps outdated --release-latency` flag to filter out recently-released versions (e.g. `--release-latency 7d`). Defaults to `auto`, which reads pnpm's `minimumReleaseAge` from `pnpm-workspace.yaml` when available
 - `--release-latency=auto` now respects pnpm's `minimumReleaseAgeExclude` list, allowing excluded packages to bypass the latency filter
+- `deps outdated` wanted column now displays `-` when the wanted version matches the current version
 
 ### Fixed
 

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -248,12 +248,14 @@ export const depsOutdatedCommand = new Command({
         {
           header: 'Wanted',
           accessor: (dep) => {
+            if (dep.wanted === getCurrent(dep)) return '-'
             if (dep.wantedDate) {
               return `${dep.wanted} (${relativeFormattedTime(dep.wantedDate)})`
             }
             return dep.wanted
           },
           format: (value, dep) => {
+            if (value === '-') return value
             const color = getVersionColor(getCurrent(dep), dep.wanted)
             if (dep.wantedDate) {
               const versionEnd = value.indexOf(' (')


### PR DESCRIPTION
## Summary

- Display `-` in the wanted column of `deps outdated` when the wanted version is the same as the current version, reducing visual noise
- Skip color formatting for the dash placeholder

## Test plan

- [x] All 568 tests pass
- [x] `bin/denvig-dev version` works
- [x] Run `denvig deps outdated` on a project with dependencies where wanted == current and verify `-` is shown