### PR TITLE
Add clickable version links to deps outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - `deps outdated --release-latency` flag to filter out recently-released versions (e.g. `--release-latency 7d`). Defaults to `auto`, which reads pnpm's `minimumReleaseAge` from `pnpm-workspace.yaml` when available
 - `--release-latency=auto` now respects pnpm's `minimumReleaseAgeExclude` list, allowing excluded packages to bypass the latency filter
 - `deps outdated` wanted column now displays `-` when the wanted version matches the current version
+- `deps outdated` version numbers are now clickable OSC 8 hyperlinks to the npm package page in supported terminals
+- `DENVIG_OPEN_NPMX=1` environment variable to use npmx.dev links instead of npmjs.com
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `--release-latency=auto` now respects pnpm's `minimumReleaseAgeExclude` list, allowing excluded packages to bypass the latency filter
 - `deps outdated` wanted column now displays `-` when the wanted version matches the current version
 - `deps outdated` version numbers are now clickable OSC 8 hyperlinks to the npm package page in supported terminals
-- `DENVIG_OPEN_NPMX=1` environment variable to use npmx.dev links instead of npmjs.com
+- `DENVIG_OPEN_VIA` environment variable to control version link target: `npm` (default), `npmx` for npmx.dev, or `none` to disable links
 
 ### Fixed
 

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -1,7 +1,7 @@
 import { Command } from '../../lib/command.ts'
 import { parseDuration } from '../../lib/formatters/duration.ts'
 import { relativeFormattedTime } from '../../lib/formatters/relative-time.ts'
-import { COLORS, formatTable } from '../../lib/formatters/table.ts'
+import { COLORS, formatTable, hyperlink } from '../../lib/formatters/table.ts'
 import { readPnpmReleaseAgeConfig } from '../../lib/pnpm-config.ts'
 import {
   getSemverLevel,
@@ -26,6 +26,21 @@ const getVersionColor = (current: string, target: string): string => {
   if (level === 'patch') return COLORS.green
 
   return COLORS.white
+}
+
+/** Get a URL for a specific package version based on ecosystem. */
+const getVersionUrl = (
+  name: string,
+  version: string,
+  ecosystem: string,
+): string | null => {
+  if (ecosystem === 'npm') {
+    if (process.env.DENVIG_OPEN_NPMX === '1') {
+      return `https://npmx.dev/package/${name}/v/${version}`
+    }
+    return `https://www.npmjs.com/package/${name}/v/${version}`
+  }
+  return null
 }
 
 export const depsOutdatedCommand = new Command({
@@ -236,13 +251,19 @@ export const depsOutdatedCommand = new Command({
             return getCurrent(dep)
           },
           format: (value, dep) => {
+            const current = getCurrent(dep)
+            const url = getVersionUrl(dep.name, current, dep.ecosystem)
             if (dep.currentDate) {
               const versionEnd = value.indexOf(' (')
               const versionPart = value.slice(0, versionEnd)
               const rest = value.slice(versionEnd)
-              return `${versionPart}${COLORS.grey}${rest}${COLORS.reset}`
+              const linked = url ? hyperlink(versionPart, url) : versionPart
+              return `${linked}${COLORS.grey}${rest}${COLORS.reset}`
             }
-            return value
+            return url
+              ? hyperlink(value.trimEnd(), url) +
+                  value.slice(value.trimEnd().length)
+              : value
           },
         },
         {
@@ -255,15 +276,22 @@ export const depsOutdatedCommand = new Command({
             return dep.wanted
           },
           format: (value, dep) => {
-            if (value === '-') return value
+            if (value.trimEnd() === '-') return value
             const color = getVersionColor(getCurrent(dep), dep.wanted)
+            const url = getVersionUrl(dep.name, dep.wanted, dep.ecosystem)
             if (dep.wantedDate) {
               const versionEnd = value.indexOf(' (')
               const versionPart = value.slice(0, versionEnd)
               const rest = value.slice(versionEnd)
-              return `${color}${versionPart}${COLORS.reset}${COLORS.grey}${rest}${COLORS.reset}`
+              const linked = url
+                ? hyperlink(`${color}${versionPart}${COLORS.reset}`, url)
+                : `${color}${versionPart}${COLORS.reset}`
+              return `${linked}${COLORS.grey}${rest}${COLORS.reset}`
             }
-            return `${color}${value}${COLORS.reset}`
+            const linked = url
+              ? hyperlink(`${color}${value.trimEnd()}${COLORS.reset}`, url)
+              : `${color}${value}${COLORS.reset}`
+            return url ? linked + value.slice(value.trimEnd().length) : linked
           },
         },
         {
@@ -276,13 +304,20 @@ export const depsOutdatedCommand = new Command({
           },
           format: (value, dep) => {
             const color = getVersionColor(getCurrent(dep), dep.latest)
+            const url = getVersionUrl(dep.name, dep.latest, dep.ecosystem)
             if (dep.latestDate) {
               const versionEnd = value.indexOf(' (')
               const versionPart = value.slice(0, versionEnd)
               const rest = value.slice(versionEnd)
-              return `${color}${versionPart}${COLORS.reset}${COLORS.grey}${rest}${COLORS.reset}`
+              const linked = url
+                ? hyperlink(`${color}${versionPart}${COLORS.reset}`, url)
+                : `${color}${versionPart}${COLORS.reset}`
+              return `${linked}${COLORS.grey}${rest}${COLORS.reset}`
             }
-            return `${color}${value}${COLORS.reset}`
+            const linked = url
+              ? hyperlink(`${color}${value.trimEnd()}${COLORS.reset}`, url)
+              : `${color}${value}${COLORS.reset}`
+            return url ? linked + value.slice(value.trimEnd().length) : linked
           },
         },
         {

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -34,8 +34,10 @@ const getVersionUrl = (
   version: string,
   ecosystem: string,
 ): string | null => {
+  const via = process.env.DENVIG_OPEN_VIA || 'npm'
+  if (via === 'none') return null
   if (ecosystem === 'npm') {
-    if (process.env.DENVIG_OPEN_NPMX === '1') {
+    if (via === 'npmx') {
       return `https://npmx.dev/package/${name}/v/${version}`
     }
     return `https://www.npmjs.com/package/${name}/v/${version}`

--- a/src/lib/formatters/table.ts
+++ b/src/lib/formatters/table.ts
@@ -37,11 +37,20 @@ export const COLORS = {
 }
 
 /**
- * Strip ANSI escape codes from a string to get display width.
+ * Strip ANSI escape codes and OSC 8 hyperlink sequences from a string to get display width.
  */
 const stripAnsi = (str: string): string => {
   // biome-ignore lint/suspicious/noControlCharactersInRegex: Required for ANSI code stripping
-  return str.replace(/\x1b\[[0-9;]*m/g, '')
+  return str.replace(/\x1b\[[0-9;]*m/g, '').replace(/\x1b]8;;[^\x07]*\x07/g, '')
+}
+
+/**
+ * Wrap text in an OSC 8 hyperlink escape sequence.
+ * Returns the text unchanged when terminal formatting is disabled.
+ */
+export const hyperlink = (text: string, url: string): string => {
+  if (!shouldUseColors()) return text
+  return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`
 }
 
 /**


### PR DESCRIPTION
## Summary

- Version numbers in `deps outdated` output are now clickable OSC 8 hyperlinks in supported terminals (iTerm2, Kitty, WezTerm, VS Code terminal)
- Clicking a version opens the npm package page for that specific version (e.g. `https://www.npmjs.com/package/zod/v/3.25.0`)
- Added `DENVIG_OPEN_VIA` environment variable to control link target: `npm` (default), `npmx` for npmx.dev, or `none` to disable links
- Added `hyperlink()` utility to the table formatter and updated `stripAnsi` to handle OSC 8 sequences for correct column alignment

## Test plan

- [x] Run `denvig deps outdated` in a supported terminal and verify version numbers are clickable
- [x] Verify clicking opens the correct npm URL with the specific version
- [x] Set `DENVIG_OPEN_VIA=npmx` and verify links point to npmx.dev
- [x] Set `DENVIG_OPEN_VIA=none` and verify no links are rendered
- [x] Verify the `-` in the Wanted column is not underlined/clickable
- [x] Verify column alignment is correct (OSC 8 sequences don't affect widths)
- [x] Run `pnpm run test` — all 568 tests pass