### PR TITLE
Add `denvig system` command for dotfiles and package management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `system setup <url>` command to clone a dotfiles repository to `~/.dotfiles` and run its `setup` action
+- `system update` command to pull dotfiles, run the `update` action, refresh Homebrew packages, and run `skills update -g` when available
+
 ### Changed
 
 - Upgraded `@biomejs/biome` from 2.4.12 to 2.4.13

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,6 +102,7 @@ async function main() {
   const { gatewayCommand } = await import('./commands/gateway/index.ts')
   const { zshCommand } = await import('./commands/zsh/index.ts')
   const { certsCommand } = await import('./commands/certs/index.ts')
+  const { systemCommand } = await import('./commands/system/index.ts')
 
   const commands = {
     run: runCommand,
@@ -120,6 +121,7 @@ async function main() {
     gateway: gatewayCommand,
     zsh: zshCommand,
     certs: certsCommand,
+    system: systemCommand,
   } as Record<string, GenericCommand>
 
   // Handle root-level help

--- a/src/commands/system/index.ts
+++ b/src/commands/system/index.ts
@@ -1,0 +1,17 @@
+import { Command } from '../../lib/command.ts'
+import { systemSetupCommand } from './setup.ts'
+import { systemUpdateCommand } from './update.ts'
+
+export const systemCommand = new Command({
+  name: 'system',
+  description: 'Manage the local system: dotfiles, packages, and tooling',
+  usage: 'system <subcommand>',
+  example: 'denvig system update',
+  args: [],
+  flags: [],
+  subcommands: {
+    setup: systemSetupCommand,
+    update: systemUpdateCommand,
+  },
+  handler: () => ({ success: true }),
+})

--- a/src/commands/system/setup.ts
+++ b/src/commands/system/setup.ts
@@ -1,0 +1,64 @@
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+import { Command } from '../../lib/command.ts'
+import { getGitHubSlug, gitClone, parseGitHubRemoteUrl } from '../../lib/git.ts'
+import { prettyPath } from '../../lib/path.ts'
+import { pathExists } from '../../lib/safeReadFile.ts'
+import { runDenvig } from '../../lib/system/denvig.ts'
+
+export const systemSetupCommand = new Command({
+  name: 'system:setup',
+  description: 'Clone a dotfiles repository to ~/.dotfiles and run setup',
+  usage: 'system setup <url>',
+  example: 'denvig system setup https://github.com/marcqualie/dotfiles',
+  args: [
+    {
+      name: 'url',
+      description: 'Git URL of the dotfiles repository',
+      required: true,
+      type: 'string',
+    },
+  ],
+  flags: [],
+  handler: async ({ args }) => {
+    const url = String(args.url)
+    const target = path.join(homedir(), '.dotfiles')
+
+    if (await pathExists(target)) {
+      const existingSlug = await getGitHubSlug(target)
+      const requestedSlug = parseGitHubRemoteUrl(url)
+
+      if (
+        existingSlug &&
+        requestedSlug &&
+        existingSlug.toLowerCase() === requestedSlug.toLowerCase()
+      ) {
+        console.warn(
+          `Warning: ${prettyPath(target)} already exists for ${existingSlug}, skipping clone`,
+        )
+      } else {
+        const existing = existingSlug ?? '(unknown remote)'
+        console.error(
+          `Error: ${prettyPath(target)} already exists with a different repository (${existing})`,
+        )
+        return { success: false, message: 'Dotfiles directory mismatch' }
+      }
+    } else {
+      console.log(`Cloning ${url} into ${prettyPath(target)}...`)
+      const cloned = await gitClone(url, target)
+      if (!cloned) {
+        return { success: false, message: 'Failed to clone dotfiles repo' }
+      }
+    }
+
+    console.log('')
+    console.log(`Running denvig setup in ${prettyPath(target)}...`)
+    const ok = await runDenvig(target, ['run', 'setup'])
+    if (!ok) {
+      return { success: false, message: 'Setup action failed' }
+    }
+
+    return { success: true, message: 'Setup complete' }
+  },
+})

--- a/src/commands/system/update.ts
+++ b/src/commands/system/update.ts
@@ -1,0 +1,98 @@
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+import { Command } from '../../lib/command.ts'
+import { gitPull, isWorkingTreeDirty } from '../../lib/git.ts'
+import { confirm } from '../../lib/input.ts'
+import { prettyPath } from '../../lib/path.ts'
+import { isDirectory } from '../../lib/safeReadFile.ts'
+import {
+  brewUpdate,
+  brewUpgrade,
+  getBrewOutdated,
+} from '../../lib/system/brew.ts'
+import { runDenvig } from '../../lib/system/denvig.ts'
+import { hasSkillsCli, skillsUpdateGlobal } from '../../lib/system/skills.ts'
+
+export const systemUpdateCommand = new Command({
+  name: 'system:update',
+  description: 'Update the local system: dotfiles, brew packages, and skills',
+  usage: 'system update',
+  example: 'denvig system update',
+  args: [],
+  flags: [],
+  handler: async () => {
+    const dotfilesPath = path.join(homedir(), '.dotfiles')
+
+    if (!(await isDirectory(dotfilesPath))) {
+      console.error(
+        `Error: ${prettyPath(dotfilesPath)} does not exist. Run 'denvig system bootstrap <url>' first.`,
+      )
+      return { success: false, message: 'Dotfiles directory missing' }
+    }
+
+    console.log(`Updating ${prettyPath(dotfilesPath)}...`)
+
+    if (await isWorkingTreeDirty(dotfilesPath)) {
+      console.warn(
+        `Warning: ${prettyPath(dotfilesPath)} has uncommitted changes`,
+      )
+    }
+
+    const pulled = await gitPull(dotfilesPath)
+    if (!pulled) {
+      return { success: false, message: 'git pull failed' }
+    }
+
+    console.log('')
+    console.log(`Running denvig update in ${prettyPath(dotfilesPath)}...`)
+    const updated = await runDenvig(dotfilesPath, ['run', 'update'])
+    if (!updated) {
+      return { success: false, message: 'Update action failed' }
+    }
+
+    console.log('')
+    console.log('Updating Homebrew...')
+    await brewUpdate()
+
+    const outdated = await getBrewOutdated()
+    const formulae = outdated?.formulae ?? []
+    const casks = outdated?.casks ?? []
+    const totalOutdated = formulae.length + casks.length
+
+    if (totalOutdated === 0) {
+      console.log('All Homebrew packages are up to date')
+    } else {
+      console.log(`Outdated Homebrew packages (${totalOutdated}):`)
+      for (const formula of formulae) {
+        const installed = formula.installed_versions?.join(', ') ?? '?'
+        const latest = formula.current_version ?? '?'
+        console.log(`  ${formula.name}: ${installed} → ${latest}`)
+      }
+      for (const cask of casks) {
+        const installed = cask.installed_versions ?? '?'
+        const latest = cask.current_version ?? '?'
+        console.log(`  ${cask.name} (cask): ${installed} → ${latest}`)
+      }
+
+      const shouldUpgrade = await confirm('Run `brew upgrade`?')
+      if (shouldUpgrade) {
+        const upgraded = await brewUpgrade()
+        if (!upgraded) {
+          return { success: false, message: 'brew upgrade failed' }
+        }
+      }
+    }
+
+    if (await hasSkillsCli()) {
+      console.log('')
+      console.log('Updating skills...')
+      const skillsOk = await skillsUpdateGlobal()
+      if (!skillsOk) {
+        return { success: false, message: 'skills update failed' }
+      }
+    }
+
+    return { success: true, message: 'System update complete' }
+  },
+})

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,5 +1,11 @@
+import { execFile } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
+import { promisify } from 'node:util'
+
+import { runInherit } from './system/process.ts'
+
+const execFileAsync = promisify(execFile)
 
 /**
  * Parse a GitHub remote URL and extract owner/repo.
@@ -70,4 +76,26 @@ export const getProjectSlug = async (projectPath: string): Promise<string> => {
     return `github:${githubSlug}`
   }
   return `local:${projectPath}`
+}
+
+/** Clone a git repository into the target directory. */
+export const gitClone = (url: string, target: string): Promise<boolean> => {
+  return runInherit('git', ['clone', url, target])
+}
+
+/** Run `git pull` in the given directory. */
+export const gitPull = (cwd: string): Promise<boolean> => {
+  return runInherit('git', ['pull'], { cwd })
+}
+
+/** Check if a git working tree has uncommitted changes. */
+export const isWorkingTreeDirty = async (cwd: string): Promise<boolean> => {
+  try {
+    const { stdout } = await execFileAsync('git', ['status', '--porcelain'], {
+      cwd,
+    })
+    return stdout.trim().length > 0
+  } catch {
+    return false
+  }
 }

--- a/src/lib/system/brew.ts
+++ b/src/lib/system/brew.ts
@@ -1,0 +1,43 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { runInherit } from './process.ts'
+
+const execFileAsync = promisify(execFile)
+
+export type BrewOutdatedFormula = {
+  name: string
+  installed_versions?: string[]
+  current_version?: string
+}
+
+export type BrewOutdatedCask = {
+  name: string
+  installed_versions?: string
+  current_version?: string
+}
+
+export type BrewOutdatedJson = {
+  formulae?: BrewOutdatedFormula[]
+  casks?: BrewOutdatedCask[]
+}
+
+/** Run `brew update` silently. Resolves to exit success. */
+export const brewUpdate = (): Promise<boolean> => {
+  return runInherit('brew', ['update'], { stdio: 'ignore' })
+}
+
+/** Run `brew upgrade` with inherited stdio. */
+export const brewUpgrade = (): Promise<boolean> => {
+  return runInherit('brew', ['upgrade'])
+}
+
+/** Read outdated brew packages as parsed JSON, or null if the call fails. */
+export const getBrewOutdated = async (): Promise<BrewOutdatedJson | null> => {
+  try {
+    const { stdout } = await execFileAsync('brew', ['outdated', '--json=v2'])
+    return JSON.parse(stdout) as BrewOutdatedJson
+  } catch {
+    return null
+  }
+}

--- a/src/lib/system/denvig.ts
+++ b/src/lib/system/denvig.ts
@@ -1,0 +1,13 @@
+import { spawn } from 'node:child_process'
+
+/**
+ * Spawn a child denvig process in the given directory and inherit stdio.
+ * Resolves to whether the command exited successfully.
+ */
+export const runDenvig = (cwd: string, args: string[]): Promise<boolean> => {
+  return new Promise((resolve) => {
+    const child = spawn('denvig', args, { cwd, stdio: 'inherit' })
+    child.on('close', (code) => resolve(code === 0))
+    child.on('error', () => resolve(false))
+  })
+}

--- a/src/lib/system/process.ts
+++ b/src/lib/system/process.ts
@@ -1,0 +1,25 @@
+import { spawn } from 'node:child_process'
+
+type RunInheritOptions = {
+  cwd?: string
+  stdio?: 'inherit' | 'ignore'
+}
+
+/**
+ * Spawn a child process with inherited (or ignored) stdio.
+ * Resolves to whether the command exited successfully.
+ */
+export const runInherit = (
+  command: string,
+  args: string[],
+  options: RunInheritOptions = {},
+): Promise<boolean> => {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: options.stdio ?? 'inherit',
+    })
+    child.on('close', (code) => resolve(code === 0))
+    child.on('error', () => resolve(false))
+  })
+}

--- a/src/lib/system/skills.ts
+++ b/src/lib/system/skills.ts
@@ -1,0 +1,12 @@
+import { pathExists } from '../safeReadFile.ts'
+import { runInherit } from './process.ts'
+
+const SKILLS_BIN = '/opt/homebrew/bin/skills'
+
+/** Whether the `skills` CLI is installed at the well-known Homebrew path. */
+export const hasSkillsCli = (): Promise<boolean> => pathExists(SKILLS_BIN)
+
+/** Run `skills update -g`. */
+export const skillsUpdateGlobal = (): Promise<boolean> => {
+  return runInherit(SKILLS_BIN, ['update', '-g'])
+}


### PR DESCRIPTION
## Summary

Adds a new `system` command tree for managing the local development environment.

- `denvig system setup <url>` — clones a dotfiles repository into `~/.dotfiles` and runs its `setup` action via `denvig run setup`. Detects when the directory already exists: warns when the remote matches the requested URL, errors when it points to a different repo.
- `denvig system update` — pulls the dotfiles repo (warns when the working tree is dirty), runs `denvig run update`, refreshes Homebrew (silent `brew update`), prints outdated formulae and casks parsed from `brew outdated --json=v2`, and prompts to run `brew upgrade`. Also runs `skills update -g` when `/opt/homebrew/bin/skills` is present.

Helpers live in `src/lib/system/` (`brew`, `denvig`, `process`, `skills`) so the `commands/system/` directory only contains command definitions. Added `gitClone`, `gitPull`, and `isWorkingTreeDirty` to `src/lib/git.ts`.

## Test plan

- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm run test` (568 passing)
- [x] `bin/denvig-dev system --help` shows both subcommands
- [x] `denvig system setup https://github.com/marcqualie/dotfiles` against a fresh machine
- [x] `denvig system update` against an existing `~/.dotfiles` checkout