### PR TITLE
Add `denvig system configure` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - `system setup <url>` command to clone a dotfiles repository to `~/.dotfiles` and run its `setup` action
 - `system update` command to pull dotfiles, run the `update` action, refresh Homebrew packages, and run `skills update -g` when available
+- `system configure` command to interactively check and enable common macOS setup steps: sudo Touch ID, FileVault, Xcode Command Line Tools, Homebrew, dotfiles, and global git config
 
 ### Changed
 

--- a/src/commands/system/configure.ts
+++ b/src/commands/system/configure.ts
@@ -1,0 +1,16 @@
+import { Command } from '../../lib/command.ts'
+import { runSystemConfigure } from '../../lib/system/configure.ts'
+
+export const systemConfigureCommand = new Command({
+  name: 'system:configure',
+  description:
+    'Walk through system setup checks and enable each feature interactively',
+  usage: 'system configure',
+  example: 'denvig system configure',
+  args: [],
+  flags: [],
+  handler: async () => {
+    await runSystemConfigure()
+    return { success: true, message: 'System configuration complete' }
+  },
+})

--- a/src/commands/system/index.ts
+++ b/src/commands/system/index.ts
@@ -1,4 +1,5 @@
 import { Command } from '../../lib/command.ts'
+import { systemConfigureCommand } from './configure.ts'
 import { systemSetupCommand } from './setup.ts'
 import { systemUpdateCommand } from './update.ts'
 
@@ -12,6 +13,7 @@ export const systemCommand = new Command({
   subcommands: {
     setup: systemSetupCommand,
     update: systemUpdateCommand,
+    configure: systemConfigureCommand,
   },
   handler: () => ({ success: true }),
 })

--- a/src/commands/system/setup.ts
+++ b/src/commands/system/setup.ts
@@ -1,11 +1,5 @@
-import { homedir } from 'node:os'
-import path from 'node:path'
-
 import { Command } from '../../lib/command.ts'
-import { getGitHubSlug, gitClone, parseGitHubRemoteUrl } from '../../lib/git.ts'
-import { prettyPath } from '../../lib/path.ts'
-import { pathExists } from '../../lib/safeReadFile.ts'
-import { runDenvig } from '../../lib/system/denvig.ts'
+import { installDotfiles } from '../../lib/system/dotfiles.ts'
 
 export const systemSetupCommand = new Command({
   name: 'system:setup',
@@ -23,42 +17,10 @@ export const systemSetupCommand = new Command({
   flags: [],
   handler: async ({ args }) => {
     const url = String(args.url)
-    const target = path.join(homedir(), '.dotfiles')
-
-    if (await pathExists(target)) {
-      const existingSlug = await getGitHubSlug(target)
-      const requestedSlug = parseGitHubRemoteUrl(url)
-
-      if (
-        existingSlug &&
-        requestedSlug &&
-        existingSlug.toLowerCase() === requestedSlug.toLowerCase()
-      ) {
-        console.warn(
-          `Warning: ${prettyPath(target)} already exists for ${existingSlug}, skipping clone`,
-        )
-      } else {
-        const existing = existingSlug ?? '(unknown remote)'
-        console.error(
-          `Error: ${prettyPath(target)} already exists with a different repository (${existing})`,
-        )
-        return { success: false, message: 'Dotfiles directory mismatch' }
-      }
-    } else {
-      console.log(`Cloning ${url} into ${prettyPath(target)}...`)
-      const cloned = await gitClone(url, target)
-      if (!cloned) {
-        return { success: false, message: 'Failed to clone dotfiles repo' }
-      }
+    const result = await installDotfiles(url)
+    if (!result.success) {
+      console.error(`Error: ${result.message}`)
     }
-
-    console.log('')
-    console.log(`Running denvig setup in ${prettyPath(target)}...`)
-    const ok = await runDenvig(target, ['run', 'setup'])
-    if (!ok) {
-      return { success: false, message: 'Setup action failed' }
-    }
-
-    return { success: true, message: 'Setup complete' }
+    return result
   },
 })

--- a/src/lib/input.ts
+++ b/src/lib/input.ts
@@ -10,3 +10,14 @@ export const confirm = (prompt: string): Promise<boolean> => {
     })
   })
 }
+
+/** Prompt the user for a free-text answer. Returns the trimmed input. */
+export const prompt = (question: string): Promise<string> => {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((resolve) => {
+    rl.question(`${question}: `, (answer) => {
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}

--- a/src/lib/system/configure.ts
+++ b/src/lib/system/configure.ts
@@ -1,0 +1,154 @@
+import { confirm, prompt } from '../input.ts'
+import {
+  areDotfilesInstalled,
+  dotfilesUrlForUsername,
+  installDotfiles,
+} from './dotfiles.ts'
+import {
+  enableFullDiskEncryption,
+  isFullDiskEncryptionEnabled,
+} from './fullDiskEncryption.ts'
+import { configureGit, getGitIdentity } from './gitConfig.ts'
+import { installHomebrew, isHomebrewInstalled } from './homebrew.ts'
+import { enableSudoTouchId, isSudoTouchIdEnabled } from './sudoTouchId.ts'
+import { installXcodeCli, isXcodeCliInstalled } from './xcodeCli.ts'
+
+type Step = {
+  name: string
+  check: () => Promise<boolean>
+  enable: () => Promise<boolean>
+  enableLabel: string
+}
+
+const ENABLED_MARK = '✓'
+const DISABLED_MARK = '✗'
+
+const printStatus = (name: string, enabled: boolean) => {
+  const mark = enabled ? ENABLED_MARK : DISABLED_MARK
+  const label = enabled ? 'configured' : 'not configured'
+  console.log(`${mark} ${name}: ${label}`)
+}
+
+/** Returns true if the step needed user interaction. */
+const runStep = async (step: Step): Promise<boolean> => {
+  const enabled = await step.check()
+  printStatus(step.name, enabled)
+  if (enabled) return false
+
+  const shouldEnable = await confirm(`  ${step.enableLabel}`)
+  if (!shouldEnable) {
+    console.log('  skipped')
+    return true
+  }
+
+  const ok = await step.enable()
+  if (!ok) {
+    console.error(`  Failed to configure ${step.name}`)
+  }
+  return true
+}
+
+const installDotfilesStep = async (): Promise<void> => {
+  const username = await prompt('  GitHub username')
+  if (!username) {
+    console.log('  skipped (no username provided)')
+    return
+  }
+  const result = await installDotfiles(dotfilesUrlForUsername(username))
+  if (!result.success) {
+    console.error(`  ${result.message}`)
+  }
+}
+
+const configureGitStep = async (): Promise<void> => {
+  const name = await prompt('  Git user.name')
+  const email = await prompt('  Git user.email')
+  if (!name || !email) {
+    console.log('  skipped (name and email required)')
+    return
+  }
+  const ok = await configureGit(name, email)
+  if (!ok) {
+    console.error('  Failed to configure git')
+  }
+}
+
+const runDotfilesStep = async (): Promise<boolean> => {
+  const enabled = await areDotfilesInstalled()
+  printStatus('Dotfiles', enabled)
+  if (enabled) return false
+
+  const shouldInstall = await confirm(
+    '  Install dotfiles from github.com/<username>/dotfiles?',
+  )
+  if (!shouldInstall) {
+    console.log('  skipped')
+    return true
+  }
+  await installDotfilesStep()
+  return true
+}
+
+const runGitConfigStep = async (): Promise<boolean> => {
+  const identity = await getGitIdentity()
+  if (identity) {
+    console.log(
+      `${ENABLED_MARK} Git config: ${identity.name} <${identity.email}>`,
+    )
+    return false
+  }
+
+  printStatus('Git config', false)
+  const shouldConfigure = await confirm(
+    '  Configure git user.name + user.email?',
+  )
+  if (!shouldConfigure) {
+    console.log('  skipped')
+    return true
+  }
+  await configureGitStep()
+  return true
+}
+
+const STEPS: Step[] = [
+  {
+    name: 'sudo Touch ID',
+    check: isSudoTouchIdEnabled,
+    enable: enableSudoTouchId,
+    enableLabel: 'Enable sudo Touch ID?',
+  },
+  {
+    name: 'FileVault',
+    check: isFullDiskEncryptionEnabled,
+    enable: enableFullDiskEncryption,
+    enableLabel: 'Enable FileVault full disk encryption?',
+  },
+  {
+    name: 'Xcode Command Line Tools',
+    check: isXcodeCliInstalled,
+    enable: installXcodeCli,
+    enableLabel: 'Install Xcode Command Line Tools?',
+  },
+  {
+    name: 'Homebrew',
+    check: isHomebrewInstalled,
+    enable: installHomebrew,
+    enableLabel: 'Install Homebrew?',
+  },
+]
+
+/** Walk through every system configure step interactively. */
+export const runSystemConfigure = async (): Promise<void> => {
+  const runners: Array<() => Promise<boolean>> = [
+    ...STEPS.map((step) => () => runStep(step)),
+    runDotfilesStep,
+    runGitConfigStep,
+  ]
+
+  for (const [index, run] of runners.entries()) {
+    const interacted = await run()
+    if (interacted && index < runners.length - 1) {
+      console.log('')
+    }
+  }
+}

--- a/src/lib/system/dotfiles.ts
+++ b/src/lib/system/dotfiles.ts
@@ -1,0 +1,68 @@
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+import { getGitHubSlug, gitClone, parseGitHubRemoteUrl } from '../git.ts'
+import { prettyPath } from '../path.ts'
+import { isDirectory } from '../safeReadFile.ts'
+import { runDenvig } from './denvig.ts'
+
+export const DOTFILES_PATH = path.join(homedir(), '.dotfiles')
+
+/** Whether the `~/.dotfiles` directory exists. */
+export const areDotfilesInstalled = (): Promise<boolean> => {
+  return isDirectory(DOTFILES_PATH)
+}
+
+/** Build the canonical dotfiles repo URL for a GitHub username. */
+export const dotfilesUrlForUsername = (username: string): string => {
+  return `https://github.com/${username}/dotfiles`
+}
+
+type InstallDotfilesResult = {
+  success: boolean
+  message: string
+}
+
+/**
+ * Clone the dotfiles repo to `~/.dotfiles` (or skip if already present and
+ * the remote matches), then run `denvig run setup` inside it.
+ */
+export const installDotfiles = async (
+  url: string,
+): Promise<InstallDotfilesResult> => {
+  if (await areDotfilesInstalled()) {
+    const existingSlug = await getGitHubSlug(DOTFILES_PATH)
+    const requestedSlug = parseGitHubRemoteUrl(url)
+
+    if (
+      existingSlug &&
+      requestedSlug &&
+      existingSlug.toLowerCase() === requestedSlug.toLowerCase()
+    ) {
+      console.warn(
+        `Warning: ${prettyPath(DOTFILES_PATH)} already exists for ${existingSlug}, skipping clone`,
+      )
+    } else {
+      const existing = existingSlug ?? '(unknown remote)'
+      return {
+        success: false,
+        message: `${prettyPath(DOTFILES_PATH)} already exists with a different repository (${existing})`,
+      }
+    }
+  } else {
+    console.log(`Cloning ${url} into ${prettyPath(DOTFILES_PATH)}...`)
+    const cloned = await gitClone(url, DOTFILES_PATH)
+    if (!cloned) {
+      return { success: false, message: 'Failed to clone dotfiles repo' }
+    }
+  }
+
+  console.log('')
+  console.log(`Running denvig setup in ${prettyPath(DOTFILES_PATH)}...`)
+  const ok = await runDenvig(DOTFILES_PATH, ['run', 'setup'])
+  if (!ok) {
+    return { success: false, message: 'Setup action failed' }
+  }
+
+  return { success: true, message: 'Dotfiles installed' }
+}

--- a/src/lib/system/fullDiskEncryption.ts
+++ b/src/lib/system/fullDiskEncryption.ts
@@ -1,0 +1,21 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { runInherit } from './process.ts'
+
+const execFileAsync = promisify(execFile)
+
+/** Whether macOS FileVault is currently turned on. */
+export const isFullDiskEncryptionEnabled = async (): Promise<boolean> => {
+  try {
+    const { stdout } = await execFileAsync('fdesetup', ['status'])
+    return /FileVault is On/i.test(stdout)
+  } catch {
+    return false
+  }
+}
+
+/** Run `sudo fdesetup enable` interactively. */
+export const enableFullDiskEncryption = (): Promise<boolean> => {
+  return runInherit('sudo', ['fdesetup', 'enable'])
+}

--- a/src/lib/system/gitConfig.ts
+++ b/src/lib/system/gitConfig.ts
@@ -1,0 +1,50 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { runInherit } from './process.ts'
+
+const execFileAsync = promisify(execFile)
+
+const readGlobalGitConfig = async (key: string): Promise<string | null> => {
+  try {
+    const { stdout } = await execFileAsync('git', ['config', '--global', key])
+    return stdout.trim() || null
+  } catch {
+    return null
+  }
+}
+
+export type GitIdentity = {
+  name: string
+  email: string
+}
+
+/** Read `user.name` and `user.email` from the global git config. */
+export const getGitIdentity = async (): Promise<GitIdentity | null> => {
+  const [name, email] = await Promise.all([
+    readGlobalGitConfig('user.name'),
+    readGlobalGitConfig('user.email'),
+  ])
+  if (!name || !email) return null
+  return { name, email }
+}
+
+/** Whether `user.name` and `user.email` are both set in global git config. */
+export const isGitConfigured = async (): Promise<boolean> => {
+  return (await getGitIdentity()) !== null
+}
+
+/** Set `user.name` and `user.email` in global git config. */
+export const configureGit = async (
+  name: string,
+  email: string,
+): Promise<boolean> => {
+  const setName = await runInherit('git', [
+    'config',
+    '--global',
+    'user.name',
+    name,
+  ])
+  if (!setName) return false
+  return runInherit('git', ['config', '--global', 'user.email', email])
+}

--- a/src/lib/system/homebrew.ts
+++ b/src/lib/system/homebrew.ts
@@ -1,0 +1,17 @@
+import { pathExists } from '../safeReadFile.ts'
+import { runInherit } from './process.ts'
+
+const HOMEBREW_BIN = '/opt/homebrew/bin/brew'
+const INSTALL_URL =
+  'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh'
+
+/** Whether Homebrew is installed at the standard Apple Silicon path. */
+export const isHomebrewInstalled = (): Promise<boolean> => {
+  return pathExists(HOMEBREW_BIN)
+}
+
+/** Run the official Homebrew install script. */
+export const installHomebrew = (): Promise<boolean> => {
+  const cmd = `/bin/bash -c "$(curl -fsSL ${INSTALL_URL})"`
+  return runInherit('sh', ['-c', cmd])
+}

--- a/src/lib/system/sudoTouchId.ts
+++ b/src/lib/system/sudoTouchId.ts
@@ -1,0 +1,27 @@
+import { safeReadTextFile } from '../safeReadFile.ts'
+import { runInherit } from './process.ts'
+
+const SUDO_LOCAL_PATH = '/etc/pam.d/sudo_local'
+const SUDO_PATH = '/etc/pam.d/sudo'
+
+const PAM_TID_PATTERN = /^\s*auth\s+sufficient\s+pam_tid\.so/m
+
+/** Whether `pam_tid.so` is configured for sudo (i.e. Touch ID is enabled). */
+export const isSudoTouchIdEnabled = async (): Promise<boolean> => {
+  for (const path of [SUDO_LOCAL_PATH, SUDO_PATH]) {
+    const content = await safeReadTextFile(path)
+    if (content && PAM_TID_PATTERN.test(content)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Append the `pam_tid.so` line to `/etc/pam.d/sudo_local`. Requires sudo.
+ */
+export const enableSudoTouchId = (): Promise<boolean> => {
+  const line = 'auth       sufficient     pam_tid.so'
+  const cmd = `echo '${line}' | sudo tee -a ${SUDO_LOCAL_PATH} > /dev/null`
+  return runInherit('sh', ['-c', cmd])
+}

--- a/src/lib/system/xcodeCli.ts
+++ b/src/lib/system/xcodeCli.ts
@@ -1,0 +1,24 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { runInherit } from './process.ts'
+
+const execFileAsync = promisify(execFile)
+
+/** Whether the Xcode Command Line Tools are installed. */
+export const isXcodeCliInstalled = async (): Promise<boolean> => {
+  try {
+    await execFileAsync('xcode-select', ['-p'])
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Trigger the Xcode Command Line Tools installer.
+ * This pops up a system dialog; installation continues asynchronously.
+ */
+export const installXcodeCli = (): Promise<boolean> => {
+  return runInherit('xcode-select', ['--install'])
+}


### PR DESCRIPTION
## Summary

Adds `denvig system configure` — an interactive walkthrough that checks each system setup feature and prompts to enable any that are missing.

Steps:

- **Sudo Touch ID** — checks `/etc/pam.d/sudo_local` (and `/etc/pam.d/sudo`) for `pam_tid.so`; appends it via `sudo tee` when enabling.
- **FileVault** — `fdesetup status` / `sudo fdesetup enable`.
- **Xcode Command Line Tools** — `xcode-select -p` / `xcode-select --install`.
- **Homebrew** — checks `/opt/homebrew/bin/brew`; runs the official install script when missing.
- **Dotfiles** — prompts for a GitHub username, then clones `https://github.com/<username>/dotfiles` to `~/.dotfiles` and runs its `setup` action via the shared `installDotfiles` helper.
- **Git config** — prompts for `user.name` and `user.email`; when already set, prints the existing identity (e.g. `✓ Git config: Marc Qualie <marc@marcqualie.com>`).

Each feature lives in its own `src/lib/system/{feature}.ts` exposing `is{Feature}Enabled()` / `enable{Feature}()` helpers. The orchestration sits in `src/lib/system/configure.ts` so `src/commands/system/configure.ts` only contains the `Command` definition. The dotfiles install logic was extracted from `system setup` so both commands share a single code path. A `prompt(question)` helper was added to `src/lib/input.ts`.

Output is compact: configured steps print on consecutive lines with no separator, and a blank line is inserted only after a step that needed user interaction.

## Test plan

- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm run test` (568 passing)
- [x] `bin/denvig-dev system configure` on a fully-configured machine prints six green check rows back-to-back, including the live git identity
- [ ] `denvig system configure` on a fresh machine, accepting each prompt