### PR TITLE
Upgrade zod from 4.3.6 to 4.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - Upgraded `@biomejs/biome` from 2.4.12 to 2.4.13
+- Upgraded `zod` from 4.3.6 to 4.4.2
 
 ## [0.6.5] - 2026-04-20
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node-forge": "^1.4.0",
     "semver": "^7.7.4",
     "yaml": "^2.8.3",
-    "zod": "^4.3.6"
+    "zod": "^4.4.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: ^4.4.2
+        version: 4.4.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.13
@@ -750,8 +750,8 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.2:
+    resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
 
 snapshots:
 
@@ -1305,4 +1305,4 @@ snapshots:
 
   yaml@2.8.3: {}
 
-  zod@4.3.6: {}
+  zod@4.4.2: {}


### PR DESCRIPTION
## Package Updates

- zod: [4.3.6 -> 4.4.2](https://github.com/colinhacks/zod/compare/v4.3.6...v4.4.2)
  - 4.4.0: correctness/soundness fixes including stricter tuple defaults, required `z.undefined()` keys, safer `.merge()` with refinements, stricter base64/httpUrl/cuid validators, record key transforms
  - 4.4.0: performance improvements via lazy-bound builder methods and improved tree-shaking (`sideEffects: false`)
  - 4.4.0: prototype pollution hardening (skip `__proto__` in object catchall)
  - 4.4.1: reject tuple holes before required defaults (#5900)
  - 4.4.2: tighten discriminated union option typing, defer optionality to inner schema in `z.preprocess` (#5929)

## Code Changes

No code modifications required. The codebase uses simple object/string schemas and `z.record()` (without key transforms), so none of the breaking bug fixes affected usage.

## Checks

- ✅ Checked changelogs for breaking changes
- ✅ Lint passes after upgrade
- ✅ Type check passes after upgrade
- ✅ All 568 tests pass after upgrade
- ✅ `bin/denvig-dev version` works
- ✅ Codegen produces no diff