### PR TITLE
Upgrade yaml from 2.8.3 to 2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Upgraded `@biomejs/biome` from 2.4.12 to 2.4.14
 - Upgraded `zod` from 4.3.6 to 4.4.2
+- Upgraded `yaml` from 2.8.3 to 2.8.4
 
 ## [0.6.5] - 2026-04-20
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "minimist": "^1.2.8",
     "node-forge": "^1.4.0",
     "semver": "^7.7.4",
-    "yaml": "^2.8.3",
+    "yaml": "^2.8.4",
     "zod": "^4.4.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^7.7.4
         version: 7.7.4
       yaml:
-        specifier: ^2.8.3
-        version: 2.8.3
+        specifier: ^2.8.4
+        version: 2.8.4
       zod:
         specifier: ^4.4.2
         version: 4.4.2
@@ -41,7 +41,7 @@ importers:
         version: 7.7.1
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(typescript@6.0.3)(yaml@2.8.3)
+        version: 8.5.1(typescript@6.0.3)(yaml@2.8.4)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -745,8 +745,8 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -1157,11 +1157,11 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(yaml@2.8.3):
+  postcss-load-config@6.0.1(yaml@2.8.4):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      yaml: 2.8.3
+      yaml: 2.8.4
 
   readdirp@4.1.2: {}
 
@@ -1254,7 +1254,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(typescript@6.0.3)(yaml@2.8.3):
+  tsup@8.5.1(typescript@6.0.3)(yaml@2.8.4):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -1265,7 +1265,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(yaml@2.8.3)
+      postcss-load-config: 6.0.1(yaml@2.8.4)
       resolve-from: 5.0.0
       rollup: 4.46.2
       source-map: 0.7.6
@@ -1303,6 +1303,6 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
-  yaml@2.8.3: {}
+  yaml@2.8.4: {}
 
   zod@4.4.2: {}


### PR DESCRIPTION
## Package Updates

- yaml: [2.8.3 -> 2.8.4](https://github.com/eemeli/yaml/releases/tag/v2.8.4)
  - Disable alias resolution with `maxAliasCount:0` (#677)
  - Handle invalid unicode escapes
  - Apply `minFractionDigits` only to decimal strings (#676)

## Code Changes

Patch version with no breaking changes or code modifications required.

## Checks

- ✅ Checked changelog for breaking changes
- ✅ Lint passes after upgrade
- ✅ All tests pass after upgrade (568 passed)
- ✅ Codegen ran successfully
- ✅ No code modifications were necessary