### PR TITLE
Format cert expiry dates as ISO 8601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 
+- `certs list` now displays expiry dates in ISO 8601 (`YYYY-MM-DD`) format instead of locale-dependent format
 - Upgraded `@biomejs/biome` from 2.4.12 to 2.4.14
 - Upgraded `zod` from 4.3.6 to 4.4.2
 - Upgraded `yaml` from 2.8.3 to 2.8.4

--- a/src/commands/certs/list.ts
+++ b/src/commands/certs/list.ts
@@ -168,7 +168,7 @@ export const certsListCommand = new Command({
         {
           header: 'Expires',
           accessor: (e) =>
-            e.depth === 0 ? e.expires.toLocaleDateString() : '',
+            e.depth === 0 ? e.expires.toISOString().slice(0, 10) : '',
         },
         {
           header: 'Status',


### PR DESCRIPTION
## Summary

- `denvig certs list` was rendering certificate expiry via `Date.toLocaleDateString()`, which produces locale-dependent output (American `MM/DD/YYYY` on US-locale systems).
- Switched to `toISOString().slice(0, 10)` so dates render as `YYYY-MM-DD` regardless of locale, matching the ISO 8601 convention used elsewhere in the codebase (CHANGELOG, dependency release dates, logs).

## Test plan

- [x] `pnpm run test` — all 568 tests pass
- [x] `pnpm run codegen` — schemas regenerated cleanly
- [x] `pnpm run build` — build succeeds
- [x] `bin/denvig-dev version` — CLI runs
- [x] Run `denvig certs list` against a project with local certs and confirm the Expires column shows `YYYY-MM-DD`