### PR TITLE
Show relative expiry with color in certs list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@
 - `system setup <url>` command to clone a dotfiles repository to `~/.dotfiles` and run its `setup` action
 - `system update` command to pull dotfiles, run the `update` action, refresh Homebrew packages, and run `skills update -g` when available
 - `system configure` command to interactively check and enable common macOS setup steps: sudo Touch ID, FileVault, Xcode Command Line Tools, Homebrew, dotfiles, and global git config
+- `certs list` Expires column now shows relative time (e.g. `2026-08-15 (3mo)`) and is colored green when over a week from expiry, yellow when within a week, and red when within a day or already expired
 
 ### Changed
 
 - `certs list` now displays expiry dates in ISO 8601 (`YYYY-MM-DD`) format instead of locale-dependent format
+- `relativeFormattedTime` now returns the magnitude of the difference for both past and future dates instead of `0s` for future dates
 - Upgraded `@biomejs/biome` from 2.4.12 to 2.4.14
 - Upgraded `zod` from 4.3.6 to 4.4.2
 - Upgraded `yaml` from 2.8.3 to 2.8.4

--- a/src/commands/certs/list.ts
+++ b/src/commands/certs/list.ts
@@ -13,7 +13,18 @@ import {
   parseCertDomains,
 } from '../../lib/certs.ts'
 import { Command } from '../../lib/command.ts'
+import { relativeFormattedTime } from '../../lib/formatters/relative-time.ts'
 import { COLORS, formatTable } from '../../lib/formatters/table.ts'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const WEEK_MS = 7 * DAY_MS
+
+const expiryColor = (expires: Date, now: Date = new Date()): string => {
+  const diffMs = expires.getTime() - now.getTime()
+  if (diffMs < DAY_MS) return COLORS.red
+  if (diffMs < WEEK_MS) return COLORS.yellow
+  return COLORS.green
+}
 
 type CertEntry = {
   dir: string
@@ -167,8 +178,19 @@ export const certsListCommand = new Command({
         { header: 'Certificate', accessor: (e) => e.name },
         {
           header: 'Expires',
-          accessor: (e) =>
-            e.depth === 0 ? e.expires.toISOString().slice(0, 10) : '',
+          accessor: (e) => {
+            if (e.depth !== 0) return ''
+            const iso = e.expires.toISOString().slice(0, 10)
+            return `${iso} (${relativeFormattedTime(e.expires.toISOString())})`
+          },
+          format: (value, row) => {
+            if (row.depth !== 0) return value
+            const trimmed = value.trimEnd()
+            if (!trimmed) return value
+            const color = expiryColor(row.expires)
+            const padding = ' '.repeat(value.length - trimmed.length)
+            return `${color}${trimmed}${COLORS.reset}${padding}`
+          },
         },
         {
           header: 'Status',

--- a/src/lib/formatters/relative-time.test.ts
+++ b/src/lib/formatters/relative-time.test.ts
@@ -53,7 +53,10 @@ describe('relativeFormattedTime()', () => {
     strictEqual(relativeFormattedTime('2026-03-31T12:00:00.000Z', now), '3w')
   })
 
-  it('should return 0s for future dates', () => {
-    strictEqual(relativeFormattedTime('2026-04-21T12:00:00.000Z', now), '0s')
+  it('should return the magnitude for future dates', () => {
+    strictEqual(relativeFormattedTime('2026-04-20T12:00:30.000Z', now), '30s')
+    strictEqual(relativeFormattedTime('2026-04-20T13:00:00.000Z', now), '1h')
+    strictEqual(relativeFormattedTime('2026-04-21T12:00:00.000Z', now), '1d')
+    strictEqual(relativeFormattedTime('2026-04-27T12:00:00.000Z', now), '1w')
   })
 })

--- a/src/lib/formatters/relative-time.ts
+++ b/src/lib/formatters/relative-time.ts
@@ -1,5 +1,6 @@
 /**
  * Format a date as a short relative time string.
+ * Returns the magnitude of the difference, regardless of whether the date is past or future.
  * Examples: "1h", "3d", "4w", "2mo", "1y"
  */
 export const relativeFormattedTime = (
@@ -7,9 +8,7 @@ export const relativeFormattedTime = (
   now: Date = new Date(),
 ): string => {
   const date = new Date(isoDate)
-  const diffMs = now.getTime() - date.getTime()
-
-  if (diffMs < 0) return '0s'
+  const diffMs = Math.abs(now.getTime() - date.getTime())
 
   const seconds = diffMs / 1000
   const minutes = seconds / 60


### PR DESCRIPTION
## Summary

- `denvig certs list` Expires column now shows a relative time tag alongside the ISO date (e.g. `2026-08-15 (3mo)`), matching the style used by `deps outdated`.
- The cell is colored based on time-to-expiry: green when more than a week away, yellow within a week, red within a day or already expired.
- `relativeFormattedTime` now returns the magnitude of the difference for both past and future dates (previously returned `0s` for any future date) so it can be reused for forward-looking displays. Test updated accordingly.

## Test plan

- [x] `pnpm run test` — all 568 tests pass
- [x] `pnpm run codegen` — schemas regenerated cleanly
- [x] `pnpm run build` — build succeeds
- [x] Verified `denvig certs list` output renders with green/yellow correctly against real local certs (caught a cert expiring in 6 days flipping to yellow)
- [x] Verify red coloring on a cert within 1 day of expiry / already expired