### PR TITLE
Warn about expiring certs in deps outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `system update` command to pull dotfiles, run the `update` action, refresh Homebrew packages, and run `skills update -g` when available
 - `system configure` command to interactively check and enable common macOS setup steps: sudo Touch ID, FileVault, Xcode Command Line Tools, Homebrew, dotfiles, and global git config
 - `certs list` Expires column now shows relative time (e.g. `2026-08-15 (3mo)`) and is colored green when over a week from expiry, yellow when within a week, and red when within a day or already expired
+- `deps outdated` now prints a yellow warning at the end when one or more managed certificates are due to expire within a week, prompting the user to run `denvig certs` for details
 
 ### Changed
 

--- a/src/commands/certs/list.ts
+++ b/src/commands/certs/list.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import {
+  findCertFile,
   getCaCertPath,
   getCertExpiry,
   getCertIssuerCN,
@@ -41,20 +42,6 @@ type CertRow = {
   isLast: boolean
   hasChildren: boolean
   parentPath: boolean[]
-}
-
-const findCertFile = (dir: string): string | null => {
-  const fullchain = resolve(dir, 'fullchain.pem')
-  const cert = resolve(dir, 'cert.pem')
-  try {
-    statSync(fullchain)
-    return fullchain
-  } catch {}
-  try {
-    statSync(cert)
-    return cert
-  } catch {}
-  return null
 }
 
 export const certsListCommand = new Command({

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -1,3 +1,4 @@
+import { countCertsExpiringWithin } from '../../lib/certs.ts'
 import { Command } from '../../lib/command.ts'
 import { parseDuration } from '../../lib/formatters/duration.ts'
 import { relativeFormattedTime } from '../../lib/formatters/relative-time.ts'
@@ -7,6 +8,18 @@ import {
   getSemverLevel,
   outdatedMatchesSemverFilter,
 } from '../../lib/semver.ts'
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+const printExpiringCertsWarning = (): void => {
+  const count = countCertsExpiringWithin(ONE_WEEK_MS)
+  if (count === 0) return
+  const noun = count === 1 ? 'certificate is' : 'certificates are'
+  console.log('')
+  console.log(
+    `${COLORS.yellow}${count} ${noun} due to expire. Run denvig certs for details.${COLORS.reset}`,
+  )
+}
 
 /**
  * Get the color for a version update based on semver difference.
@@ -203,6 +216,7 @@ export const depsOutdatedCommand = new Command({
           message = `No ${semverFilter}-level updates available.`
         }
         console.log(message)
+        printExpiringCertsWarning()
       }
       let message = 'All dependencies are up to date!'
       if (ecosystemFilter && semverFilter) {
@@ -334,6 +348,8 @@ export const depsOutdatedCommand = new Command({
     for (const line of lines) {
       console.log(line)
     }
+
+    printExpiringCertsWarning()
 
     return { success: true, message: 'Outdated dependencies listed.' }
   },

--- a/src/lib/certs.ts
+++ b/src/lib/certs.ts
@@ -1,5 +1,6 @@
 import { execSync, spawnSync } from 'node:child_process'
 import { X509Certificate } from 'node:crypto'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -347,4 +348,59 @@ export const getCertIssuerCN = (certPem: string): string | null => {
 const generateSerialNumber = async (): Promise<string> => {
   const forge = await importNodeForge()
   return forge.util.bytesToHex(forge.random.getBytesSync(16))
+}
+
+/**
+ * Find the certificate file (fullchain.pem or cert.pem) inside a cert directory.
+ * Returns null if neither exists.
+ */
+export const findCertFile = (dir: string): string | null => {
+  const fullchain = resolve(dir, 'fullchain.pem')
+  const cert = resolve(dir, 'cert.pem')
+  try {
+    statSync(fullchain)
+    return fullchain
+  } catch {}
+  try {
+    statSync(cert)
+    return cert
+  } catch {}
+  return null
+}
+
+/**
+ * Count managed certificates whose expiry is at or before `now + durationMs`.
+ * Already-expired certificates are included in the count.
+ * Returns 0 if the certs directory is missing or unreadable.
+ */
+export const countCertsExpiringWithin = (
+  durationMs: number,
+  now: Date = new Date(),
+): number => {
+  const certsDir = getCertsDir()
+  let dirs: string[]
+  try {
+    dirs = readdirSync(certsDir).filter((name) => {
+      try {
+        return statSync(resolve(certsDir, name)).isDirectory()
+      } catch {
+        return false
+      }
+    })
+  } catch {
+    return 0
+  }
+
+  const threshold = now.getTime() + durationMs
+  let count = 0
+  for (const dir of dirs) {
+    const certFile = findCertFile(resolve(certsDir, dir))
+    if (!certFile) continue
+    try {
+      const pem = readFileSync(certFile, 'utf-8')
+      const expires = getCertExpiry(pem)
+      if (expires.getTime() <= threshold) count++
+    } catch {}
+  }
+  return count
 }


### PR DESCRIPTION
## Summary

- `denvig deps outdated` now prints a yellow warning at the end of its output when one or more managed certificates are due to expire within the next week (already-expired certs included): `{count} certificate(s) {is|are} due to expire. Run denvig certs for details.`
- Warning is printed in both the "all up to date" and table-rendered paths, but suppressed under `--json` to keep machine-readable output clean.
- Extracted `findCertFile` from `certs/list.ts` into `lib/certs.ts` and added a new `countCertsExpiringWithin(durationMs, now?)` helper so the scan can be shared between the two commands.

## Test plan

- [x] `pnpm run check-types` — clean
- [x] `pnpm run test` — all 568 tests pass
- [x] `pnpm run build` — build succeeds
- [x] Verified `denvig deps outdated` prints the yellow warning against real local certs (1 cert flagged as expiring within a week)
- [x] Verify `--json` output is unchanged (no warning embedded)
- [x] Verify the warning is absent when no certs are nearing expiry