### PR TITLE
Continue through failures in system update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 ### Changed
 
-- `system update` now continues through all steps when one fails, printing each step header as it runs and a succeeded/failed summary at the end
 - `certs list` now displays expiry dates in ISO 8601 (`YYYY-MM-DD`) format instead of locale-dependent format
 - `relativeFormattedTime` now returns the magnitude of the difference for both past and future dates instead of `0s` for future dates
 - Upgraded `@biomejs/biome` from 2.4.12 to 2.4.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
+- `system update` now continues through all steps when one fails, printing each step header as it runs and a succeeded/failed summary at the end
 - `certs list` now displays expiry dates in ISO 8601 (`YYYY-MM-DD`) format instead of locale-dependent format
 - `relativeFormattedTime` now returns the magnitude of the difference for both past and future dates instead of `0s` for future dates
 - Upgraded `@biomejs/biome` from 2.4.12 to 2.4.14

--- a/src/commands/system/update.ts
+++ b/src/commands/system/update.ts
@@ -2,6 +2,7 @@ import { homedir } from 'node:os'
 import path from 'node:path'
 
 import { Command } from '../../lib/command.ts'
+import { COLORS } from '../../lib/formatters/table.ts'
 import { gitPull, isWorkingTreeDirty } from '../../lib/git.ts'
 import { confirm } from '../../lib/input.ts'
 import { prettyPath } from '../../lib/path.ts'
@@ -13,6 +14,12 @@ import {
 } from '../../lib/system/brew.ts'
 import { runDenvig } from '../../lib/system/denvig.ts'
 import { hasSkillsCli, skillsUpdateGlobal } from '../../lib/system/skills.ts'
+
+type StepResult = {
+  name: string
+  success: boolean
+  message?: string
+}
 
 export const systemUpdateCommand = new Command({
   name: 'system:update',
@@ -31,35 +38,58 @@ export const systemUpdateCommand = new Command({
       return { success: false, message: 'Dotfiles directory missing' }
     }
 
-    console.log(`Updating ${prettyPath(dotfilesPath)}...`)
+    const results: StepResult[] = []
 
-    if (await isWorkingTreeDirty(dotfilesPath)) {
-      console.warn(
-        `Warning: ${prettyPath(dotfilesPath)} has uncommitted changes`,
-      )
+    const runStep = async (
+      name: string,
+      fn: () => Promise<{ success: boolean; message?: string }>,
+    ): Promise<boolean> => {
+      console.log('')
+      console.log(`${COLORS.bold}==> ${name}${COLORS.reset}`)
+      try {
+        const result = await fn()
+        results.push({ name, ...result })
+        return result.success
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        console.error(`Error: ${message}`)
+        results.push({ name, success: false, message })
+        return false
+      }
     }
 
-    const pulled = await gitPull(dotfilesPath)
-    if (!pulled) {
-      return { success: false, message: 'git pull failed' }
-    }
+    await runStep(`Pull dotfiles (${prettyPath(dotfilesPath)})`, async () => {
+      if (await isWorkingTreeDirty(dotfilesPath)) {
+        console.warn(
+          `Warning: ${prettyPath(dotfilesPath)} has uncommitted changes`,
+        )
+      }
+      const ok = await gitPull(dotfilesPath)
+      return ok
+        ? { success: true }
+        : { success: false, message: 'git pull failed' }
+    })
 
-    console.log('')
-    console.log(`Running denvig update in ${prettyPath(dotfilesPath)}...`)
-    const updated = await runDenvig(dotfilesPath, ['run', 'update'])
-    if (!updated) {
-      return { success: false, message: 'Update action failed' }
-    }
+    await runStep('Run dotfiles update action', async () => {
+      const ok = await runDenvig(dotfilesPath, ['run', 'update'])
+      return ok
+        ? { success: true }
+        : { success: false, message: 'denvig run update failed' }
+    })
 
-    console.log('')
-    console.log('Updating Homebrew...')
-    await brewUpdate()
+    await runStep('Update Homebrew', async () => {
+      const ok = await brewUpdate()
+      return ok
+        ? { success: true }
+        : { success: false, message: 'brew update failed' }
+    })
 
     const outdated = await getBrewOutdated()
     const formulae = outdated?.formulae ?? []
     const casks = outdated?.casks ?? []
     const totalOutdated = formulae.length + casks.length
 
+    console.log('')
     if (totalOutdated === 0) {
       console.log('All Homebrew packages are up to date')
     } else {
@@ -77,22 +107,41 @@ export const systemUpdateCommand = new Command({
 
       const shouldUpgrade = await confirm('Run `brew upgrade`?')
       if (shouldUpgrade) {
-        const upgraded = await brewUpgrade()
-        if (!upgraded) {
-          return { success: false, message: 'brew upgrade failed' }
-        }
+        await runStep('Upgrade Homebrew packages', async () => {
+          const ok = await brewUpgrade()
+          return ok
+            ? { success: true }
+            : { success: false, message: 'brew upgrade failed' }
+        })
       }
     }
 
     if (await hasSkillsCli()) {
-      console.log('')
-      console.log('Updating skills...')
-      const skillsOk = await skillsUpdateGlobal()
-      if (!skillsOk) {
-        return { success: false, message: 'skills update failed' }
-      }
+      await runStep('Update skills', async () => {
+        const ok = await skillsUpdateGlobal()
+        return ok
+          ? { success: true }
+          : { success: false, message: 'skills update failed' }
+      })
     }
 
+    const failed = results.filter((r) => !r.success)
+
+    console.log('')
+    console.log(`${COLORS.bold}Summary${COLORS.reset}`)
+    for (const r of results) {
+      const icon = r.success
+        ? `${COLORS.green}✓${COLORS.reset}`
+        : `${COLORS.red}✗${COLORS.reset}`
+      console.log(`${icon} ${r.name}`)
+    }
+
+    if (failed.length > 0) {
+      return {
+        success: false,
+        message: `${failed.length} of ${results.length} steps failed`,
+      }
+    }
     return { success: true, message: 'System update complete' }
   },
 })


### PR DESCRIPTION
## Summary

- `denvig system update` now runs every step independently. A failure (e.g. a dirty dotfiles git tree halting `git pull`) no longer aborts the rest of the run — Homebrew and skills updates still get a chance.
- Each step prints a `==> <name>` header before it runs so the active step is obvious.
- A summary at the end lists each step with a green check or red cross, left-aligned.
- The command exits non-zero when any step failed.

## Test plan

- [x] `pnpm run test`
- [x] `pnpm run build`
- [x] `bin/denvig-dev version`
- [x] Manual: run `denvig system update` with a dirty `~/.dotfiles` tree and confirm subsequent steps still execute and the summary marks the dotfiles step as failed