### PR TITLE
Default deps outdated release latency to 24h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
+
 ## [0.6.6] - 2026-05-02
 
 ### Added

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -91,7 +91,7 @@ export const depsOutdatedCommand = new Command({
     {
       name: 'release-latency',
       description:
-        'Only show updates released longer ago than this duration (e.g., "3h", "7d", "2w"). Use "auto" to read from pnpm minimumReleaseAge, or "0" to disable.',
+        'Only show updates released longer ago than this duration (e.g., "3h", "7d", "2w"). Use "auto" to read from pnpm minimumReleaseAge with a 24h fallback, or "0" to disable.',
       required: false,
       type: 'string',
       defaultValue: 'auto',
@@ -152,11 +152,13 @@ export const depsOutdatedCommand = new Command({
       // Explicitly disabled
       releaseLatencyMs = null
     } else if (latencyValue === 'auto') {
-      // Read from pnpm-workspace.yaml if available
+      // Read from pnpm-workspace.yaml if available, otherwise default to 24h
       const pnpmConfig = await readPnpmReleaseAgeConfig(project.path)
       if (pnpmConfig) {
         releaseLatencyMs = pnpmConfig.minimumReleaseAgeMs
         releaseLatencyExclude = pnpmConfig.exclude
+      } else {
+        releaseLatencyMs = 24 * 60 * 60 * 1000
       }
     } else {
       releaseLatencyMs = parseDuration(latencyValue)


### PR DESCRIPTION
## Summary

- `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
- Pass `--release-latency 0` to disable the filter (existing behaviour).
- When `pnpm-workspace.yaml` sets `minimumReleaseAge`, that value is still used as before.

## Test plan

- [x] `bin/denvig-dev deps outdated` in a project without `minimumReleaseAge` hides updates released within the last 24h
- [x] `bin/denvig-dev deps outdated --release-latency 0` shows all updates
- [x] `bin/denvig-dev deps outdated` in a project with `minimumReleaseAge` set respects the configured value