### PR TITLE
Add pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
+allowBuilds:
+  esbuild: false


### PR DESCRIPTION
## Summary
- Add `pnpm-workspace.yaml` setting `minimumReleaseAge` to 1440 minutes (24h) with strict enforcement to mitigate supply chain risk from freshly published package versions.
- Disable build scripts for `esbuild` via `allowBuilds`.

## Test plan
- [x] `pnpm install` runs successfully with the new workspace config
- [x] `pnpm run test` passes
- [x] `pnpm run build` succeeds and `bin/denvig-dev version` works