### PR TITLE
Test against Node 26 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         node-version:
           - 22
           - 24
-          - 25
+          - 26
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 - `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
+- CI now tests against Node 26 instead of Node 25.
 
 ## [0.6.6] - 2026-05-02
 


### PR DESCRIPTION
## Summary
- Bump CI Node matrix from 25 to 26 to track the latest release line
- Note the change in the `[Unreleased]` section of CHANGELOG.md
- Update the `Enforce PRs` branch ruleset so the required status check matches the new matrix entry

## Branch ruleset update (audit reference)

The ruleset (id `7138058`) on `~DEFAULT_BRANCH` had `build (25)` pinned as a required status check. It was replaced with `build (26)` via:

```bash
# Apply update (full PUT body — PATCH returned 404 on this endpoint)
gh api -X PUT /repos/marcqualie/denvig/rulesets/7138058 --input - <<'JSON'
{
  "name": "Enforce PRs",
  "target": "branch",
  "enforcement": "active",
  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
  "bypass_actors": [
    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
  ],
  "rules": [
    {
      "type": "pull_request",
      "parameters": {
        "required_approving_review_count": 0,
        "dismiss_stale_reviews_on_push": false,
        "require_code_owner_review": false,
        "require_last_push_approval": false,
        "required_review_thread_resolution": false,
        "allowed_merge_methods": ["squash"]
      }
    },
    {
      "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": false,
        "do_not_enforce_on_create": false,
        "required_status_checks": [
          { "context": "build (22)", "integration_id": 15368 },
          { "context": "build (24)", "integration_id": 15368 },
          { "context": "build (26)", "integration_id": 15368 }
        ]
      }
    }
  ]
}
JSON
```

## Test plan
- [x] CI matrix job for Node 26 passes
- [x] Existing Node 22 and 24 jobs continue to pass
- [x] Branch ruleset shows `build (26)` as a required status check