### PR TITLE
Upgrade zod from 4.4.2 to 4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
 - CI now tests against Node 26 instead of Node 25.
+- Upgraded `zod` from 4.4.2 to 4.4.3
 
 ## [0.6.6] - 2026-05-02
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node-forge": "^1.4.0",
     "semver": "^7.7.4",
     "yaml": "^2.8.4",
-    "zod": "^4.4.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.8.4
         version: 2.8.4
       zod:
-        specifier: ^4.4.2
-        version: 4.4.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.14
@@ -750,8 +750,8 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  zod@4.4.2:
-    resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1305,4 +1305,4 @@ snapshots:
 
   yaml@2.8.4: {}
 
-  zod@4.4.2: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
## Package Updates

- zod: [4.4.2 -> 4.4.3](https://github.com/colinhacks/zod/compare/v4.4.2...v4.4.3)
  - Restore catch handling for absent object keys (#5937, #5939)
  - Generalize optin/fallback to transform; restore preprocess on absent keys (#5941)

## Code Changes

Patch version with no breaking changes; no code modifications required.

## Checks

- ✅ Checked changelog for breaking changes
- ✅ Lint passes after upgrade
- ✅ Build succeeds and `bin/denvig-dev version` works
- ✅ Test failures are pre-existing and unrelated to zod