### PR TITLE
Replace minimist with node:util parseArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
 - CI now tests against Node 26 instead of Node 25.
 - Upgraded `zod` from 4.4.2 to 4.4.3
+- Replaced `minimist` with the built-in `node:util` `parseArgs` for argument parsing. Command flag definitions can now declare a `short` alias (e.g. `services logs -n` for `--lines`).
 
 ## [0.6.6] - 2026-05-02
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "minimist": "^1.2.8",
     "node-forge": "^1.4.0",
     "semver": "^7.7.4",
     "yaml": "^2.8.4",
@@ -47,7 +46,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
-    "@types/minimist": "^1.2.5",
     "@types/node": "^25",
     "@types/node-forge": "^1.3.14",
     "@types/semver": "^7.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      minimist:
-        specifier: ^1.2.8
-        version: 1.2.8
       node-forge:
         specifier: ^1.4.0
         version: 1.4.0
@@ -27,9 +24,6 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.14
         version: 2.4.14
-      '@types/minimist':
-        specifier: ^1.2.5
-        version: 1.2.5
       '@types/node':
         specifier: ^25
         version: 25.6.0
@@ -396,9 +390,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/minimist@1.2.5':
-    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
-
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
@@ -555,9 +546,6 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -956,8 +944,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/minimist@1.2.5': {}
-
   '@types/node-forge@1.3.14':
     dependencies:
       '@types/node': 25.6.0
@@ -1110,8 +1096,6 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
-
-  minimist@1.2.8: {}
 
   minipass@7.1.2: {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import parseArgs from 'minimist'
+import { type ParseArgsConfig, parseArgs } from 'node:util'
 
 import {
   globalFlags,
@@ -18,14 +18,29 @@ import { getDenvigVersion } from './lib/version.ts'
 
 import type { GenericCommand } from './lib/command.ts'
 
+type ParseArgsOptions = NonNullable<ParseArgsConfig['options']>
+
 // Main CLI execution
 async function main() {
   let commandName = process.argv[2]
   let args = process.argv.slice(2)
-  const rootFlags = parseArgs(args)
+
+  // Initial lenient parse for root-level flags. Unknown flags are tolerated
+  // because the command (and its flag schema) hasn't been resolved yet.
+  const rootResult = parseArgs({
+    args,
+    options: {
+      version: { type: 'boolean', short: 'v' },
+      help: { type: 'boolean', short: 'h' },
+      project: { type: 'string' },
+    },
+    strict: false,
+    allowPositionals: true,
+  })
+  const rootFlags = rootResult.values
 
   // Handle root-level --version/-v
-  if (rootFlags.version || rootFlags.v) {
+  if (rootFlags.version) {
     console.log(`v${getDenvigVersion()}`)
     process.exit(0)
   }
@@ -33,7 +48,8 @@ async function main() {
   // Detect project from current directory or --project flag
   const globalConfig = await getGlobalConfig()
   const currentDir = process.cwd()
-  const projectFlag = parseArgs(process.argv.slice(2)).project?.toString()
+  const projectFlag =
+    typeof rootFlags.project === 'string' ? rootFlags.project : undefined
 
   // Find project path: either from flag, or detect from current directory
   let projectPath: string | null = null
@@ -132,7 +148,7 @@ async function main() {
   }
 
   // Handle --help or -h at root level (no valid command provided)
-  if ((rootFlags.help || rootFlags.h) && !commands[commandName]) {
+  if (rootFlags.help && !commands[commandName]) {
     showRootHelp(commands)
     await cliLogTracker.finish(0, 'Showed help')
     process.exit(0)
@@ -147,7 +163,7 @@ async function main() {
 
   // Resolve subcommands: walk the command tree consuming from args
   // args[0] is command name, args[1..] are potential subcommands/arguments
-  const helpRequested = rootFlags.help || rootFlags.h
+  const helpRequested = !!rootFlags.help
   let command = commands[commandName]
   let subArgIndex = 1
   while (command.hasSubcommands) {
@@ -166,8 +182,6 @@ async function main() {
   // Rebuild args: keep the root command name, then any unconsumed args
   args = [args[0], ...args.slice(subArgIndex)]
 
-  const flags = parseArgs(args)
-
   // If help is requested, show appropriate help
   if (helpRequested) {
     if (command.hasSubcommands) {
@@ -179,13 +193,37 @@ async function main() {
     process.exit(0)
   }
 
-  // Parse command arguments
+  // Build options config from the resolved command's flags so parseArgs can
+  // distinguish known options (with their types and short aliases) from
+  // unknown ones (which still parse leniently via strict: false).
+  const allFlags = [...globalFlags, ...(command?.flags || [])]
+  const optionsConfig: ParseArgsOptions = {
+    help: { type: 'boolean', short: 'h' },
+    version: { type: 'boolean', short: 'v' },
+  }
+  for (const flag of allFlags) {
+    const short = 'short' in flag ? flag.short : undefined
+    optionsConfig[flag.name] = {
+      type: flag.type === 'boolean' ? 'boolean' : 'string',
+      ...(short ? { short } : {}),
+    }
+  }
+
+  const result = parseArgs({
+    args,
+    options: optionsConfig,
+    strict: false,
+    allowPositionals: true,
+    tokens: true,
+  })
+
+  // Parse command arguments from positionals (skipping the command name itself)
   const parsedArgs: Record<string, string | number> = {}
   let missingArg: string | null = null
   for (const [index, arg] of (command?.args || []).entries()) {
-    const value = flags._[index + 1]
+    const value = result.positionals[index + 1]
     if (value !== undefined) {
-      parsedArgs[arg.name] = value
+      parsedArgs[arg.name] = arg.type === 'number' ? Number(value) : value
     } else if (arg.required) {
       missingArg = arg.name
       break
@@ -198,19 +236,18 @@ async function main() {
     process.exit(1)
   }
 
-  // Extract extra arguments that weren't consumed by the command definition
-  const extraPositionalArgs =
-    flags._.slice(command?.args.length + 1).map((arg) => String(arg)) || []
-
-  const allFlags = [...globalFlags, ...(command?.flags || [])]
   const recognizedFlagNames = new Set(allFlags.map((flag) => flag.name))
 
-  // Parse command flags
+  // Parse command flags, applying defaults and number coercion
   const parsedFlags: Record<string, string | number | boolean> = {}
   let missingFlag: string | null = null
   for (const flag of allFlags) {
-    if (flags[flag.name] !== undefined) {
-      parsedFlags[flag.name] = flags[flag.name]
+    const value = result.values[flag.name]
+    if (value !== undefined) {
+      parsedFlags[flag.name] =
+        flag.type === 'number' && typeof value === 'string'
+          ? Number(value)
+          : value
     } else if (flag.defaultValue !== undefined) {
       parsedFlags[flag.name] = flag.defaultValue
     } else if (flag.required) {
@@ -225,22 +262,34 @@ async function main() {
     process.exit(1)
   }
 
-  // Extract unrecognized flags and convert them to command line arguments
-  const extraFlagArgs: string[] = []
-  for (const [key, value] of Object.entries(flags)) {
-    if (key !== '_' && !recognizedFlagNames.has(key)) {
-      if (value === true) {
-        extraFlagArgs.push(`--${key}`)
-      } else if (value === false) {
-        extraFlagArgs.push(`--no-${key}`)
+  // Walk tokens in original order to collect anything not consumed by the
+  // command's defined args/flags. This preserves the order users typed so
+  // forwarded subprocesses receive arguments as expected.
+  const definedArgsCount = command?.args.length || 0
+  const extraArgs: string[] = []
+  let positionalIndex = 0
+  for (const token of result.tokens ?? []) {
+    if (token.kind === 'positional') {
+      // Skip the command name (index 0) and any defined args
+      if (positionalIndex > definedArgsCount) {
+        extraArgs.push(token.value)
+      }
+      positionalIndex++
+    } else if (token.kind === 'option') {
+      if (recognizedFlagNames.has(token.name)) continue
+      if (token.name === 'help' || token.name === 'version') continue
+      const rawName = token.rawName ?? `--${token.name}`
+      if (token.value !== undefined) {
+        if (token.inlineValue) {
+          extraArgs.push(`${rawName}=${token.value}`)
+        } else {
+          extraArgs.push(rawName, token.value)
+        }
       } else {
-        extraFlagArgs.push(`--${key}`, String(value))
+        extraArgs.push(rawName)
       }
     }
   }
-
-  // Combine extra positional args and extra flag args
-  const extraArgs = [...extraPositionalArgs, ...extraFlagArgs]
 
   try {
     if (!project) {

--- a/src/commands/services/logs.ts
+++ b/src/commands/services/logs.ts
@@ -27,6 +27,7 @@ export const logsCommand = new Command({
       required: false,
       type: 'number',
       defaultValue: 10,
+      short: 'n',
     },
     {
       name: 'follow',
@@ -45,8 +46,7 @@ export const logsCommand = new Command({
       nameArg,
       project,
     )
-    // Support alias `-n` through `flags.n` for compatibility with common CLI usage
-    const lines = (flags.lines as number) ?? (flags.n as number) ?? 10
+    const lines = (flags.lines as number) ?? 10
     const follow = !!flags.follow
 
     const logPath = manager.getLogPath(name)

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -33,6 +33,7 @@ type FlagDefinition = {
   required: boolean
   type: 'string' | 'number' | 'boolean' | 'array'
   defaultValue?: string | number | boolean
+  short?: string
 }
 
 type CommandResponse = {


### PR DESCRIPTION
## Summary

- Drops the `minimist` (and `@types/minimist`) dependency in favour of the built-in `node:util` `parseArgs`. Node 22+ is already the minimum supported runtime, so no shim is needed.
- Builds the `parseArgs` options schema dynamically from each command's flag definitions, then walks `tokens` to preserve original argument order when forwarding extras to subprocesses (e.g. `denvig run lint -- ...`).
- Adds an optional `short` field to flag definitions and uses it for `services logs --lines`/`-n` instead of relying on minimist's implicit short-name access via `flags.n`.

## Test plan

- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` — only pre-existing failures (`run.test.ts` lint match and `pnpm/actions` stderr) reproduce on `main`
- [x] `bin/denvig-dev version` / `--version` / `-v`
- [x] `bin/denvig-dev --help` and per-command `--help`
- [x] `bin/denvig-dev deps list --depth 1` (number flag coercion)
- [x] `bin/denvig-dev deps outdated --no-cache`
- [x] `bin/denvig-dev run lint --some-extra-flag` (extra-arg forwarding)