### PR TITLE
Improve deps why output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed
 
-- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping). Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white; other entries default to grey, and packages with available updates are colored green (patch), yellow (minor), or red (major).
+- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping). Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white and other entries default to grey. Packages with available updates show the wanted/latest versions in brackets next to the resolved version (e.g. `express 4.21.2 (5.2.1)`), each colored green (patch), yellow (minor), or red (major).
 - `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
 - CI now tests against Node 26 instead of Node 25.
 - Upgraded `zod` from 4.4.2 to 4.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Changed
 
-- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping). Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white and other entries default to grey. Packages with available updates show the wanted/latest versions in brackets next to the resolved version (e.g. `express 4.21.2 (5.2.1)`), each colored green (patch), yellow (minor), or red (major). The outdated check now walks the dependency tree deep enough to cover every occurrence of the queried package, so transitive dependencies (like `qs` under `body-parser`) report update info too.
+- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping). Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white and other entries default to grey.
+- `deps why <package> --check-versions` opts into a registry lookup that annotates each entry with available wanted/latest versions in brackets (e.g. `express 4.21.2 (5.2.1)`), colored green (patch), yellow (minor), or red (major). The check walks the dependency tree deep enough to cover every occurrence of the queried package, so transitive dependencies report update info too. Default behaviour stays instant by skipping the registry lookup.
 - `outdatedDependencies` now accepts a `depth` option (default `0`, meaning direct dependencies only). When `depth > 0`, the check walks transitive dependencies up to that depth via the new `filterDependenciesByDepth` helper.
 - `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
 - CI now tests against Node 26 instead of Node 25.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 ### Changed
 
-- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping). Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white and other entries default to grey.
-- `deps why <package> --check-versions` opts into a registry lookup that annotates each entry with available wanted/latest versions in brackets (e.g. `express 4.21.2 (5.2.1)`), colored green (patch), yellow (minor), or red (major). The check walks the dependency tree deep enough to cover every occurrence of the queried package, so transitive dependencies report update info too. Default behaviour stays instant by skipping the registry lookup.
+- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping) sorted alphabetically at every depth. Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white and other entries default to grey.
+- `deps why <package>` now performs a single registry lookup for the queried package by default and annotates its tree entries with the latest available version in brackets (e.g. `express 4.21.2 (5.2.1)`), colored green (patch), yellow (minor), or red (major). The lookup covers npm, jsr, PyPI, and RubyGems ecosystems.
+- `deps why <package> --check-all-versions` extends that annotation to every entry in the tree by walking the dependency tree deep enough to cover every occurrence of the queried package, so transitive dependencies report update info too. Off by default since it issues many registry calls.
 - `outdatedDependencies` now accepts a `depth` option (default `0`, meaning direct dependencies only). When `depth > 0`, the check walks transitive dependencies up to that depth via the new `filterDependenciesByDepth` helper.
 - `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
 - CI now tests against Node 26 instead of Node 25.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping). Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white; other entries default to grey, and packages with available updates are colored green (patch), yellow (minor), or red (major).
 - `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
 - CI now tests against Node 26 instead of Node 25.
 - Upgraded `zod` from 4.4.2 to 4.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Changed
 
-- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping). Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white and other entries default to grey. Packages with available updates show the wanted/latest versions in brackets next to the resolved version (e.g. `express 4.21.2 (5.2.1)`), each colored green (patch), yellow (minor), or red (major).
+- `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping). Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white and other entries default to grey. Packages with available updates show the wanted/latest versions in brackets next to the resolved version (e.g. `express 4.21.2 (5.2.1)`), each colored green (patch), yellow (minor), or red (major). The outdated check now walks the dependency tree deep enough to cover every occurrence of the queried package, so transitive dependencies (like `qs` under `body-parser`) report update info too.
+- `outdatedDependencies` now accepts a `depth` option (default `0`, meaning direct dependencies only). When `depth > 0`, the check walks transitive dependencies up to that depth via the new `filterDependenciesByDepth` helper.
 - `deps outdated --release-latency auto` (the default) now falls back to a 24h threshold when pnpm's `minimumReleaseAge` is not configured.
 - CI now tests against Node 26 instead of Node 25.
 - Upgraded `zod` from 4.4.2 to 4.4.3

--- a/src/commands/deps/why.ts
+++ b/src/commands/deps/why.ts
@@ -68,11 +68,7 @@ export const depsWhyCommand = new Command({
   handler: async ({ project, args, flags }) => {
     const dependencyName = args.dependency as string
 
-    const [allDependencies, outdated] = await Promise.all([
-      project.dependencies(),
-      project.outdatedDependencies({ cache: true }).catch(() => []),
-    ])
-
+    const allDependencies = await project.dependencies()
     const dep = allDependencies.find((d) => d.name === dependencyName)
 
     if (!dep) {
@@ -95,6 +91,48 @@ export const depsWhyCommand = new Command({
     for (const d of allDependencies) {
       depsMap.set(d.name, d)
     }
+
+    const depChains: TreeNode[] = []
+    const devDepChains: TreeNode[] = []
+
+    for (const v of dep.versions) {
+      const chain = buildReverseChain(dep.name, v.resolved, v.source, depsMap)
+      if (!chain) continue
+
+      const rootDep = depsMap.get(chain.name)
+      const rootVersion = rootDep?.versions.find(
+        (rv) => rv.resolved === chain.version,
+      )
+      const isDevChain = rootVersion
+        ? isDevDependenciesSource(rootVersion.source)
+        : false
+
+      if (isDevChain) {
+        mergeTreeNode(devDepChains, chain)
+      } else {
+        mergeTreeNode(depChains, chain)
+      }
+    }
+
+    const chains: RootChain[] = [
+      ...depChains.map((tree) => ({ tree, isDev: false })),
+      ...devDepChains.map((tree) => ({ tree, isDev: true })),
+    ]
+
+    const computeMaxDepth = (node: TreeNode, depth = 0): number => {
+      if (node.children.length === 0) return depth
+      return Math.max(
+        ...node.children.map((child) => computeMaxDepth(child, depth + 1)),
+      )
+    }
+    const outdatedDepth = chains.reduce(
+      (max, { tree }) => Math.max(max, computeMaxDepth(tree)),
+      0,
+    )
+
+    const outdated = await project
+      .outdatedDependencies({ cache: true, depth: outdatedDepth })
+      .catch(() => [])
 
     const outdatedMap = new Map<string, { latest: string; wanted: string }>()
     for (const o of outdated) {
@@ -149,33 +187,6 @@ export const depsWhyCommand = new Command({
       suffix: buildSuffix(node, isRoot, isDev),
       children: node.children.map((child) => decorate(child, false, false)),
     })
-
-    const depChains: TreeNode[] = []
-    const devDepChains: TreeNode[] = []
-
-    for (const v of dep.versions) {
-      const chain = buildReverseChain(dep.name, v.resolved, v.source, depsMap)
-      if (!chain) continue
-
-      const rootDep = depsMap.get(chain.name)
-      const rootVersion = rootDep?.versions.find(
-        (rv) => rv.resolved === chain.version,
-      )
-      const isDevChain = rootVersion
-        ? isDevDependenciesSource(rootVersion.source)
-        : false
-
-      if (isDevChain) {
-        mergeTreeNode(devDepChains, chain)
-      } else {
-        mergeTreeNode(depChains, chain)
-      }
-    }
-
-    const chains: RootChain[] = [
-      ...depChains.map((tree) => ({ tree, isDev: false })),
-      ...devDepChains.map((tree) => ({ tree, isDev: true })),
-    ]
 
     if (flags.json) {
       console.log(

--- a/src/commands/deps/why.ts
+++ b/src/commands/deps/why.ts
@@ -1,3 +1,5 @@
+import semver from 'semver'
+
 import { Command } from '../../lib/command.ts'
 import {
   buildReverseChain,
@@ -16,6 +18,33 @@ import type { ProjectDependencySchema } from '../../lib/dependencies.ts'
 type RootChain = {
   tree: TreeNode
   isDev: boolean
+}
+
+type AvailableVersion = {
+  version: string
+  color: string
+}
+
+const colorForLevel = (level: 'major' | 'minor' | 'patch'): string => {
+  if (level === 'major') return COLORS.red
+  if (level === 'minor') return COLORS.yellow
+  return COLORS.green
+}
+
+const isUpgrade = (from: string, to: string): boolean => {
+  try {
+    return semver.gt(to, from)
+  } catch {
+    return false
+  }
+}
+
+const formatAvailableVersions = (versions: AvailableVersion[]): string => {
+  if (versions.length === 0) return ''
+  const inner = versions
+    .map(({ version, color }) => `${color}${version}${COLORS.reset}`)
+    .join(`${COLORS.grey}, ${COLORS.reset}`)
+  return `${COLORS.grey}(${COLORS.reset}${inner}${COLORS.grey})${COLORS.reset}`
 }
 
 export const depsWhyCommand = new Command({
@@ -72,24 +101,55 @@ export const depsWhyCommand = new Command({
       outdatedMap.set(o.name, { latest: o.latest, wanted: o.wanted })
     }
 
-    const getNodeColor = (name: string, version: string): string => {
+    const getAvailableVersions = (
+      name: string,
+      version: string,
+    ): AvailableVersion[] => {
       const o = outdatedMap.get(name)
-      if (o) {
-        const level = getSemverLevel(version, o.latest)
-        if (level === 'major') return COLORS.red
-        if (level === 'minor') return COLORS.yellow
-        if (level === 'patch') return COLORS.green
+      if (!o) return []
+      const candidates = [o.wanted, o.latest].filter(
+        (v): v is string => typeof v === 'string' && v.length > 0,
+      )
+      const versions: AvailableVersion[] = []
+      const seen = new Set<string>([version])
+      for (const candidate of candidates) {
+        if (seen.has(candidate)) continue
+        if (!isUpgrade(version, candidate)) continue
+        const level = getSemverLevel(version, candidate)
+        if (!level) continue
+        seen.add(candidate)
+        versions.push({ version: candidate, color: colorForLevel(level) })
       }
-      return name === dependencyName ? COLORS.white : COLORS.grey
+      return versions
     }
 
-    const decorate = (node: TreeNode): TreeNode => ({
+    const buildSuffix = (
+      node: TreeNode,
+      isRoot: boolean,
+      isDev: boolean,
+    ): string | undefined => {
+      const parts: string[] = []
+      if (isRoot && isDev) {
+        parts.push(`${COLORS.grey}(dev)${COLORS.reset}`)
+      }
+      const formatted = formatAvailableVersions(
+        getAvailableVersions(node.name, node.version),
+      )
+      if (formatted) parts.push(formatted)
+      return parts.length > 0 ? parts.join(' ') : undefined
+    }
+
+    const decorate = (
+      node: TreeNode,
+      isRoot: boolean,
+      isDev: boolean,
+    ): TreeNode => ({
       ...node,
-      color: getNodeColor(node.name, node.version),
-      children: node.children.map(decorate),
+      color: node.name === dependencyName ? COLORS.white : COLORS.grey,
+      suffix: buildSuffix(node, isRoot, isDev),
+      children: node.children.map((child) => decorate(child, false, false)),
     })
 
-    const chains: RootChain[] = []
     const depChains: TreeNode[] = []
     const devDepChains: TreeNode[] = []
 
@@ -112,8 +172,10 @@ export const depsWhyCommand = new Command({
       }
     }
 
-    for (const tree of depChains) chains.push({ tree, isDev: false })
-    for (const tree of devDepChains) chains.push({ tree, isDev: true })
+    const chains: RootChain[] = [
+      ...depChains.map((tree) => ({ tree, isDev: false })),
+      ...devDepChains.map((tree) => ({ tree, isDev: true })),
+    ]
 
     if (flags.json) {
       console.log(
@@ -139,8 +201,7 @@ export const depsWhyCommand = new Command({
     }
 
     for (const { tree, isDev } of chains) {
-      const decorated = decorate(tree)
-      if (isDev) decorated.suffix = '(dev)'
+      const decorated = decorate(tree, true, isDev)
       const lines = formatTree(decorated, '', true, true)
       for (const line of lines) {
         console.log(line)

--- a/src/commands/deps/why.ts
+++ b/src/commands/deps/why.ts
@@ -60,7 +60,16 @@ export const depsWhyCommand = new Command({
       type: 'string',
     },
   ],
-  flags: [],
+  flags: [
+    {
+      name: 'check-versions',
+      description:
+        'Fetch latest versions from the registry and annotate available patch/minor/major updates next to each entry. Off by default since registry lookups can be slow.',
+      required: false,
+      type: 'boolean',
+      defaultValue: false,
+    },
+  ],
   completions: async ({ project }) => {
     const dependencies = await project.dependencies()
     return dependencies.map((d) => d.name)
@@ -119,24 +128,28 @@ export const depsWhyCommand = new Command({
       ...devDepChains.map((tree) => ({ tree, isDev: true })),
     ]
 
-    const computeMaxDepth = (node: TreeNode, depth = 0): number => {
-      if (node.children.length === 0) return depth
-      return Math.max(
-        ...node.children.map((child) => computeMaxDepth(child, depth + 1)),
-      )
-    }
-    const outdatedDepth = chains.reduce(
-      (max, { tree }) => Math.max(max, computeMaxDepth(tree)),
-      0,
-    )
-
-    const outdated = await project
-      .outdatedDependencies({ cache: true, depth: outdatedDepth })
-      .catch(() => [])
+    const checkVersions = flags['check-versions'] as boolean
 
     const outdatedMap = new Map<string, { latest: string; wanted: string }>()
-    for (const o of outdated) {
-      outdatedMap.set(o.name, { latest: o.latest, wanted: o.wanted })
+    if (checkVersions) {
+      const computeMaxDepth = (node: TreeNode, depth = 0): number => {
+        if (node.children.length === 0) return depth
+        return Math.max(
+          ...node.children.map((child) => computeMaxDepth(child, depth + 1)),
+        )
+      }
+      const outdatedDepth = chains.reduce(
+        (max, { tree }) => Math.max(max, computeMaxDepth(tree)),
+        0,
+      )
+
+      const outdated = await project
+        .outdatedDependencies({ cache: true, depth: outdatedDepth })
+        .catch(() => [])
+
+      for (const o of outdated) {
+        outdatedMap.set(o.name, { latest: o.latest, wanted: o.wanted })
+      }
     }
 
     const getAvailableVersions = (

--- a/src/commands/deps/why.ts
+++ b/src/commands/deps/why.ts
@@ -11,9 +11,36 @@ import {
   mergeTreeNode,
   type TreeNode,
 } from '../../lib/formatters/tree.ts'
+import { fetchJsrPackageInfo } from '../../lib/jsr/info.ts'
+import { fetchNpmPackageInfo } from '../../lib/npm/info.ts'
+import { fetchRubygemInfo } from '../../lib/rubygems/info.ts'
 import { getSemverLevel } from '../../lib/semver.ts'
+import { fetchPyPIPackageInfo } from '../../lib/uv/info.ts'
 
 import type { ProjectDependencySchema } from '../../lib/dependencies.ts'
+
+const fetchLatestForPackage = async (
+  name: string,
+  ecosystem: string,
+): Promise<string | null> => {
+  if (ecosystem === 'npm') {
+    const info = await fetchNpmPackageInfo(name)
+    return info?.latest ?? null
+  }
+  if (ecosystem === 'jsr') {
+    const info = await fetchJsrPackageInfo(name)
+    return info?.latest ?? null
+  }
+  if (ecosystem === 'pypi') {
+    const info = await fetchPyPIPackageInfo(name)
+    return info?.latest ?? null
+  }
+  if (ecosystem === 'rubygems') {
+    const info = await fetchRubygemInfo(name)
+    return info?.latest ?? null
+  }
+  return null
+}
 
 type RootChain = {
   tree: TreeNode
@@ -62,9 +89,9 @@ export const depsWhyCommand = new Command({
   ],
   flags: [
     {
-      name: 'check-versions',
+      name: 'check-all-versions',
       description:
-        'Fetch latest versions from the registry and annotate available patch/minor/major updates next to each entry. Off by default since registry lookups can be slow.',
+        'Fetch latest versions from the registry for every entry in the tree. Off by default since registry lookups can be slow; without this flag only the queried package is checked.',
       required: false,
       type: 'boolean',
       defaultValue: false,
@@ -123,12 +150,19 @@ export const depsWhyCommand = new Command({
       }
     }
 
+    const sortChildren = (node: TreeNode): void => {
+      node.children.sort((a, b) => a.name.localeCompare(b.name))
+      for (const child of node.children) sortChildren(child)
+    }
+    for (const tree of depChains) sortChildren(tree)
+    for (const tree of devDepChains) sortChildren(tree)
+
     const chains: RootChain[] = [
       ...depChains.map((tree) => ({ tree, isDev: false })),
       ...devDepChains.map((tree) => ({ tree, isDev: true })),
-    ]
+    ].sort((a, b) => a.tree.name.localeCompare(b.tree.name))
 
-    const checkVersions = flags['check-versions'] as boolean
+    const checkVersions = flags['check-all-versions'] as boolean
 
     const outdatedMap = new Map<string, { latest: string; wanted: string }>()
     if (checkVersions) {
@@ -149,6 +183,13 @@ export const depsWhyCommand = new Command({
 
       for (const o of outdated) {
         outdatedMap.set(o.name, { latest: o.latest, wanted: o.wanted })
+      }
+    } else {
+      const latest = await fetchLatestForPackage(dep.name, dep.ecosystem).catch(
+        () => null,
+      )
+      if (latest) {
+        outdatedMap.set(dep.name, { latest, wanted: latest })
       }
     }
 

--- a/src/commands/deps/why.ts
+++ b/src/commands/deps/why.ts
@@ -3,13 +3,20 @@ import {
   buildReverseChain,
   isDevDependenciesSource,
 } from '../../lib/deps/tree.ts'
+import { COLORS } from '../../lib/formatters/table.ts'
 import {
   formatTree,
   mergeTreeNode,
   type TreeNode,
 } from '../../lib/formatters/tree.ts'
+import { getSemverLevel } from '../../lib/semver.ts'
 
 import type { ProjectDependencySchema } from '../../lib/dependencies.ts'
+
+type RootChain = {
+  tree: TreeNode
+  isDev: boolean
+}
 
 export const depsWhyCommand = new Command({
   name: 'deps:why',
@@ -31,9 +38,12 @@ export const depsWhyCommand = new Command({
   },
   handler: async ({ project, args, flags }) => {
     const dependencyName = args.dependency as string
-    const allDependencies = await project.dependencies()
 
-    // Find the dependency
+    const [allDependencies, outdated] = await Promise.all([
+      project.dependencies(),
+      project.outdatedDependencies({ cache: true }).catch(() => []),
+    ])
+
     const dep = allDependencies.find((d) => d.name === dependencyName)
 
     if (!dep) {
@@ -52,35 +62,59 @@ export const depsWhyCommand = new Command({
       return { success: false, message: 'Dependency not found.' }
     }
 
-    // Build a map of all dependencies for resolving chains
     const depsMap = new Map<string, ProjectDependencySchema>()
     for (const d of allDependencies) {
       depsMap.set(d.name, d)
     }
 
-    // Group chains by source type (dependencies vs devDependencies)
+    const outdatedMap = new Map<string, { latest: string; wanted: string }>()
+    for (const o of outdated) {
+      outdatedMap.set(o.name, { latest: o.latest, wanted: o.wanted })
+    }
+
+    const getNodeColor = (name: string, version: string): string => {
+      const o = outdatedMap.get(name)
+      if (o) {
+        const level = getSemverLevel(version, o.latest)
+        if (level === 'major') return COLORS.red
+        if (level === 'minor') return COLORS.yellow
+        if (level === 'patch') return COLORS.green
+      }
+      return name === dependencyName ? COLORS.white : COLORS.grey
+    }
+
+    const decorate = (node: TreeNode): TreeNode => ({
+      ...node,
+      color: getNodeColor(node.name, node.version),
+      children: node.children.map(decorate),
+    })
+
+    const chains: RootChain[] = []
     const depChains: TreeNode[] = []
     const devDepChains: TreeNode[] = []
 
-    // For each version of the target dependency, build the chain back to root
     for (const v of dep.versions) {
       const chain = buildReverseChain(dep.name, v.resolved, v.source, depsMap)
-      if (chain) {
-        // Determine if this is a dev dependency chain
-        const rootDep = depsMap.get(chain.name)
-        const isDevChain = rootDep?.versions.some((rv) =>
-          isDevDependenciesSource(rv.source),
-        )
+      if (!chain) continue
 
-        if (isDevChain) {
-          mergeTreeNode(devDepChains, chain)
-        } else {
-          mergeTreeNode(depChains, chain)
-        }
+      const rootDep = depsMap.get(chain.name)
+      const rootVersion = rootDep?.versions.find(
+        (rv) => rv.resolved === chain.version,
+      )
+      const isDevChain = rootVersion
+        ? isDevDependenciesSource(rootVersion.source)
+        : false
+
+      if (isDevChain) {
+        mergeTreeNode(devDepChains, chain)
+      } else {
+        mergeTreeNode(depChains, chain)
       }
     }
 
-    // JSON output
+    for (const tree of depChains) chains.push({ tree, isDev: false })
+    for (const tree of devDepChains) chains.push({ tree, isDev: true })
+
     if (flags.json) {
       console.log(
         JSON.stringify({
@@ -97,47 +131,20 @@ export const depsWhyCommand = new Command({
       return { success: true, message: 'Dependency chain shown.' }
     }
 
-    console.log(`${project.name} ${project.path}`)
-    console.log('')
-
-    // Print dependencies chains
-    if (depChains.length > 0) {
-      console.log('dependencies:')
-      for (let i = 0; i < depChains.length; i++) {
-        const lines = formatTree(
-          depChains[i],
-          '',
-          i === depChains.length - 1,
-          true,
-        )
-        for (const line of lines) {
-          console.log(line)
-        }
-      }
-      console.log('')
-    }
-
-    // Print devDependencies chains
-    if (devDepChains.length > 0) {
-      console.log('devDependencies:')
-      for (let i = 0; i < devDepChains.length; i++) {
-        const lines = formatTree(
-          devDepChains[i],
-          '',
-          i === devDepChains.length - 1,
-          true,
-        )
-        for (const line of lines) {
-          console.log(line)
-        }
-      }
-      console.log('')
-    }
-
-    if (depChains.length === 0 && devDepChains.length === 0) {
+    if (chains.length === 0) {
       console.log(
         `Could not determine dependency chain for "${dependencyName}".`,
       )
+      return { success: true, message: 'Dependency chain shown.' }
+    }
+
+    for (const { tree, isDev } of chains) {
+      const decorated = decorate(tree)
+      if (isDev) decorated.suffix = '(dev)'
+      const lines = formatTree(decorated, '', true, true)
+      for (const line of lines) {
+        console.log(line)
+      }
     }
 
     return { success: true, message: 'Dependency chain shown.' }

--- a/src/lib/deps/tree.ts
+++ b/src/lib/deps/tree.ts
@@ -59,6 +59,86 @@ export const isLockfileSource = (source: string): boolean => {
 }
 
 /**
+ * Filter dependencies to those reachable from direct deps within `depth` levels.
+ * - `depth <= 0` returns only direct dependencies (those with `#dependencies` or
+ *   `#devDependencies` sources).
+ * - `depth > 0` walks the parent/child relationships and includes transitive
+ *   dependencies up to that depth.
+ */
+export const filterDependenciesByDepth = <T extends ProjectDependencySchema>(
+  dependencies: T[],
+  depth: number,
+): T[] => {
+  if (depth <= 0) {
+    return dependencies.filter((dep) =>
+      dep.versions.some(
+        (v) =>
+          v.source.includes('#dependencies') ||
+          v.source.includes('#devDependencies'),
+      ),
+    )
+  }
+
+  const childrenByParent = new Map<string, Set<string>>()
+  for (const dep of dependencies) {
+    for (const v of dep.versions) {
+      const parent = parseParentFromSource(v.source)
+      if (!parent) continue
+      const parentKey = `${parent.name}@${parent.version}`
+      const set = childrenByParent.get(parentKey) ?? new Set<string>()
+      set.add(dep.name)
+      childrenByParent.set(parentKey, set)
+    }
+  }
+
+  const includedNames = new Set<string>()
+  const queue: { name: string; version: string; depth: number }[] = []
+
+  for (const dep of dependencies) {
+    for (const v of dep.versions) {
+      if (
+        v.source.includes('#dependencies') ||
+        v.source.includes('#devDependencies')
+      ) {
+        if (!includedNames.has(dep.name)) {
+          includedNames.add(dep.name)
+        }
+        queue.push({ name: dep.name, version: v.resolved, depth: 0 })
+      }
+    }
+  }
+
+  const visited = new Set<string>()
+  while (queue.length > 0) {
+    const node = queue.shift()
+    if (!node) break
+    if (node.depth >= depth) continue
+    const key = `${node.name}@${node.version}`
+    if (visited.has(key)) continue
+    visited.add(key)
+    const children = childrenByParent.get(key)
+    if (!children) continue
+    for (const childName of children) {
+      includedNames.add(childName)
+      const childDep = dependencies.find((d) => d.name === childName)
+      if (!childDep) continue
+      for (const cv of childDep.versions) {
+        const parent = parseParentFromSource(cv.source)
+        if (parent?.name === node.name && parent.version === node.version) {
+          queue.push({
+            name: childDep.name,
+            version: cv.resolved,
+            depth: node.depth + 1,
+          })
+        }
+      }
+    }
+  }
+
+  return dependencies.filter((dep) => includedNames.has(dep.name))
+}
+
+/**
  * Check if a source is from dependencies section.
  */
 export const isDependenciesSource = (source: string): boolean => {

--- a/src/lib/formatters/tree.ts
+++ b/src/lib/formatters/tree.ts
@@ -7,6 +7,18 @@ export type TreeNode = {
   name: string
   version: string
   children: TreeNode[]
+  /** Optional ANSI color applied to the entire `name version` body. */
+  color?: string
+  /** Optional suffix appended after the version (rendered in grey). */
+  suffix?: string
+}
+
+const formatNodeBody = (node: TreeNode): string => {
+  const body = node.color
+    ? `${node.color}${node.name} ${node.version}${COLORS.reset}`
+    : `${node.name} ${COLORS.grey}${node.version}${COLORS.reset}`
+  if (!node.suffix) return body
+  return `${body} ${COLORS.grey}${node.suffix}${COLORS.reset}`
 }
 
 /**
@@ -23,7 +35,7 @@ export const formatTree = (
 
   if (isRoot) {
     // Root nodes don't get tree prefixes
-    lines.push(`${node.name} ${COLORS.grey}${node.version}${COLORS.reset}`)
+    lines.push(formatNodeBody(node))
   } else {
     // Non-root nodes get tree prefixes
     const branch = hasChildren
@@ -34,9 +46,7 @@ export const formatTree = (
         ? '└── '
         : '├── '
 
-    lines.push(
-      `${prefix}${branch}${node.name} ${COLORS.grey}${node.version}${COLORS.reset}`,
-    )
+    lines.push(`${prefix}${branch}${formatNodeBody(node)}`)
   }
 
   // Format children

--- a/src/lib/formatters/tree.ts
+++ b/src/lib/formatters/tree.ts
@@ -9,7 +9,7 @@ export type TreeNode = {
   children: TreeNode[]
   /** Optional ANSI color applied to the entire `name version` body. */
   color?: string
-  /** Optional suffix appended after the version (rendered in grey). */
+  /** Optional preformatted suffix appended after the version. */
   suffix?: string
 }
 
@@ -17,8 +17,7 @@ const formatNodeBody = (node: TreeNode): string => {
   const body = node.color
     ? `${node.color}${node.name} ${node.version}${COLORS.reset}`
     : `${node.name} ${COLORS.grey}${node.version}${COLORS.reset}`
-  if (!node.suffix) return body
-  return `${body} ${COLORS.grey}${node.suffix}${COLORS.reset}`
+  return node.suffix ? `${body} ${node.suffix}` : body
 }
 
 /**

--- a/src/lib/jsr/outdated.ts
+++ b/src/lib/jsr/outdated.ts
@@ -1,3 +1,4 @@
+import { filterDependenciesByDepth } from '../deps/tree.ts'
 import { extractDepInfo, findWantedVersion } from '../npm/outdated.ts'
 import { fetchJsrPackageInfo } from './info.ts'
 
@@ -16,17 +17,12 @@ export const jsrOutdated = async (
   options: OutdatedDependenciesOptions = {},
 ): Promise<OutdatedDependencySchema[]> => {
   const useCache = options.cache ?? true
+  const depth = options.depth ?? 0
   const result: OutdatedDependencySchema[] = []
 
-  const directDeps = dependencies.filter((dep) => {
-    return dep.versions.some(
-      (v) =>
-        v.source.includes('#dependencies') ||
-        v.source.includes('#devDependencies'),
-    )
-  })
+  const toCheck = filterDependenciesByDepth(dependencies, depth)
 
-  const fetchPromises = directDeps.map(async (dep) => {
+  const fetchPromises = toCheck.map(async (dep) => {
     const info = extractDepInfo(dep)
     if (!info) return
 

--- a/src/lib/npm/outdated.ts
+++ b/src/lib/npm/outdated.ts
@@ -1,3 +1,4 @@
+import { filterDependenciesByDepth } from '../deps/tree.ts'
 import { fetchNpmPackageInfo } from './info.ts'
 
 import type {
@@ -146,20 +147,12 @@ export const npmOutdated = async (
   options: OutdatedDependenciesOptions = {},
 ): Promise<OutdatedDependencySchema[]> => {
   const useCache = options.cache ?? true
+  const depth = options.depth ?? 0
   const result: OutdatedDependencySchema[] = []
 
-  // Filter to only direct dependencies (those with sources, not transitive)
-  const directDeps = dependencies.filter((dep) => {
-    // Direct deps have sources like ".#dependencies" or "packages/foo#dependencies"
-    // Transitive deps have sources like "pnpm-lock.yaml:package@version"
-    return dep.versions.some(
-      (v) =>
-        v.source.includes('#dependencies') ||
-        v.source.includes('#devDependencies'),
-    )
-  })
+  const toCheck = filterDependenciesByDepth(dependencies, depth)
 
-  const fetchPromises = directDeps.map(async (dep) => {
+  const fetchPromises = toCheck.map(async (dep) => {
     const info = extractDepInfo(dep)
     if (!info) return
 

--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -10,6 +10,12 @@ import type { DenvigProject } from './project'
 export type OutdatedDependenciesOptions = {
   /** Use cache for registry requests (default: true) */
   cache?: boolean
+  /**
+   * How many levels of the dependency tree to include.
+   * 0 (default) = direct dependencies only.
+   * N > 0 = direct deps plus transitive dependencies up to depth N.
+   */
+  depth?: number
 }
 
 /**


### PR DESCRIPTION
## Summary

Reworks the `denvig deps why <package>` command output and adds optional registry lookups for latest versions.

### Output changes
- Single flat list — no project header, no `dependencies:`/`devDependencies:` grouping.
- Direct dev dependencies are tagged with a `(dev)` suffix on the root.
- Every level of the tree is sorted alphabetically by package name (root chains and nested children).
- The queried package is highlighted in white; other entries default to grey.

### Version annotations
- By default, a single registry lookup is performed for the queried package via a new `fetchLatestForPackage` dispatcher (npm / jsr / PyPI / RubyGems). Tree entries for that package get a bracketed annotation, e.g. `express 4.21.2 (5.2.1)`, colored green / yellow / red for patch / minor / major updates.
- `--check-all-versions` extends that annotation to every entry by walking the dependency tree and calling `outdatedDependencies` deep enough to cover every occurrence of the queried package. Off by default since it issues many registry calls.

### Supporting changes
- `OutdatedDependenciesOptions` gains a `depth` option (default `0`, i.e. direct deps only). When `depth > 0`, transitive dependencies are walked via the new `filterDependenciesByDepth` helper in `src/lib/deps/tree.ts`.
- `npmOutdated` and `jsrOutdated` use the helper instead of inlining their own direct-deps filter.
- `TreeNode` gains optional `color` and `suffix` fields so the tree formatter can render colored bodies and verbatim suffixes (e.g. `(dev)` and the bracketed update list).

## Test plan
- [x] `pnpm run check-types`
- [x] `pnpm exec node --test src/lib/formatters/tree.test.ts src/lib/deps/tree.test.ts src/lib/npm/info.test.ts`
- [x] `bin/denvig-dev deps why --project upvio/api qs` (default: queried-only annotation)
- [x] `bin/denvig-dev deps why --project upvio/api qs --check-all-versions` (full tree annotation)
- [x] `bin/denvig-dev deps why --project upvio/api express` (verifies queried package coloring)
- [x] `bin/denvig-dev deps outdated --project upvio/api` (sanity check `depth=0` default still works)