### PR TITLE
Resolve pnpm catalog specifiers in deps outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `deps outdated` now resolves pnpm `catalog:` and `catalog:<name>` specifiers via `pnpm-workspace.yaml` so the `Wanted` column reflects the real version range (previously the literal `catalog:` string was passed to the semver matcher and yielded no wanted update).
+
 ### Changed
 
+- pnpm dependency detection now adds a `pnpm-workspace.yaml$catalog` (or `pnpm-workspace.yaml$catalogs.<name>`) source entry for every dependency declared via a workspace catalog, alongside the existing importer source entries.
 - `deps why <package>` output is now a single flat list (no project header, no `dependencies:`/`devDependencies:` grouping) sorted alphabetically at every depth. Direct dev dependencies are tagged with a `(dev)` suffix. The queried package is highlighted in white and other entries default to grey.
 - `deps why <package>` now performs a single registry lookup for the queried package by default and annotates its tree entries with the latest available version in brackets (e.g. `express 4.21.2 (5.2.1)`), colored green (patch), yellow (minor), or red (major). The lookup covers npm, jsr, PyPI, and RubyGems ecosystems.
 - `deps why <package> --check-all-versions` extends that annotation to every entry in the tree by walking the dependency tree deep enough to cover every occurrence of the queried package, so transitive dependencies report update info too. Off by default since it issues many registry calls.

--- a/src/lib/npm/outdated.test.ts
+++ b/src/lib/npm/outdated.test.ts
@@ -1,0 +1,68 @@
+import { strictEqual } from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { extractDepInfo } from './outdated.ts'
+
+describe('extractDepInfo()', () => {
+  it('returns the first version entry for plain importer specifiers', () => {
+    const info = extractDepInfo({
+      versions: [
+        { resolved: '1.2.3', specifier: '^1.2.0', source: '.#dependencies' },
+      ],
+    })
+    strictEqual(info?.current, '1.2.3')
+    strictEqual(info?.specifier, '^1.2.0')
+    strictEqual(info?.isDevDependency, false)
+  })
+
+  it('skips literal `catalog:` specifiers in favour of a real range', () => {
+    const info = extractDepInfo({
+      versions: [
+        {
+          resolved: '14.0.14',
+          specifier: 'catalog:',
+          source: 'apps/api#devDependencies',
+        },
+        {
+          resolved: '14.0.14',
+          specifier: '^14.0.14',
+          source: 'pnpm-workspace.yaml$catalog',
+        },
+      ],
+    })
+    strictEqual(info?.current, '14.0.14')
+    strictEqual(info?.specifier, '^14.0.14')
+    strictEqual(info?.isDevDependency, true)
+  })
+
+  it('skips named-catalog specifiers (`catalog:<name>`)', () => {
+    const info = extractDepInfo({
+      versions: [
+        {
+          resolved: '18.3.1',
+          specifier: 'catalog:legacy',
+          source: 'apps/web#dependencies',
+        },
+        {
+          resolved: '18.3.1',
+          specifier: '^18.3.1',
+          source: 'pnpm-workspace.yaml$catalogs.legacy',
+        },
+      ],
+    })
+    strictEqual(info?.specifier, '^18.3.1')
+  })
+
+  it('falls back to the first specifier when only catalog entries exist', () => {
+    const info = extractDepInfo({
+      versions: [
+        {
+          resolved: '14.0.14',
+          specifier: 'catalog:',
+          source: 'apps/api#devDependencies',
+        },
+      ],
+    })
+    strictEqual(info?.specifier, 'catalog:')
+  })
+})

--- a/src/lib/npm/outdated.ts
+++ b/src/lib/npm/outdated.ts
@@ -121,19 +121,28 @@ export const findWantedVersion = (
 /**
  * Extract dependency info from ProjectDependencySchema versions.
  * Returns the current version, specifier, and whether it's a dev dependency.
+ *
+ * The first entry establishes the current version and dev flag (matching the
+ * declaration order in the lockfile). The specifier may need to come from a
+ * different entry — when the first importer references a pnpm catalog, its
+ * literal specifier is `catalog:` and the real semver range lives on the
+ * `pnpm-workspace.yaml$catalog` source entry added by the pnpm plugin.
  */
 export const extractDepInfo = (
   dep: Pick<ProjectDependencySchema, 'versions'>,
 ): { current: string; specifier: string; isDevDependency: boolean } | null => {
-  // Get the first version entry (there should typically be one for direct deps)
   if (dep.versions.length === 0) return null
 
   const firstVersion = dep.versions[0]
   const isDevDependency = firstVersion.source.includes('#devDependencies')
 
+  const usableSpecifier =
+    dep.versions.find((v) => !v.specifier.startsWith('catalog:'))?.specifier ??
+    firstVersion.specifier
+
   return {
     current: firstVersion.resolved,
-    specifier: firstVersion.specifier,
+    specifier: usableSpecifier,
     isDevDependency,
   }
 }

--- a/src/lib/pnpm-config.ts
+++ b/src/lib/pnpm-config.ts
@@ -3,14 +3,91 @@ import { parse } from 'yaml'
 
 import { parseDuration } from './formatters/duration.ts'
 
+type PnpmCatalog = Record<string, string>
+
 type PnpmWorkspaceConfig = {
   minimumReleaseAge?: number | string
   minimumReleaseAgeExclude?: string[]
+  catalog?: PnpmCatalog
+  catalogs?: Record<string, PnpmCatalog>
 }
 
 export type PnpmReleaseAgeConfig = {
   minimumReleaseAgeMs: number
   exclude: string[]
+}
+
+export type PnpmCatalogs = {
+  default: PnpmCatalog
+  named: Record<string, PnpmCatalog>
+}
+
+const readPnpmWorkspaceConfig = async (
+  projectPath: string,
+): Promise<PnpmWorkspaceConfig | null> => {
+  try {
+    const content = await readFile(
+      `${projectPath}/pnpm-workspace.yaml`,
+      'utf-8',
+    )
+    return parse(content) as PnpmWorkspaceConfig
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read pnpm catalog definitions from `pnpm-workspace.yaml`.
+ * Returns the default catalog (under the top-level `catalog` key) and any
+ * named catalogs (under `catalogs.<name>`). Returns null if the file is
+ * missing or doesn't define any catalogs.
+ */
+export const readPnpmCatalogs = async (
+  projectPath: string,
+): Promise<PnpmCatalogs | null> => {
+  const config = await readPnpmWorkspaceConfig(projectPath)
+  if (!config) return null
+  const hasDefault = config.catalog && typeof config.catalog === 'object'
+  const hasNamed = config.catalogs && typeof config.catalogs === 'object'
+  if (!hasDefault && !hasNamed) return null
+  return {
+    default: hasDefault ? config.catalog! : {},
+    named: hasNamed ? config.catalogs! : {},
+  }
+}
+
+/**
+ * Resolve a `catalog:` / `catalog:<name>` specifier to the actual specifier
+ * declared in `pnpm-workspace.yaml`. Returns null if the specifier doesn't
+ * reference a catalog or the catalog/entry isn't found.
+ */
+export const resolveCatalogSpecifier = (
+  catalogs: PnpmCatalogs | null,
+  packageName: string,
+  specifier: string,
+): { specifier: string; catalogName: string } | null => {
+  if (!catalogs) return null
+  if (!specifier.startsWith('catalog:')) return null
+  const name = specifier.slice('catalog:'.length).trim()
+  const catalogName = name === '' || name === 'default' ? 'default' : name
+  const catalog =
+    catalogName === 'default' ? catalogs.default : catalogs.named[catalogName]
+  if (!catalog) return null
+  const resolved = catalog[packageName]
+  if (!resolved) return null
+  return { specifier: resolved, catalogName }
+}
+
+/**
+ * Build a source identifier for a catalog entry.
+ *
+ * @example catalogSource('default') // 'pnpm-workspace.yaml$catalog'
+ * @example catalogSource('react17') // 'pnpm-workspace.yaml$catalogs.react17'
+ */
+export const catalogSource = (catalogName: string): string => {
+  return catalogName === 'default'
+    ? 'pnpm-workspace.yaml$catalog'
+    : `pnpm-workspace.yaml$catalogs.${catalogName}`
 }
 
 /**

--- a/src/lib/pnpm-config.ts
+++ b/src/lib/pnpm-config.ts
@@ -47,12 +47,16 @@ export const readPnpmCatalogs = async (
 ): Promise<PnpmCatalogs | null> => {
   const config = await readPnpmWorkspaceConfig(projectPath)
   if (!config) return null
-  const hasDefault = config.catalog && typeof config.catalog === 'object'
-  const hasNamed = config.catalogs && typeof config.catalogs === 'object'
-  if (!hasDefault && !hasNamed) return null
+  const defaultCatalog =
+    config.catalog && typeof config.catalog === 'object' ? config.catalog : null
+  const namedCatalogs =
+    config.catalogs && typeof config.catalogs === 'object'
+      ? config.catalogs
+      : null
+  if (!defaultCatalog && !namedCatalogs) return null
   return {
-    default: hasDefault ? config.catalog! : {},
-    named: hasNamed ? config.catalogs! : {},
+    default: defaultCatalog ?? {},
+    named: namedCatalogs ?? {},
   }
 }
 

--- a/src/plugins/pnpm.test.ts
+++ b/src/plugins/pnpm.test.ts
@@ -9,6 +9,11 @@ const turborepoExamplePath = new URL(
   import.meta.url,
 ).pathname
 
+const catalogExamplePath = new URL(
+  '../test/examples/pnpm-catalog',
+  import.meta.url,
+).pathname
+
 describe('pnpm plugin', () => {
   it('should have correct plugin name', () => {
     strictEqual(pnpmPlugin.name, 'pnpm')
@@ -205,6 +210,78 @@ describe('pnpm plugin', () => {
         'should include react from workspace packages',
       )
       ok(depNames.includes('denvig'), 'should include denvig from package2')
+    })
+  })
+
+  describe('catalog resolution', () => {
+    it('should resolve `catalog:` specifiers via pnpm-workspace.yaml', async () => {
+      const project = createMockProjectFromPath(catalogExamplePath)
+      ok(pnpmPlugin.dependencies, 'dependencies function should exist')
+      const deps = await pnpmPlugin.dependencies(project)
+
+      const nockDep = deps.find((d) => d.name === 'nock')
+      ok(nockDep, 'nock should be detected')
+
+      const importerEntry = nockDep.versions.find(
+        (v) => v.source === 'apps/api#devDependencies',
+      )
+      ok(importerEntry, 'should have importer source entry')
+      strictEqual(
+        importerEntry.specifier,
+        'catalog:',
+        'importer entry preserves the literal `catalog:` specifier',
+      )
+
+      const catalogEntry = nockDep.versions.find(
+        (v) => v.source === 'pnpm-workspace.yaml$catalog',
+      )
+      ok(catalogEntry, 'should have a catalog source entry')
+      strictEqual(
+        catalogEntry.specifier,
+        '^14.0.14',
+        'catalog entry exposes the resolved specifier',
+      )
+      strictEqual(catalogEntry.resolved, '14.0.14')
+    })
+
+    it('should resolve `catalog:<name>` specifiers from named catalogs', async () => {
+      const project = createMockProjectFromPath(catalogExamplePath)
+      ok(pnpmPlugin.dependencies, 'dependencies function should exist')
+      const deps = await pnpmPlugin.dependencies(project)
+
+      const reactDep = deps.find((d) => d.name === 'react')
+      ok(reactDep, 'react should be detected')
+
+      const namedCatalogEntry = reactDep.versions.find(
+        (v) => v.source === 'pnpm-workspace.yaml$catalogs.legacy',
+      )
+      ok(namedCatalogEntry, 'should have a named catalog source entry')
+      strictEqual(namedCatalogEntry.specifier, '^18.3.1')
+      strictEqual(namedCatalogEntry.resolved, '18.3.1')
+
+      const defaultCatalogEntry = reactDep.versions.find(
+        (v) => v.source === 'pnpm-workspace.yaml$catalog',
+      )
+      ok(defaultCatalogEntry, 'should also have the default catalog entry')
+      strictEqual(defaultCatalogEntry.specifier, '^19.2.0')
+    })
+
+    it('should not duplicate the catalog source when many importers reference it', async () => {
+      const project = createMockProjectFromPath(catalogExamplePath)
+      ok(pnpmPlugin.dependencies, 'dependencies function should exist')
+      const deps = await pnpmPlugin.dependencies(project)
+
+      const nockDep = deps.find((d) => d.name === 'nock')
+      ok(nockDep, 'nock should be detected')
+
+      const catalogEntries = nockDep.versions.filter(
+        (v) => v.source === 'pnpm-workspace.yaml$catalog',
+      )
+      strictEqual(
+        catalogEntries.length,
+        1,
+        'each catalog should contribute at most one source entry per dep',
+      )
     })
   })
 

--- a/src/plugins/pnpm.ts
+++ b/src/plugins/pnpm.ts
@@ -10,6 +10,11 @@ import { preparePnpmRemovals } from '../lib/dedupe/prepare-removals-pnpm.ts'
 import { npmOutdated } from '../lib/npm/outdated.ts'
 import { readPackageJson } from '../lib/packageJson.ts'
 import { definePlugin } from '../lib/plugin.ts'
+import {
+  catalogSource,
+  readPnpmCatalogs,
+  resolveCatalogSpecifier,
+} from '../lib/pnpm-config.ts'
 import { pathExists } from '../lib/safeReadFile.ts'
 
 import type { ProjectDependencySchema } from '../lib/dependencies.ts'
@@ -149,6 +154,47 @@ const plugin = definePlugin({
     const lockfileContent = await readFile(lockfilePath, 'utf-8')
     const lockfile = parse(lockfileContent) as PnpmLockfile
 
+    // Read catalogs from pnpm-workspace.yaml so we can resolve `catalog:` /
+    // `catalog:<name>` specifiers in importer entries to their real version
+    // ranges.
+    const catalogs = await readPnpmCatalogs(project.path)
+    const catalogSourcesAdded = new Set<string>()
+
+    const addImporterDep = (
+      name: string,
+      depInfo: PnpmLockfileDep,
+      source: string,
+    ) => {
+      const id = `npm:${name}`
+      const resolvedVersion = stripPeerDeps(depInfo.version)
+      const catalogMatch = resolveCatalogSpecifier(
+        catalogs,
+        name,
+        depInfo.specifier,
+      )
+
+      // Importer entry: keep the literal `catalog:` specifier so the source
+      // truthfully reflects what's declared in the workspace package's
+      // package.json. Resolution lives on the catalog source entry below.
+      addDependency(id, name, 'npm', resolvedVersion, source, depInfo.specifier)
+
+      if (catalogMatch) {
+        const catSource = catalogSource(catalogMatch.catalogName)
+        const dedupeKey = `${id}@${catSource}`
+        if (!catalogSourcesAdded.has(dedupeKey)) {
+          catalogSourcesAdded.add(dedupeKey)
+          addDependency(
+            id,
+            name,
+            'npm',
+            resolvedVersion,
+            catSource,
+            catalogMatch.specifier,
+          )
+        }
+      }
+    }
+
     // Iterate through importers (workspace packages)
     if (lockfile?.importers) {
       for (const [importerPath, importer] of Object.entries(
@@ -160,14 +206,7 @@ const plugin = definePlugin({
         if (importer.dependencies) {
           for (const [name, depInfo] of Object.entries(importer.dependencies)) {
             if (depInfo?.specifier && depInfo?.version) {
-              addDependency(
-                `npm:${name}`,
-                name,
-                'npm',
-                stripPeerDeps(depInfo.version),
-                `${basePath}#dependencies`,
-                depInfo.specifier,
-              )
+              addImporterDep(name, depInfo, `${basePath}#dependencies`)
             }
           }
         }
@@ -178,14 +217,7 @@ const plugin = definePlugin({
             importer.devDependencies,
           )) {
             if (depInfo?.specifier && depInfo?.version) {
-              addDependency(
-                `npm:${name}`,
-                name,
-                'npm',
-                stripPeerDeps(depInfo.version),
-                `${basePath}#devDependencies`,
-                depInfo.specifier,
-              )
+              addImporterDep(name, depInfo, `${basePath}#devDependencies`)
             }
           }
         }

--- a/src/test/examples/pnpm-catalog/apps/api/package.json
+++ b/src/test/examples/pnpm-catalog/apps/api/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "api",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "catalog:"
+  },
+  "devDependencies": {
+    "nock": "catalog:"
+  }
+}

--- a/src/test/examples/pnpm-catalog/apps/web/package.json
+++ b/src/test/examples/pnpm-catalog/apps/web/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "catalog:legacy"
+  }
+}

--- a/src/test/examples/pnpm-catalog/package.json
+++ b/src/test/examples/pnpm-catalog/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pnpm-catalog-example",
+  "private": true,
+  "version": "0.0.0"
+}

--- a/src/test/examples/pnpm-catalog/pnpm-lock.yaml
+++ b/src/test/examples/pnpm-catalog/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    nock:
+      specifier: ^14.0.14
+      version: 14.0.14
+    react:
+      specifier: ^19.2.0
+      version: 19.2.3
+  legacy:
+    react:
+      specifier: ^18.3.1
+      version: 18.3.1
+
+importers:
+
+  apps/api:
+    dependencies:
+      react:
+        specifier: 'catalog:'
+        version: 19.2.3
+    devDependencies:
+      nock:
+        specifier: 'catalog:'
+        version: 14.0.14
+
+  apps/web:
+    dependencies:
+      react:
+        specifier: 'catalog:legacy'
+        version: 18.3.1
+
+packages:
+
+  nock@14.0.14:
+    resolution: {integrity: sha512-fake==}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-fake==}
+
+  react@19.2.3:
+    resolution: {integrity: sha512-fake==}
+
+snapshots:
+
+  nock@14.0.14: {}
+
+  react@18.3.1: {}
+
+  react@19.2.3: {}

--- a/src/test/examples/pnpm-catalog/pnpm-workspace.yaml
+++ b/src/test/examples/pnpm-catalog/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages:
+  - "apps/*"
+
+catalog:
+  nock: ^14.0.14
+  react: ^19.2.0
+
+catalogs:
+  legacy:
+    react: ^18.3.1


### PR DESCRIPTION
## Summary

`deps outdated` was missing the **Wanted** column for any dependency declared via a pnpm workspace catalog (e.g. `nock` showed `14.0.14` current, `14.0.15` latest, but `-` for wanted).

The pnpm lockfile stores `specifier: 'catalog:'` literally for importers that pull from a catalog. The current code passed that string straight to the semver matcher, which couldn't parse it, so `findWantedVersion` returned null and the wanted column fell back to `-`.

## Changes

- **`src/lib/pnpm-config.ts`**: New `readPnpmCatalogs`, `resolveCatalogSpecifier`, and `catalogSource` helpers parse default + named catalogs from `pnpm-workspace.yaml`.
- **`src/plugins/pnpm.ts`**: When an importer entry's specifier is `catalog:` / `catalog:<name>`, the plugin now also emits a `pnpm-workspace.yaml$catalog` (or `…$catalogs.<name>`) source entry with the resolved specifier. The original importer entries keep the literal `catalog:` so the source still tells the truth about what's declared in each `package.json`.
- **`src/lib/npm/outdated.ts`**: `extractDepInfo` skips `catalog:`-prefixed specifiers when picking the one to feed into `findWantedVersion`, so the catalog's real range gets used.
- **Tests**: New `src/test/examples/pnpm-catalog/` fixture covering default + named catalogs, plus a new `outdated.test.ts` for `extractDepInfo` and three new `pnpm.test.ts` cases (default catalog, named catalog, dedupe of repeated importer references).

## Verification

`bin/denvig-dev outdated --project upvio/api` now resolves catalog deps:

```
nock              (dev)  14.0.14 (1w)      14.0.15 (1d)  14.0.15 (1d)
express                  4.21.2 (1y)       4.22.1 (5mo)  5.2.1 (5mo)
libphonenumber-js        1.12.42 (2w)      1.12.43 (1d)  1.12.43 (1d)
stripe                   22.1.0 (2w)       22.1.1 (2d)   22.1.1 (2d)
```

(All four had `-` in the Wanted column on `main`.)

## Test plan

- [x] New `src/lib/npm/outdated.test.ts` covers `extractDepInfo` with `catalog:` and `catalog:<name>` specifiers
- [x] New `src/plugins/pnpm.test.ts` cases verify catalog resolution against the new `pnpm-catalog` fixture
- [x] `pnpm run test` — only the 2 pre-existing failures on `main` remain (`run.test.ts`, `pnpm/actions.test.ts`); +7 new passing cases
- [x] `pnpm run codegen` and `pnpm run build` succeed
- [x] Manual: `bin/denvig-dev outdated --project upvio/api` shows wanted versions for all catalog-managed deps