### PR TITLE
Fix OSC 8 hyperlinks in Ghostty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - `deps outdated` now resolves pnpm `catalog:` and `catalog:<name>` specifiers via `pnpm-workspace.yaml` so the `Wanted` column reflects the real version range (previously the literal `catalog:` string was passed to the semver matcher and yielded no wanted update).
+- OSC 8 hyperlinks in `deps outdated` now use the ST (`ESC \`) terminator instead of BEL (`\x07`), so version links render as clickable in Ghostty (previously links only worked in VSCode/Zed integrated terminals). Hyperlinked text is also explicitly underlined via the extended SGR dotted underline (`\x1b[4:4m`/`\x1b[4:0m`) so the clickable indicator is visible in Ghostty (which does not auto-style OSC 8 links).
 
 ### Changed
 

--- a/src/lib/formatters/table.ts
+++ b/src/lib/formatters/table.ts
@@ -41,10 +41,13 @@ export const COLORS = {
  * Handles both BEL (\x07) and ST (\x1b\\) terminators.
  */
 const stripAnsi = (str: string): string => {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: Required for ANSI code stripping
-  return str
-    .replace(/\x1b\[[0-9;:]*m/g, '')
-    .replace(/\x1b]8;;.*?(?:\x07|\x1b\\)/g, '')
+  return (
+    str
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: Required for ANSI code stripping
+      .replace(/\x1b\[[0-9;:]*m/g, '')
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: Required for OSC 8 stripping
+      .replace(/\x1b]8;;.*?(?:\x07|\x1b\\)/g, '')
+  )
 }
 
 /**

--- a/src/lib/formatters/table.ts
+++ b/src/lib/formatters/table.ts
@@ -38,19 +38,24 @@ export const COLORS = {
 
 /**
  * Strip ANSI escape codes and OSC 8 hyperlink sequences from a string to get display width.
+ * Handles both BEL (\x07) and ST (\x1b\\) terminators.
  */
 const stripAnsi = (str: string): string => {
   // biome-ignore lint/suspicious/noControlCharactersInRegex: Required for ANSI code stripping
-  return str.replace(/\x1b\[[0-9;]*m/g, '').replace(/\x1b]8;;[^\x07]*\x07/g, '')
+  return str
+    .replace(/\x1b\[[0-9;:]*m/g, '')
+    .replace(/\x1b]8;;.*?(?:\x07|\x1b\\)/g, '')
 }
 
 /**
  * Wrap text in an OSC 8 hyperlink escape sequence.
+ * Uses ST (ESC \) as terminator for broader terminal compatibility (e.g. Ghostty).
+ * Adds an explicit ANSI underline since Ghostty does not auto-style OSC 8 links.
  * Returns the text unchanged when terminal formatting is disabled.
  */
 export const hyperlink = (text: string, url: string): string => {
   if (!shouldUseColors()) return text
-  return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`
+  return `\x1b]8;;${url}\x1b\\\x1b[4:4m${text}\x1b[4:0m\x1b]8;;\x1b\\`
 }
 
 /**


### PR DESCRIPTION
## Summary

- `deps outdated` version links now render as clickable in Ghostty: switched the OSC 8 terminator from BEL (`\x07`) to ST (`ESC \`), which Ghostty's parser requires.
- Hyperlinked text now carries an explicit dotted ANSI underline (`\x1b[4:4m` / `\x1b[4:0m`) so the clickable indicator is visible in Ghostty (which does not auto-style OSC 8 links). Terminals that do not understand the `4:4` sub-parameter (VSCode, Zed) fall back to a solid underline — still clickable, just not dotted.
- Widened the strip-ansi regex in `formatTable` to allow colons in SGR sub-parameters and to match either BEL or ST when stripping OSC 8 sequences, so column width math stays correct.

## Test plan

- [x] `bin/denvig-dev outdated --project upvio/api` in Ghostty — version columns are underlined (dotted) and Cmd-clickable.
- [x] Same command in VSCode integrated terminal — version columns are underlined (solid) and clickable.
- [x] Same command in Zed integrated terminal — version columns are underlined (solid, since Zed's renderer collapses dotted to solid) and clickable.
- [x] `pnpm run test` — no new failures vs. main.