### PR TITLE
Upgrade semver from 7.7.4 to 7.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded `semver` from 7.7.4 to 7.8.0
+
 ## [0.6.7] - 2026-05-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "node-forge": "^1.4.0",
-    "semver": "^7.7.4",
+    "semver": "^7.8.0",
     "yaml": "^2.8.4",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       semver:
-        specifier: ^7.7.4
-        version: 7.7.4
+        specifier: ^7.8.0
+        version: 7.8.0
       yaml:
         specifier: ^2.8.4
         version: 2.8.4
@@ -627,8 +627,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1177,7 +1177,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.46.2
       fsevents: 2.3.3
 
-  semver@7.7.4: {}
+  semver@7.8.0: {}
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## Package Updates

- semver: [7.7.4 -> 7.8.0](https://github.com/npm/node-semver/releases/tag/v7.8.0)
  - Added new `truncate` function (#855)
  - Warn when defaulting to --inc=patch in CLI (#859)
  - Documentation fixes (typos, BNF grammar for prerelease vs build identifiers)

## Code Changes

No code modifications required. The upgrade is fully backward compatible.

## Checks

- ✅ Checked changelogs for breaking changes
- ✅ Lint passes after upgrade
- ✅ Type check passes after upgrade
- ✅ CLI verified via `bin/denvig-dev version`
- ⚠️ Pre-existing test failures unrelated to semver upgrade (also fail on main)