### PR TITLE
Make --cpu-prof opt-in for bin/denvig-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- `bin/denvig-dev` no longer passes `--cpu-prof` to node by default. Set `DEBUG=denvig:*` or `DEBUG=denvig:cpu` to opt in to CPU profiling (which writes `.cpuprofile` files into the working directory).
 - `services list` now defaults to listing services for the current project only (matching the convention of other commands). Use `--all` to list services across every project plus global services, `--global` to list only global services, or the existing `--project <slug>` to scope to a different project.
 - Upgraded `semver` from 7.7.4 to 7.8.0
 - Upgraded `@biomejs/biome` from 2.4.14 to 2.4.15

--- a/bin/denvig-dev
+++ b/bin/denvig-dev
@@ -1,4 +1,9 @@
 #!/bin/sh
 
-# shellcheck disable=SC2068
-node --cpu-prof --experimental-strip-types src/cli.ts $@
+case "$DEBUG" in
+  "denvig:*"|"denvig:cpu") CPU_PROF="--cpu-prof" ;;
+  *) CPU_PROF="" ;;
+esac
+
+# shellcheck disable=SC2068,SC2086
+node $CPU_PROF --experimental-strip-types src/cli.ts $@


### PR DESCRIPTION
## Summary

- `bin/denvig-dev` previously always passed `--cpu-prof` to node, which writes a `.cpuprofile` file into the working directory on every invocation — noisy for normal day-to-day dev runs.
- CPU profiling is now opt-in: set `DEBUG=denvig:*` or `DEBUG=denvig:cpu` to enable it.
- CHANGELOG updated under `[Unreleased]`.

## Test plan

- [x] `bin/denvig-dev version` runs without producing a `.cpuprofile` file
- [x] `DEBUG=denvig:cpu bin/denvig-dev version` produces a `.cpuprofile` file