### PR TITLE
Error on unknown CLI commands and flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- CLI now errors on unknown subcommands and unrecognised flags instead of silently falling back to the default subcommand. For example `denvig services listtt` or `denvig services --al` previously ran `services list`; both now exit with code 1 and a descriptive message. Commands that intentionally forward extra arguments to subprocesses (`run`, `zsh __complete__`) opt in via a new `acceptsExtraArgs` option on `Command`.
 - `bin/denvig-dev` no longer passes `--cpu-prof` to node by default. Set `DEBUG=denvig:*` or `DEBUG=denvig:cpu` to opt in to CPU profiling (which writes `.cpuprofile` files into the working directory).
 - `services list` now defaults to listing services for the current project only (matching the convention of other commands). Use `--all` to list services across every project plus global services, `--global` to list only global services, or the existing `--project <slug>` to scope to a different project.
 - Upgraded `semver` from 7.7.4 to 7.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed
 
-- CLI now errors on unknown subcommands and unrecognised flags instead of silently falling back to the default subcommand. For example `denvig services listtt` or `denvig services --al` previously ran `services list`; both now exit with code 1 and a descriptive message. Commands that intentionally forward extra arguments to subprocesses (`run`, `zsh __complete__`) opt in via a new `acceptsExtraArgs` option on `Command`.
+- CLI now errors on unknown subcommands and unrecognised flags instead of silently falling back to the default subcommand. For example `denvig services listtt` or `denvig services --al` previously ran `services list`; both now exit with code 1 and a descriptive message followed by the relevant help block (root help for unknown commands, subcommand help for unknown subcommands, command help for unknown flags / missing arguments). Commands that intentionally forward extra arguments to subprocesses (`run`, `zsh __complete__`) opt in via a new `acceptsExtraArgs` option on `Command`.
 - `bin/denvig-dev` no longer passes `--cpu-prof` to node by default. Set `DEBUG=denvig:*` or `DEBUG=denvig:cpu` to opt in to CPU profiling (which writes `.cpuprofile` files into the working directory).
 - `services list` now defaults to listing services for the current project only (matching the convention of other commands). Use `--all` to list services across every project plus global services, `--global` to list only global services, or the existing `--project <slug>` to scope to a different project.
 - Upgraded `semver` from 7.7.4 to 7.8.0

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -58,6 +58,9 @@ describe('cli', () => {
 
     strictEqual(result.code, 1)
     match(result.stderr, /Command "typocommand" not found/)
+    // Root help block follows the error message
+    match(result.stderr, /Denvig v/)
+    match(result.stderr, /Commands:/)
   })
 
   it('should error on unknown subcommand instead of running default', async () => {
@@ -67,6 +70,9 @@ describe('cli', () => {
     match(result.stderr, /Unknown subcommand "listtt" for "services"/)
     match(result.stderr, /Available subcommands:/)
     match(result.stderr, /list/)
+    // Help block follows the error message
+    match(result.stderr, /Usage: denvig services <subcommand>/)
+    match(result.stderr, /Subcommands:/)
   })
 
   it('should error on unknown nested subcommand', async () => {
@@ -81,6 +87,9 @@ describe('cli', () => {
 
     strictEqual(result.code, 1)
     match(result.stderr, /Unknown flag: --al/)
+    // Help block follows the error message
+    match(result.stderr, /Usage: denvig services list/)
+    match(result.stderr, /Options:/)
   })
 
   it('should error on unknown long flag when falling back to default subcommand', async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -52,4 +52,69 @@ describe('cli', () => {
     match(result.stdout, /name/)
     strictEqual(result.stderr, '')
   })
+
+  it('should error on unknown top-level command', async () => {
+    const result = await runTestCommand('denvig typocommand')
+
+    strictEqual(result.code, 1)
+    match(result.stderr, /Command "typocommand" not found/)
+  })
+
+  it('should error on unknown subcommand instead of running default', async () => {
+    const result = await runTestCommand('denvig services listtt')
+
+    strictEqual(result.code, 1)
+    match(result.stderr, /Unknown subcommand "listtt" for "services"/)
+    match(result.stderr, /Available subcommands:/)
+    match(result.stderr, /list/)
+  })
+
+  it('should error on unknown nested subcommand', async () => {
+    const result = await runTestCommand('denvig certs ca whatever')
+
+    strictEqual(result.code, 1)
+    match(result.stderr, /Unknown subcommand "whatever" for "certs:ca"/)
+  })
+
+  it('should error on unknown long flag', async () => {
+    const result = await runTestCommand('denvig services list --al')
+
+    strictEqual(result.code, 1)
+    match(result.stderr, /Unknown flag: --al/)
+  })
+
+  it('should error on unknown long flag when falling back to default subcommand', async () => {
+    const result = await runTestCommand('denvig services --al')
+
+    strictEqual(result.code, 1)
+    match(result.stderr, /Unknown flag: --al/)
+  })
+
+  it('should error on unknown short flag', async () => {
+    const result = await runTestCommand('denvig services list -x')
+
+    strictEqual(result.code, 1)
+    match(result.stderr, /Unknown flag: -x/)
+  })
+
+  it('should error on unexpected positional argument', async () => {
+    const result = await runTestCommand('denvig services list extra-arg')
+
+    strictEqual(result.code, 1)
+    match(result.stderr, /Unexpected argument: "extra-arg"/)
+  })
+
+  it('should still accept the default subcommand when no positional given', async () => {
+    const result = await runTestCommand('denvig services --json')
+
+    strictEqual(result.code, 0)
+    strictEqual(result.stderr, '')
+  })
+
+  it('should allow extra args to be passed through to run', async () => {
+    const result = await runTestCommand('denvig run nonexistent --foo bar')
+
+    strictEqual(result.code, 1)
+    match(result.stderr, /Action "nonexistent" not found/)
+  })
 })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,9 @@
 import { type ParseArgsConfig, parseArgs } from 'node:util'
 
 import {
+  formatCommandHelp,
+  formatRootHelp,
+  formatSubcommandHelp,
   globalFlags,
   showCommandHelp,
   showRootHelp,
@@ -154,9 +157,15 @@ async function main() {
     process.exit(0)
   }
 
+  const printLinesToStderr = (lines: string[]) => {
+    console.error('')
+    for (const line of lines) console.error(line)
+  }
+
   if (!commands[commandName]) {
     const errorMsg = `Command "${commandName}" not found`
     console.error(`${errorMsg}.`)
+    printLinesToStderr(formatRootHelp(commands))
     await cliLogTracker.finish(1, errorMsg)
     process.exit(1)
   }
@@ -181,6 +190,7 @@ async function main() {
         .join(', ')
       const errorMsg = `Unknown subcommand "${nextArg}" for "${command.name}". Available subcommands: ${available}`
       console.error(errorMsg)
+      printLinesToStderr(formatSubcommandHelp(command))
       await cliLogTracker.finish(1, errorMsg)
       process.exit(1)
     } else if (command.defaultSubcommand && !helpRequested) {
@@ -244,6 +254,7 @@ async function main() {
   if (missingArg) {
     const errorMsg = `Missing required argument: ${missingArg}`
     console.error(errorMsg)
+    printLinesToStderr(formatCommandHelp(command))
     await cliLogTracker.finish(1, errorMsg)
     process.exit(1)
   }
@@ -270,6 +281,7 @@ async function main() {
   if (missingFlag) {
     const errorMsg = `Missing required flag: ${missingFlag}`
     console.error(errorMsg)
+    printLinesToStderr(formatCommandHelp(command))
     await cliLogTracker.finish(1, errorMsg)
     process.exit(1)
   }
@@ -288,6 +300,7 @@ async function main() {
         if (!command.acceptsExtraArgs) {
           const errorMsg = `Unexpected argument: "${token.value}"`
           console.error(errorMsg)
+          printLinesToStderr(formatCommandHelp(command))
           await cliLogTracker.finish(1, errorMsg)
           process.exit(1)
         }
@@ -301,6 +314,7 @@ async function main() {
       if (!command.acceptsExtraArgs) {
         const errorMsg = `Unknown flag: ${rawName}`
         console.error(errorMsg)
+        printLinesToStderr(formatCommandHelp(command))
         await cliLogTracker.finish(1, errorMsg)
         process.exit(1)
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,6 +171,18 @@ async function main() {
     if (nextArg && command.subcommands[nextArg]) {
       command = command.subcommands[nextArg]
       subArgIndex++
+    } else if (
+      nextArg &&
+      !nextArg.startsWith('-') &&
+      !command.acceptsExtraArgs
+    ) {
+      const available = Object.keys(command.subcommands)
+        .filter((n) => !n.startsWith('__'))
+        .join(', ')
+      const errorMsg = `Unknown subcommand "${nextArg}" for "${command.name}". Available subcommands: ${available}`
+      console.error(errorMsg)
+      await cliLogTracker.finish(1, errorMsg)
+      process.exit(1)
     } else if (command.defaultSubcommand && !helpRequested) {
       // Only apply default when not requesting help, so --help shows subcommand list
       command = command.subcommands[command.defaultSubcommand]
@@ -264,14 +276,21 @@ async function main() {
 
   // Walk tokens in original order to collect anything not consumed by the
   // command's defined args/flags. This preserves the order users typed so
-  // forwarded subprocesses receive arguments as expected.
+  // forwarded subprocesses receive arguments as expected. Commands that don't
+  // opt in to extraArgs error on any unrecognized positional or flag, which
+  // catches typos like `services listtt` or `services --al`.
   const definedArgsCount = command?.args.length || 0
   const extraArgs: string[] = []
   let positionalIndex = 0
   for (const token of result.tokens ?? []) {
     if (token.kind === 'positional') {
-      // Skip the command name (index 0) and any defined args
       if (positionalIndex > definedArgsCount) {
+        if (!command.acceptsExtraArgs) {
+          const errorMsg = `Unexpected argument: "${token.value}"`
+          console.error(errorMsg)
+          await cliLogTracker.finish(1, errorMsg)
+          process.exit(1)
+        }
         extraArgs.push(token.value)
       }
       positionalIndex++
@@ -279,6 +298,12 @@ async function main() {
       if (recognizedFlagNames.has(token.name)) continue
       if (token.name === 'help' || token.name === 'version') continue
       const rawName = token.rawName ?? `--${token.name}`
+      if (!command.acceptsExtraArgs) {
+        const errorMsg = `Unknown flag: ${rawName}`
+        console.error(errorMsg)
+        await cliLogTracker.finish(1, errorMsg)
+        process.exit(1)
+      }
       if (token.value !== undefined) {
         if (token.inlineValue) {
           extraArgs.push(`${rawName}=${token.value}`)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -18,6 +18,7 @@ export const runCommand = new Command({
     },
   ],
   flags: [],
+  acceptsExtraArgs: true,
   completions: async ({ project }) => {
     const actions = await project.actions
     return Object.keys(actions)

--- a/src/commands/zsh/__complete__.ts
+++ b/src/commands/zsh/__complete__.ts
@@ -9,6 +9,7 @@ export const zshCompleteCommand = new Command({
   example: 'denvig zsh __complete__ -- denvig services',
   args: [],
   flags: [],
+  acceptsExtraArgs: true,
   handler: async ({ project, extraArgs = [] }) => {
     // Get the words passed after --
     const words = extraArgs

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -17,6 +17,12 @@ type CommandOptions<
   ) => string[] | Promise<string[]>
   subcommands?: Record<string, GenericCommand>
   defaultSubcommand?: string
+  /**
+   * When true, unrecognized positional arguments and flags are passed through
+   * to the handler via `extraArgs` instead of triggering a validation error.
+   * Commands that forward to external processes (e.g. `run`) should opt in.
+   */
+  acceptsExtraArgs?: boolean
 }
 
 type ArgDefinition = {
@@ -84,6 +90,7 @@ export class Command<
   ) => string[] | Promise<string[]>
   subcommands: Record<string, GenericCommand>
   defaultSubcommand?: string
+  acceptsExtraArgs: boolean
 
   get hasSubcommands(): boolean {
     return Object.keys(this.subcommands).length > 0
@@ -100,6 +107,7 @@ export class Command<
     this.completions = options.completions
     this.subcommands = options.subcommands ?? {}
     this.defaultSubcommand = options.defaultSubcommand
+    this.acceptsExtraArgs = options.acceptsExtraArgs ?? false
   }
 
   async run(


### PR DESCRIPTION
## Summary

Previously the CLI silently fell back to the default subcommand on unknown input. For example `denvig services listtt` quietly ran `services list`, and `denvig services --al` ran `services list` while dropping the unrecognised flag. This PR makes the CLI strict about its grammar:

- Unknown top-level commands → error + root help
- Unknown subcommands → error + parent's subcommand list
- Unknown flags (long and short) → error + command help
- Unexpected positional arguments → error + command help
- Missing required args / flags now also print command help alongside the existing error

All errors exit with code 1 and print to stderr. The help block appears after the error message so users see available options without having to re-run with `--help`.

Commands that intentionally forward arbitrary args to a subprocess (`run`, `zsh __complete__`) opt in via a new `acceptsExtraArgs: true` option on `Command`.

## Test plan

- [x] `pnpm run check-types` passes
- [x] `pnpm run test` — 9 new cases added under `src/cli.test.ts`; only pre-existing failures (`commands/run` lint output, `pnpm examples/hello`) remain, also failing on `main`
- [x] Manually verified:
  - `denvig services listtt` → unknown subcommand error + help
  - `denvig services --al` → unknown flag error + help
  - `denvig services start` → missing required arg error + help
  - `denvig typocommand` → unknown command error + root help
  - `denvig services`, `denvig services list`, `denvig services --json` still work
  - `denvig run build --foo bar` still passes `--foo bar` through to the spawned subprocess