### PR TITLE
Refactor projects command into parent/subcommand pattern

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,7 +113,7 @@ async function main() {
   const { internalsResourceHashCommand, internalsResourceIdCommand } =
     await import('./commands/internals.ts')
   const { depsCommand } = await import('./commands/deps/index.ts')
-  const { projectsListCommand } = await import('./commands/projects/list.ts')
+  const { projectsCommand } = await import('./commands/projects/index.ts')
   const { zshCompletionsCommand } = await import(
     './commands/zsh/completions.ts'
   )
@@ -133,8 +133,7 @@ async function main() {
     deps: depsCommand,
     'internals:resource-hash': internalsResourceHashCommand,
     'internals:resource-id': internalsResourceIdCommand,
-    projects: projectsListCommand,
-    'projects:list': projectsListCommand,
+    projects: projectsCommand,
     'zsh:completions': zshCompletionsCommand,
     'zsh:__complete__': zshCompleteCommand,
     gateway: gatewayCommand,

--- a/src/commands/projects/index.ts
+++ b/src/commands/projects/index.ts
@@ -1,0 +1,16 @@
+import { Command } from '../../lib/command.ts'
+import { projectsListCommand } from './list.ts'
+
+export const projectsCommand = new Command({
+  name: 'projects',
+  description: 'Manage projects on the system',
+  usage: 'projects <subcommand>',
+  example: 'denvig projects list',
+  args: [],
+  flags: [],
+  subcommands: {
+    list: projectsListCommand,
+  },
+  defaultSubcommand: 'list',
+  handler: () => ({ success: true }),
+})

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -24,10 +24,10 @@ const getStatusIcon = (status: ServiceStatus): string => {
 }
 
 export const projectsListCommand = new Command({
-  name: 'projects',
+  name: 'projects:list',
   description: 'List all projects on the system',
-  usage: 'projects [list] [--with-config]',
-  example: 'projects --json',
+  usage: 'projects list [--with-config]',
+  example: 'projects list --json',
   args: [],
   flags: [
     {

--- a/src/lib/zsh/commands.ts
+++ b/src/lib/zsh/commands.ts
@@ -14,9 +14,7 @@ export const getCommands = async (): Promise<
   const { infoCommand } = await import('../../commands/info.ts')
   const { servicesCommand } = await import('../../commands/services/index.ts')
   const { depsCommand } = await import('../../commands/deps/index.ts')
-  const { projectsListCommand } = await import(
-    '../../commands/projects/list.ts'
-  )
+  const { projectsCommand } = await import('../../commands/projects/index.ts')
   const { zshCommand } = await import('../../commands/zsh/index.ts')
   const { certsCommand } = await import('../../commands/certs/index.ts')
 
@@ -28,7 +26,7 @@ export const getCommands = async (): Promise<
     info: infoCommand,
     services: servicesCommand,
     deps: depsCommand,
-    projects: projectsListCommand,
+    projects: projectsCommand,
     zsh: zshCommand,
     certs: certsCommand,
   }


### PR DESCRIPTION
## Summary

- The root `denvig` help previously rendered `projects` twice because the command was registered under both `projects` and `projects:list` keys pointing at the same flat command.
- Refactored `projects` to match the structure used by `services`, `deps`, etc.: a parent command (`src/commands/projects/index.ts`) with `list` as the default subcommand, and `projectsListCommand` renamed to `projects:list` in `src/commands/projects/list.ts`.
- Updated `src/cli.ts` and `src/lib/zsh/commands.ts` to register the new parent command once.

## Test plan

- [x] `pnpm run check-types`
- [x] `pnpm run test` (only pre-existing `examples / pnpm / actions` failures, unrelated)
- [x] `bin/denvig-dev` root help lists `projects` exactly once
- [x] `bin/denvig-dev projects --help` shows the subcommand list
- [x] `bin/denvig-dev projects` and `bin/denvig-dev projects list` both run the listing