### PR TITLE
Add --worktree flag to services commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Projects now expose a list of refs identifying themselves and the worktree they live in, shown in a new `Refs:` block in `denvig info` and on the SDK's `ProjectResponse`
 - `denvig info` now shows a `Worktrees:` block listing detached git worktrees for the project, also exposed as `worktrees` on the SDK's `ProjectResponse`
+- `--worktree <branch>` flag on every `services` subcommand to target a sibling git worktree without switching directories (use `--worktree main` for the primary checkout)
+- Running `denvig` from inside a detached git worktree now defaults to that worktree's services instead of the primary checkout's
 
 ### Changed
 

--- a/src/commands/services/list.test.ts
+++ b/src/commands/services/list.test.ts
@@ -10,6 +10,9 @@ describe('servicesListCommand', () => {
   })
 
   it('should have correct usage', () => {
-    ok(servicesListCommand.usage === 'services list [--all] [--global]')
+    ok(
+      servicesListCommand.usage ===
+        'services list [--all] [--global] [--worktree <branch>]',
+    )
   })
 })

--- a/src/commands/services/list.ts
+++ b/src/commands/services/list.ts
@@ -8,6 +8,7 @@ import {
   ServiceManager,
   type ServiceResponse,
 } from '../../lib/services/manager.ts'
+import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
 
 const getStatusIcon = (status: 'running' | 'error' | 'stopped'): string => {
   switch (status) {
@@ -23,7 +24,7 @@ const getStatusIcon = (status: 'running' | 'error' | 'stopped'): string => {
 export const servicesListCommand = new Command({
   name: 'services:list',
   description: 'List services for the current project',
-  usage: 'services list [--all] [--global]',
+  usage: 'services list [--all] [--global] [--worktree <branch>]',
   example: 'services list',
   args: [],
   flags: [
@@ -41,22 +42,50 @@ export const servicesListCommand = new Command({
       type: 'boolean',
       defaultValue: false,
     },
+    {
+      name: 'worktree',
+      description:
+        'List services for a sibling git worktree by branch name (use "main" for the primary checkout)',
+      required: false,
+      type: 'string',
+    },
   ],
   completions: () => {
     return []
   },
-  handler: async ({ project, flags }) => {
+  handler: async ({ project: currentProject, flags }) => {
     const all = flags.all as boolean
     const globalOnly = flags.global as boolean
+    const worktreeFlag =
+      typeof flags.worktree === 'string' ? flags.worktree : null
 
-    if (all && globalOnly) {
-      const message = 'Cannot use --all and --global together.'
+    const selectedCount = [all, globalOnly, worktreeFlag !== null].filter(
+      Boolean,
+    ).length
+    if (selectedCount > 1) {
+      const message =
+        'Cannot use --all, --global, and --worktree together. Choose one.'
       if (flags.json) {
         console.log(JSON.stringify({ success: false, message }))
       } else {
         console.error(message)
       }
       return { success: false, message }
+    }
+
+    let project = currentProject
+    if (worktreeFlag !== null) {
+      try {
+        project = await resolveWorktreeProject(currentProject, worktreeFlag)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, message }))
+        } else {
+          console.error(message)
+        }
+        return { success: false, message }
+      }
     }
 
     // Pre-fetch launchctl list once to avoid N shell calls

--- a/src/commands/services/logs.ts
+++ b/src/commands/services/logs.ts
@@ -6,11 +6,12 @@ import {
   getServiceCompletions,
   getServiceContext,
 } from '../../lib/services/identifier.ts'
+import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
 
 export const logsCommand = new Command({
   name: 'services:logs',
   description: 'Show logs for a service',
-  usage: 'services logs <name> [-n <lines>] [--follow]',
+  usage: 'services logs <name> [-n <lines>] [--follow] [--worktree <branch>]',
   example: 'services logs api -n 50 --follow',
   args: [
     {
@@ -36,12 +37,35 @@ export const logsCommand = new Command({
       type: 'boolean',
       defaultValue: false,
     },
+    {
+      name: 'worktree',
+      description:
+        'Target the service in a sibling git worktree by branch name (use "main" for the primary checkout)',
+      required: false,
+      type: 'string',
+    },
   ],
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project, args, flags }) => {
+  handler: async ({ project: currentProject, args, flags }) => {
     const nameArg = args.name as string
+
+    let project = currentProject
+    if (typeof flags.worktree === 'string') {
+      try {
+        project = await resolveWorktreeProject(currentProject, flags.worktree)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, message }))
+        } else {
+          console.error(message)
+        }
+        return { success: false, message }
+      }
+    }
+
     const { manager, serviceName: name } = await getServiceContext(
       nameArg,
       project,

--- a/src/commands/services/restart.test.ts
+++ b/src/commands/services/restart.test.ts
@@ -10,6 +10,9 @@ describe('servicesRestartCommand', () => {
   })
 
   it('should have correct usage', () => {
-    ok(servicesRestartCommand.usage === 'services restart <name>')
+    ok(
+      servicesRestartCommand.usage ===
+        'services restart <name> [--worktree <branch>]',
+    )
   })
 })

--- a/src/commands/services/restart.ts
+++ b/src/commands/services/restart.ts
@@ -6,11 +6,12 @@ import {
   getServiceCompletions,
   getServiceContext,
 } from '../../lib/services/identifier.ts'
+import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
 
 export const servicesRestartCommand = new Command({
   name: 'services:restart',
   description: 'Restart a service',
-  usage: 'services restart <name>',
+  usage: 'services restart <name> [--worktree <branch>]',
   example: 'services restart api',
   args: [
     {
@@ -21,12 +22,35 @@ export const servicesRestartCommand = new Command({
       type: 'string',
     },
   ],
-  flags: [],
+  flags: [
+    {
+      name: 'worktree',
+      description:
+        'Target the service in a sibling git worktree by branch name (use "main" for the primary checkout)',
+      required: false,
+      type: 'string',
+    },
+  ],
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project, args, flags }) => {
+  handler: async ({ project: currentProject, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
+
+    let project = currentProject
+    if (typeof flags.worktree === 'string') {
+      try {
+        project = await resolveWorktreeProject(currentProject, flags.worktree)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, message }))
+        } else {
+          console.error(message)
+        }
+        return { success: false, message }
+      }
+    }
 
     const {
       manager,

--- a/src/commands/services/start.test.ts
+++ b/src/commands/services/start.test.ts
@@ -10,6 +10,9 @@ describe('servicesStartCommand', () => {
   })
 
   it('should have correct usage', () => {
-    ok(servicesStartCommand.usage === 'services start <name>')
+    ok(
+      servicesStartCommand.usage ===
+        'services start <name> [--worktree <branch>]',
+    )
   })
 })

--- a/src/commands/services/start.ts
+++ b/src/commands/services/start.ts
@@ -6,11 +6,12 @@ import {
   getServiceCompletions,
   getServiceContext,
 } from '../../lib/services/identifier.ts'
+import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
 
 export const servicesStartCommand = new Command({
   name: 'services:start',
   description: 'Start a service',
-  usage: 'services start <name>',
+  usage: 'services start <name> [--worktree <branch>]',
   example: 'services start api',
   args: [
     {
@@ -21,12 +22,35 @@ export const servicesStartCommand = new Command({
       type: 'string',
     },
   ],
-  flags: [],
+  flags: [
+    {
+      name: 'worktree',
+      description:
+        'Target the service in a sibling git worktree by branch name (use "main" for the primary checkout)',
+      required: false,
+      type: 'string',
+    },
+  ],
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project, args, flags }) => {
+  handler: async ({ project: currentProject, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
+
+    let project = currentProject
+    if (typeof flags.worktree === 'string') {
+      try {
+        project = await resolveWorktreeProject(currentProject, flags.worktree)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, message }))
+        } else {
+          console.error(message)
+        }
+        return { success: false, message }
+      }
+    }
 
     const {
       manager,

--- a/src/commands/services/status.test.ts
+++ b/src/commands/services/status.test.ts
@@ -10,6 +10,9 @@ describe('servicesStatusCommand', () => {
   })
 
   it('should have correct usage', () => {
-    ok(servicesStatusCommand.usage === 'services status <name>')
+    ok(
+      servicesStatusCommand.usage ===
+        'services status <name> [--worktree <branch>]',
+    )
   })
 })

--- a/src/commands/services/status.ts
+++ b/src/commands/services/status.ts
@@ -9,11 +9,12 @@ import {
   getServiceCompletions,
   getServiceContext,
 } from '../../lib/services/identifier.ts'
+import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
 
 export const servicesStatusCommand = new Command({
   name: 'services:status',
   description: 'Show status of a specific service',
-  usage: 'services status <name>',
+  usage: 'services status <name> [--worktree <branch>]',
   example: 'services status api or services status marcqualie/denvig/hello',
   args: [
     {
@@ -24,12 +25,36 @@ export const servicesStatusCommand = new Command({
       type: 'string',
     },
   ],
-  flags: [],
+  flags: [
+    {
+      name: 'worktree',
+      description:
+        'Target the service in a sibling git worktree by branch name (use "main" for the primary checkout)',
+      required: false,
+      type: 'string',
+    },
+  ],
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project, args, flags }) => {
+  handler: async ({ project: currentProject, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
+
+    let project = currentProject
+    if (typeof flags.worktree === 'string') {
+      try {
+        project = await resolveWorktreeProject(currentProject, flags.worktree)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, message }))
+        } else {
+          console.error(message)
+        }
+        return { success: false, message }
+      }
+    }
+
     const {
       manager,
       serviceName,

--- a/src/commands/services/stop.test.ts
+++ b/src/commands/services/stop.test.ts
@@ -10,6 +10,9 @@ describe('servicesStopCommand', () => {
   })
 
   it('should have correct usage', () => {
-    ok(servicesStopCommand.usage === 'services stop <name>')
+    ok(
+      servicesStopCommand.usage ===
+        'services stop <name> [--worktree <branch>]',
+    )
   })
 })

--- a/src/commands/services/stop.ts
+++ b/src/commands/services/stop.ts
@@ -5,11 +5,12 @@ import {
   getServiceCompletions,
   getServiceContext,
 } from '../../lib/services/identifier.ts'
+import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
 
 export const servicesStopCommand = new Command({
   name: 'services:stop',
   description: 'Stop a service',
-  usage: 'services stop <name>',
+  usage: 'services stop <name> [--worktree <branch>]',
   example: 'services stop api',
   args: [
     {
@@ -20,12 +21,35 @@ export const servicesStopCommand = new Command({
       type: 'string',
     },
   ],
-  flags: [],
+  flags: [
+    {
+      name: 'worktree',
+      description:
+        'Target the service in a sibling git worktree by branch name (use "main" for the primary checkout)',
+      required: false,
+      type: 'string',
+    },
+  ],
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project, args, flags }) => {
+  handler: async ({ project: currentProject, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
+
+    let project = currentProject
+    if (typeof flags.worktree === 'string') {
+      try {
+        project = await resolveWorktreeProject(currentProject, flags.worktree)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, message }))
+        } else {
+          console.error(message)
+        }
+        return { success: false, message }
+      }
+    }
 
     const {
       manager,

--- a/src/commands/services/teardown.ts
+++ b/src/commands/services/teardown.ts
@@ -1,10 +1,11 @@
 import { Command } from '../../lib/command.ts'
+import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
 import { teardownGlobal, teardownProject } from '../../lib/teardown.ts'
 
 export const servicesTeardownCommand = new Command({
   name: 'services:teardown',
   description: 'Stop all services and remove them from launchctl',
-  usage: 'services teardown [--global] [--remove-logs]',
+  usage: 'services teardown [--global] [--remove-logs] [--worktree <branch>]',
   example: 'services teardown',
   args: [],
   flags: [
@@ -22,10 +23,44 @@ export const servicesTeardownCommand = new Command({
       type: 'boolean',
       defaultValue: false,
     },
+    {
+      name: 'worktree',
+      description:
+        'Teardown services for a sibling git worktree by branch name (use "main" for the primary checkout)',
+      required: false,
+      type: 'string',
+    },
   ],
-  handler: async ({ project, flags }) => {
+  handler: async ({ project: currentProject, flags }) => {
     const removeLogs = flags['remove-logs'] as boolean
     const global = flags.global as boolean
+    const worktreeFlag =
+      typeof flags.worktree === 'string' ? flags.worktree : null
+
+    if (global && worktreeFlag !== null) {
+      const message = 'Cannot use --global and --worktree together.'
+      if (flags.json) {
+        console.log(JSON.stringify({ success: false, message }))
+      } else {
+        console.error(message)
+      }
+      return { success: false, message }
+    }
+
+    let project = currentProject
+    if (worktreeFlag !== null) {
+      try {
+        project = await resolveWorktreeProject(currentProject, worktreeFlag)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, message }))
+        } else {
+          console.error(message)
+        }
+        return { success: false, message }
+      }
+    }
 
     if (global) {
       // Global teardown - all denvig services across all projects

--- a/src/lib/services/worktree.test.ts
+++ b/src/lib/services/worktree.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert'
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+
+import { DenvigProject } from '../project.ts'
+import { resolveWorktreeProject } from './worktree.ts'
+
+const primaryPath = '/tmp/denvig-test-worktree-primary'
+const worktreePath = `${primaryPath}+feature`
+
+const initRepo = () => {
+  fs.mkdirSync(primaryPath, { recursive: true })
+  execSync('git init -q -b main', { cwd: primaryPath })
+  execSync('git config user.email "test@denvig.test"', { cwd: primaryPath })
+  execSync('git config user.name "Denvig Test"', { cwd: primaryPath })
+  execSync('git commit --allow-empty -q -m "Initial commit"', {
+    cwd: primaryPath,
+  })
+}
+
+describe('resolveWorktreeProject()', () => {
+  beforeEach(() => initRepo())
+  afterEach(() => {
+    fs.rmSync(primaryPath, { recursive: true, force: true })
+    fs.rmSync(worktreePath, { recursive: true, force: true })
+  })
+
+  it('resolves a sibling worktree by branch name', async () => {
+    execSync(`git worktree add ${worktreePath} -b feature`, {
+      cwd: primaryPath,
+    })
+    const primary = await DenvigProject.retrieve(primaryPath)
+    const worktreeProject = await resolveWorktreeProject(primary, 'feature')
+    const realWorktreePath = fs.realpathSync(worktreePath)
+    assert.strictEqual(worktreeProject.path, realWorktreePath)
+  })
+
+  it('resolves "main" to the primary checkout when called from a worktree', async () => {
+    execSync(`git worktree add ${worktreePath} -b feature`, {
+      cwd: primaryPath,
+    })
+    const worktreeProject = await DenvigProject.retrieve(worktreePath)
+    const primaryProject = await resolveWorktreeProject(worktreeProject, 'main')
+    const realPrimaryPath = fs.realpathSync(primaryPath)
+    assert.strictEqual(primaryProject.path, realPrimaryPath)
+  })
+
+  it('throws when the branch does not match any worktree', async () => {
+    const primary = await DenvigProject.retrieve(primaryPath)
+    await assert.rejects(
+      () => resolveWorktreeProject(primary, 'nonexistent'),
+      /Worktree with branch "nonexistent" not found/,
+    )
+  })
+})

--- a/src/lib/services/worktree.ts
+++ b/src/lib/services/worktree.ts
@@ -1,0 +1,32 @@
+import { readGitInfo } from '../project/git.ts'
+import { DenvigProject } from '../project.ts'
+
+/**
+ * Resolve a worktree branch name to a `DenvigProject`. The branch `main`
+ * always resolves to the primary checkout (matching the convention used by
+ * `projectRefs`). Other branches are looked up against the project's detached
+ * worktrees.
+ *
+ * Throws when the branch does not match any worktree (or the primary).
+ */
+export const resolveWorktreeProject = async (
+  currentProject: DenvigProject,
+  branch: string,
+): Promise<DenvigProject> => {
+  if (branch === 'main') {
+    const info = readGitInfo(currentProject.path)
+    if (info?.worktree.primaryPath) {
+      return await DenvigProject.retrieve(info.worktree.primaryPath)
+    }
+  }
+
+  const worktree = currentProject.worktrees.find((w) => w.branch === branch)
+  if (!worktree) {
+    const available = currentProject.worktrees.map((w) => w.branch)
+    const hint = available.length
+      ? ` Available worktrees: ${available.join(', ')}`
+      : ''
+    throw new Error(`Worktree with branch "${branch}" not found.${hint}`)
+  }
+  return await DenvigProject.retrieve(worktree.path)
+}


### PR DESCRIPTION
## Summary

- Adds `--worktree <branch>` to every `services` subcommand (`list`, `start`, `stop`, `restart`, `status`, `logs`, `teardown`) so a sibling git worktree's services can be managed without switching the current branch. Use `--worktree main` to target the primary checkout.
- New `resolveWorktreeProject()` helper in `src/lib/services/worktree.ts` does the branch → `DenvigProject` lookup (`main` → primary via `readGitInfo`, otherwise matched against `project.worktrees`).
- For `list`, `--worktree` is mutually exclusive with `--all` and `--global`; for `teardown`, mutually exclusive with `--global`.
- The detached-worktree default ("services default to the worktree's services when run from inside one") already falls out of the existing `listProjects()` + cwd matching in `cli.ts` — confirmed against the local `denvig+worktree1` worktree.

## Test plan

- [x] `pnpm exec node --test src/lib/services/worktree.test.ts` — 3 new tests pass
- [x] `pnpm run lint` clean
- [x] `pnpm run codegen` clean
- [x] `pnpm run build` clean
- [x] `bin/denvig-dev services list --worktree denvig+worktree1` returns the worktree's services
- [x] `bin/denvig-dev services list --worktree nonexistent` errors with available worktree list
- [x] Running from inside `denvig+worktree1` resolves to that worktree (same id as `--worktree denvig+worktree1` from primary)
- [x] `bin/denvig-dev services list --worktree main` from inside a worktree resolves to the primary

Note: two pre-existing test failures in `src/commands/run.test.ts` and `src/test/examples/pnpm/actions.test.ts` are unrelated to this change (verified on `main`/branch base).