### PR TITLE
SDK services.list defaults to every project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `services list` now defaults to the current project; use `--all` for every project plus globals, or `--global` for globals only
 - Migrated the build from `tsup` to `rolldown`
 - Removed the default export from the SDK entry point; use the named import (`import { DenvigSDK } from 'denvig'`)
+- SDK `services.list()` now returns services from every project by default; pass `{ project }` to scope to one project and `{ project, worktree }` to target a worktree
 
 ## [0.6.7] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `~/.denvig/state.json` is now the source of truth for services: `services start` snapshots the full config (command, env, http, etc.) into state and every mutating `services` command then reconciles launchctl against it (starting services that should be running, stopping unknown ones, restarting when the snapshot drifts from the on-disk plist)
 - `denvig gateway configure` now runs the same reconcile pass before rebuilding nginx, so it can be used to manually re-sync launchctl with state.json
 - `~/.denvig/state.json` now also tracks SSL certs in a top-level `certs` map and each gateway route references the cert it should present; nginx is rendered from this snapshot rather than re-scanning `~/.denvig/certs/` on every regeneration
+- `services list --status <running|stopped|error>` filters the output by runtime status, and accepts a comma-separated list (e.g., `--status stopped,error`)
 
 ### Changed
 
@@ -26,7 +27,7 @@
 - `services list` now defaults to the current project; use `--all` for every project plus globals, or `--global` for globals only
 - Migrated the build from `tsup` to `rolldown`
 - Removed the default export from the SDK entry point; use the named import (`import { DenvigSDK } from 'denvig'`)
-- SDK `services.list()` now returns services from every project by default; pass `{ project }` to scope to one project and `{ project, worktree }` to target a worktree
+- SDK `services.list()` now returns services from every project by default; pass `{ project }` to scope to one project, `{ project, worktree }` to target a worktree, and `{ status }` to filter by runtime status
 
 ## [0.6.7] - 2026-05-08
 

--- a/src/commands/services/list.test.ts
+++ b/src/commands/services/list.test.ts
@@ -12,7 +12,7 @@ describe('servicesListCommand', () => {
   it('should have correct usage', () => {
     ok(
       servicesListCommand.usage ===
-        'services list [--all] [--global] [--worktree <branch>]',
+        'services list [--all] [--global] [--worktree <branch>] [--status <status>]',
     )
   })
 })

--- a/src/commands/services/list.ts
+++ b/src/commands/services/list.ts
@@ -24,7 +24,8 @@ const getStatusIcon = (status: 'running' | 'error' | 'stopped'): string => {
 export const servicesListCommand = new Command({
   name: 'services:list',
   description: 'List services for the current project',
-  usage: 'services list [--all] [--global] [--worktree <branch>]',
+  usage:
+    'services list [--all] [--global] [--worktree <branch>] [--status <status>]',
   example: 'services list',
   args: [],
   flags: [
@@ -49,6 +50,13 @@ export const servicesListCommand = new Command({
       required: false,
       type: 'string',
     },
+    {
+      name: 'status',
+      description:
+        'Filter by runtime status. Accepts a single value or a comma-separated list (running, stopped, error).',
+      required: false,
+      type: 'string',
+    },
   ],
   completions: () => {
     return []
@@ -58,6 +66,24 @@ export const servicesListCommand = new Command({
     const globalOnly = flags.global as boolean
     const worktreeFlag =
       typeof flags.worktree === 'string' ? flags.worktree : null
+    const statusFlag = typeof flags.status === 'string' ? flags.status : null
+
+    const validStatuses = new Set(['running', 'stopped', 'error'])
+    const statusFilter = statusFlag
+      ? statusFlag.split(',').map((s) => s.trim().toLowerCase())
+      : null
+    if (statusFilter) {
+      const invalid = statusFilter.filter((s) => !validStatuses.has(s))
+      if (invalid.length > 0) {
+        const message = `Invalid --status value(s): ${invalid.join(', ')}. Allowed: running, stopped, error.`
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, message }))
+        } else {
+          console.error(message)
+        }
+        return { success: false, message }
+      }
+    }
 
     if ((all || globalOnly) && worktreeFlag !== null) {
       const message = '--worktree cannot be combined with --all or --global.'
@@ -139,23 +165,27 @@ export const servicesListCommand = new Command({
       await collectFromManager(new ServiceManager(project), allServices)
     }
 
-    if (allServices.length === 0) {
+    const filteredServices = statusFilter
+      ? allServices.filter((s) => statusFilter.includes(s.status))
+      : allServices
+
+    if (filteredServices.length === 0) {
       if (flags.json) {
         console.log(JSON.stringify([]))
+      } else if (statusFilter) {
+        console.log(`No services matching status: ${statusFilter.join(', ')}.`)
+      } else if (globalOnly) {
+        console.log('No global services configured.')
+      } else if (all) {
+        console.log('No services configured across any project.')
       } else {
-        if (globalOnly) {
-          console.log('No global services configured.')
-        } else if (all) {
-          console.log('No services configured across any project.')
-        } else {
-          console.log(`No services configured for ${project.slug}.`)
-        }
+        console.log(`No services configured for ${project.slug}.`)
       }
       return { success: true, message: 'No services configured.' }
     }
 
     const currentProjectSlug = project.slug
-    const sortedServices = allServices.sort((a, b) => {
+    const sortedServices = filteredServices.sort((a, b) => {
       const aIsCurrent = a.project.slug === currentProjectSlug
       const bIsCurrent = b.project.slug === currentProjectSlug
 
@@ -207,17 +237,21 @@ export const servicesListCommand = new Command({
     }
 
     console.log('')
+    const shown = filteredServices.length
+    const statusSuffix = statusFilter
+      ? ` (filtered by status: ${statusFilter.join(', ')})`
+      : ''
     if (all) {
       console.log(
-        `${allServices.length} service${allServices.length === 1 ? '' : 's'} configured across ${projectCount} project${projectCount === 1 ? '' : 's'}`,
+        `${shown} service${shown === 1 ? '' : 's'} configured across ${projectCount} project${projectCount === 1 ? '' : 's'}${statusSuffix}`,
       )
     } else if (globalOnly) {
       console.log(
-        `${allServices.length} global service${allServices.length === 1 ? '' : 's'} configured`,
+        `${shown} global service${shown === 1 ? '' : 's'} configured${statusSuffix}`,
       )
     } else {
       console.log(
-        `${allServices.length} service${allServices.length === 1 ? '' : 's'} configured for ${project.slug}`,
+        `${shown} service${shown === 1 ? '' : 's'} configured for ${project.slug}${statusSuffix}`,
       )
     }
 

--- a/src/commands/services/list.ts
+++ b/src/commands/services/list.ts
@@ -45,7 +45,7 @@ export const servicesListCommand = new Command({
     {
       name: 'worktree',
       description:
-        'List services for a sibling git worktree by branch name (use "main" for the primary checkout)',
+        'List services for a sibling git worktree by branch name (use "main" for the primary checkout). Pair with the global --project flag to target a worktree of another project.',
       required: false,
       type: 'string',
     },
@@ -59,12 +59,18 @@ export const servicesListCommand = new Command({
     const worktreeFlag =
       typeof flags.worktree === 'string' ? flags.worktree : null
 
-    const selectedCount = [all, globalOnly, worktreeFlag !== null].filter(
-      Boolean,
-    ).length
-    if (selectedCount > 1) {
-      const message =
-        'Cannot use --all, --global, and --worktree together. Choose one.'
+    if ((all || globalOnly) && worktreeFlag !== null) {
+      const message = '--worktree cannot be combined with --all or --global.'
+      if (flags.json) {
+        console.log(JSON.stringify({ success: false, message }))
+      } else {
+        console.error(message)
+      }
+      return { success: false, message }
+    }
+
+    if (all && globalOnly) {
+      const message = 'Cannot combine --all and --global. Choose one.'
       if (flags.json) {
         console.log(JSON.stringify({ success: false, message }))
       } else {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -71,6 +71,8 @@ export type DenvigSDKOptions = {
   client: string
 }
 
+export type ServiceRuntimeStatus = 'running' | 'stopped' | 'error'
+
 export type ListServicesOptions = {
   /**
    * Filter to a specific project slug (e.g., `github:marcqualie/denvig`).
@@ -82,6 +84,11 @@ export type ListServicesOptions = {
    * Use `main` to target the primary checkout. Requires `project`.
    */
   worktree?: string
+  /**
+   * Filter by runtime status. Pass a single status or an array to match any
+   * of multiple (e.g., `['stopped', 'error']` for everything that isn't running).
+   */
+  status?: ServiceRuntimeStatus | ServiceRuntimeStatus[]
 }
 
 export type ServiceOperationOptions = {
@@ -282,12 +289,17 @@ export class DenvigSDK {
           'services.list: `worktree` requires `project` to be specified.',
         )
       }
-      const flags = options?.project
+      const status = Array.isArray(options?.status)
+        ? options.status.join(',')
+        : options?.status
+      const scopeFlags = options?.project
         ? this.buildFlags({
             project: options.project,
             worktree: options.worktree,
           })
         : '--all'
+      const statusFlags = status ? this.buildFlags({ status }) : ''
+      const flags = [scopeFlags, statusFlags].filter(Boolean).join(' ')
       return this.run<ServiceResponse[]>(`services ${flags}`.trim())
     },
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -72,13 +72,24 @@ export type DenvigSDKOptions = {
 }
 
 export type ListServicesOptions = {
-  /** Filter to a specific project slug */
+  /**
+   * Filter to a specific project slug (e.g., `github:marcqualie/denvig`).
+   * When omitted, services from all projects are returned.
+   */
   project?: string
+  /**
+   * Filter to a specific git worktree branch within the project.
+   * Use `main` to target the primary checkout. Requires `project`.
+   */
+  worktree?: string
 }
 
 export type ServiceOperationOptions = {
-  /** Filter to a specific project slug */
-  project?: string
+  /**
+   * Target a specific git worktree branch by name. Use `main` for the
+   * primary checkout.
+   */
+  worktree?: string
 }
 
 export type DepsListOptions = {
@@ -261,10 +272,22 @@ export class DenvigSDK {
    */
   services = {
     /**
-     * List all services across all projects.
+     * List services. By default returns services for all projects.
+     * Pass `project` to filter to a single project, and optionally
+     * `worktree` to target one of its worktrees.
      */
     list: async (options?: ListServicesOptions): Promise<ServiceResponse[]> => {
-      const flags = options ? this.buildFlags(options) : ''
+      if (options?.worktree && !options.project) {
+        throw new Error(
+          'services.list: `worktree` requires `project` to be specified.',
+        )
+      }
+      const flags = options?.project
+        ? this.buildFlags({
+            project: options.project,
+            worktree: options.worktree,
+          })
+        : '--all'
       return this.run<ServiceResponse[]>(`services ${flags}`.trim())
     },
 


### PR DESCRIPTION
## Summary

- `DenvigSDK.services.list()` now returns services from **every project** by default (using `--all` under the hood), matching how SDK consumers like the Raycast extension typically work without a cwd context.
- Pass `{ project }` to scope to a single project, and optionally `{ project, worktree }` to target one of its worktrees. Passing `worktree` without `project` throws.
- `ServiceOperationOptions` no longer carries an unused `project` field — only `worktree` — matching what the CLI start/stop/status/restart commands actually accept.
- The CLI's `services list` already honoured the global `--project <slug>` flag; `--worktree` now resolves relative to that project so `services list --project foo --worktree bar` works without `cd`-ing into the project.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run check-types`
- [x] `pnpm exec node --test src/commands/services/list.test.ts`
- [x] Manual: `denvig services list --all --json`
- [x] Manual: `denvig services list --project github:marcqualie/denvig --json`
- [x] Manual: `denvig services list --project github:marcqualie/denvig --worktree denvig+worktree1 --json`