### PR TITLE
Publish prereleases under matching npm dist-tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,12 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm test
-      - run: pnpm publish --no-git-checks
+      - name: Choose npm dist-tag
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            *-alpha.*) echo "NPM_TAG=alpha"  >> "$GITHUB_ENV" ;;
+            *-beta.*)  echo "NPM_TAG=beta"   >> "$GITHUB_ENV" ;;
+            *-rc.*)    echo "NPM_TAG=rc"     >> "$GITHUB_ENV" ;;
+            *)         echo "NPM_TAG=latest" >> "$GITHUB_ENV" ;;
+          esac
+      - run: pnpm publish --no-git-checks --tag "$NPM_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Prerelease tags (`vX.Y.Z-alpha.N` / `-beta.N` / `-rc.N`) now publish to npm under matching dist-tags (`@alpha`, `@beta`, `@rc`) instead of `@latest`, so `pnpm add denvig` keeps tracking stable releases
+
 ## [0.7.0-alpha.1] - 2026-05-28
 
 ### Added


### PR DESCRIPTION
## Summary

- Prerelease tags (`vX.Y.Z-alpha.N` / `-beta.N` / `-rc.N`) currently fail to publish: `npm error You must specify a tag using --tag when publishing a prerelease version` ([failed run](https://github.com/marcqualie/denvig/actions/runs/26571491174/job/78279487354)).
- Derive the npm dist-tag from the git ref so prereleases publish under `@alpha` / `@beta` / `@rc` and stable releases keep going to `@latest`.
- Consumers can now opt into prereleases with `pnpm add denvig@alpha` without polluting the default `latest` tag.

## Test plan

- [ ] Tag a fresh prerelease (e.g. `v0.7.0-alpha.2`) after merge and confirm the publish workflow succeeds.
- [ ] Verify `npm view denvig dist-tags` shows the new `alpha` entry and `latest` is unchanged.
- [ ] Tag a future stable release and confirm it still publishes to `@latest`.