### PR TITLE
Exclude detached worktrees from project listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `denvig projects` and the SDK's `projects.list` no longer list detached git worktrees as standalone projects
+
 ## [0.7.0-alpha.2] - 2026-05-28
 
 ### Changed

--- a/src/lib/project/git.test.ts
+++ b/src/lib/project/git.test.ts
@@ -9,6 +9,7 @@ import { inspect } from 'node:util'
 import {
   detectProjectWorktrees,
   getGitHubSlug,
+  isDetachedWorktree,
   normaliseGitRemote,
   parseGitHubRemoteUrl,
 } from './git.ts'
@@ -500,5 +501,38 @@ describe('detectProjectWorktrees()', () => {
       { path: realWorktree, branch: 'branch-a' },
       { path: realWorktree2, branch: 'branch-b' },
     ])
+  })
+})
+
+describe('isDetachedWorktree()', () => {
+  beforeEach(() => {
+    fs.mkdirSync(mockProjectPath, { recursive: true })
+    execSync('git init -q -b main', { cwd: mockProjectPath })
+    execSync('git config user.email "test@denvig.test"', {
+      cwd: mockProjectPath,
+    })
+    execSync('git config user.name "Denvig Test"', { cwd: mockProjectPath })
+    execSync('git commit --allow-empty -q -m "Initial commit"', {
+      cwd: mockProjectPath,
+    })
+  })
+  afterEach(() => {
+    fs.rmSync(mockProjectPath, { recursive: true, force: true })
+    fs.rmSync(worktreePath, { recursive: true, force: true })
+  })
+
+  it('returns false for a primary checkout', () => {
+    strictEqual(isDetachedWorktree(mockProjectPath), false)
+  })
+
+  it('returns false for a non-git directory', () => {
+    strictEqual(isDetachedWorktree('/path/to/project'), false)
+  })
+
+  it('returns true for a detached worktree', () => {
+    execSync(`git worktree add ${worktreePath} -b test-branch`, {
+      cwd: mockProjectPath,
+    })
+    strictEqual(isDetachedWorktree(worktreePath), true)
   })
 })

--- a/src/lib/project/git.ts
+++ b/src/lib/project/git.ts
@@ -152,6 +152,25 @@ export const detectGitWorktree = (path: string): GitWorktree | null => {
   return readGitInfo(resolve(path))?.worktree ?? null
 }
 
+/**
+ * True when `path` is a detached git worktree rather than the primary
+ * checkout. Worktrees are a subset of their primary project, so this is used
+ * to keep them out of project listings. Non-git paths and primary checkouts
+ * return false.
+ */
+export const isDetachedWorktree = (path: string): boolean => {
+  const absolutePath = resolve(path)
+  const info = readGitInfo(absolutePath)
+  if (!info) return false
+  let real: string
+  try {
+    real = realpathSync(absolutePath)
+  } catch {
+    real = absolutePath
+  }
+  return info.worktree.primaryPath !== real
+}
+
 export type ProjectWorktree = {
   /** Absolute path of the detached worktree's checkout. */
   path: string

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,6 +1,7 @@
 import { readdir } from 'node:fs/promises'
 
 import { expandTilde, getGlobalConfig } from './config.ts'
+import { isDetachedWorktree } from './project/git.ts'
 import { projectSlug } from './project/refs.ts'
 import { isDirectory, pathExists } from './safeReadFile.ts'
 
@@ -99,6 +100,9 @@ export const listProjects = async (
   const projects = (
     await Promise.all(
       uniquePaths.map(async (projectPath): Promise<ProjectInfo | null> => {
+        // Worktrees are a subset of their primary checkout, not standalone
+        // projects, so exclude them from the listing.
+        if (isDetachedWorktree(projectPath)) return null
         if (withConfig) {
           const configPath = `${projectPath}/.denvig.yml`
           if (!(await pathExists(configPath))) return null


### PR DESCRIPTION
## Summary

`denvig projects` (and the SDK's `projects.list`) were listing detached git worktrees as standalone projects. Project discovery scans glob patterns like `~/src/*/*`, which also match sibling worktree directories (e.g. `denvig+worktree1`). Since a worktree is a subset of its primary checkout — not a project in itself — surfacing them was confusing.

## Changes

- Added an `isDetachedWorktree()` helper in `src/lib/project/git.ts`. It reuses the existing `readGitInfo()` (a detached worktree's `.git` is a *file* pointing at the primary checkout, vs a *directory* for the primary) and compares the resolved path to its primary checkout path.
- `listProjects()` now skips detached worktrees. Primary checkouts and non-git paths are unaffected.
- Added tests covering primary checkout (false), non-git dir (false), and detached worktree (true).
- Updated the `[Unreleased]` section of the changelog.

## Verification

- New and existing git tests pass.
- `codegen`, `lint`, and `build` are all clean.
- Confirmed `denvig projects` no longer lists `denvig+worktree1` while the primary `~/src/marcqualie/denvig` remains.
- The pre-existing `examples/pnpm` test failures are unrelated (they fail identically on a clean tree).