### PR TITLE
Revert "Exclude detached worktrees from project listings (#202)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@
 
 - Shell completions moved to `denvig shell completions zsh` (pass the shell as an argument); unsupported shells now show a helpful error instead of being silently ignored
 
-### Fixed
-
-- `denvig projects` and the SDK's `projects.list` no longer list detached git worktrees as standalone projects
-
 ## [0.7.0-alpha.2] - 2026-05-28
 
 ### Changed

--- a/src/lib/project/git.test.ts
+++ b/src/lib/project/git.test.ts
@@ -9,7 +9,6 @@ import { inspect } from 'node:util'
 import {
   detectProjectWorktrees,
   getGitHubSlug,
-  isDetachedWorktree,
   normaliseGitRemote,
   parseGitHubRemoteUrl,
 } from './git.ts'
@@ -501,38 +500,5 @@ describe('detectProjectWorktrees()', () => {
       { path: realWorktree, branch: 'branch-a' },
       { path: realWorktree2, branch: 'branch-b' },
     ])
-  })
-})
-
-describe('isDetachedWorktree()', () => {
-  beforeEach(() => {
-    fs.mkdirSync(mockProjectPath, { recursive: true })
-    execSync('git init -q -b main', { cwd: mockProjectPath })
-    execSync('git config user.email "test@denvig.test"', {
-      cwd: mockProjectPath,
-    })
-    execSync('git config user.name "Denvig Test"', { cwd: mockProjectPath })
-    execSync('git commit --allow-empty -q -m "Initial commit"', {
-      cwd: mockProjectPath,
-    })
-  })
-  afterEach(() => {
-    fs.rmSync(mockProjectPath, { recursive: true, force: true })
-    fs.rmSync(worktreePath, { recursive: true, force: true })
-  })
-
-  it('returns false for a primary checkout', () => {
-    strictEqual(isDetachedWorktree(mockProjectPath), false)
-  })
-
-  it('returns false for a non-git directory', () => {
-    strictEqual(isDetachedWorktree('/path/to/project'), false)
-  })
-
-  it('returns true for a detached worktree', () => {
-    execSync(`git worktree add ${worktreePath} -b test-branch`, {
-      cwd: mockProjectPath,
-    })
-    strictEqual(isDetachedWorktree(worktreePath), true)
   })
 })

--- a/src/lib/project/git.ts
+++ b/src/lib/project/git.ts
@@ -152,25 +152,6 @@ export const detectGitWorktree = (path: string): GitWorktree | null => {
   return readGitInfo(resolve(path))?.worktree ?? null
 }
 
-/**
- * True when `path` is a detached git worktree rather than the primary
- * checkout. Worktrees are a subset of their primary project, so this is used
- * to keep them out of project listings. Non-git paths and primary checkouts
- * return false.
- */
-export const isDetachedWorktree = (path: string): boolean => {
-  const absolutePath = resolve(path)
-  const info = readGitInfo(absolutePath)
-  if (!info) return false
-  let real: string
-  try {
-    real = realpathSync(absolutePath)
-  } catch {
-    real = absolutePath
-  }
-  return info.worktree.primaryPath !== real
-}
-
 export type ProjectWorktree = {
   /** Absolute path of the detached worktree's checkout. */
   path: string

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,7 +1,6 @@
 import { readdir } from 'node:fs/promises'
 
 import { expandTilde, getGlobalConfig } from './config.ts'
-import { isDetachedWorktree } from './project/git.ts'
 import { projectSlug } from './project/refs.ts'
 import { isDirectory, pathExists } from './safeReadFile.ts'
 
@@ -100,9 +99,6 @@ export const listProjects = async (
   const projects = (
     await Promise.all(
       uniquePaths.map(async (projectPath): Promise<ProjectInfo | null> => {
-        // Worktrees are a subset of their primary checkout, not standalone
-        // projects, so exclude them from the listing.
-        if (isDetachedWorktree(projectPath)) return null
         if (withConfig) {
           const configPath = `${projectPath}/.denvig.yml`
           if (!(await pathExists(configPath))) return null


### PR DESCRIPTION
## Summary

Reverts #202 (commit 7eca35c), which excluded detached git worktrees from project listings.

That change made `listProjects()` skip detached worktrees, but the same function backs the cwd-to-project detection in `cli.ts`. As a result, running commands like `denvig outdated` and `denvig info` inside a worktree no longer resolved the worktree's own config, dependencies, or refs — they fell through to a coincidental parent directory.

Rather than patch around the listing filter, we're reverting it cleanly and will revisit hiding worktrees from `denvig projects` with a separate approach that doesn't break project resolution.

## Changes

- Removes the `isDetachedWorktree()` helper and its tests
- Restores `listProjects()` to include detached worktrees
- Reverts the corresponding changelog entry

## Notes

- The revert was clean apart from a CHANGELOG.md conflict (resolved to keep the unrelated #203 entry).
- `codegen`, `lint`, and `check-types` are clean.