### PR TITLE
Model projects as owning their worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Shell completions moved to `denvig shell completions zsh` (pass the shell as an argument); unsupported shells now show a helpful error instead of being silently ignored
 - `denvig projects` now groups each project's worktrees beneath it as a subtree instead of listing them as separate projects
+- `denvig services list --worktrees` nests each project's worktree services beneath it (pair with `--all` to show worktrees for every project)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 ### Changed
 
 - Shell completions moved to `denvig shell completions zsh` (pass the shell as an argument); unsupported shells now show a helpful error instead of being silently ignored
+- `denvig projects` now groups each project's worktrees beneath it as a subtree instead of listing them as separate projects
+
+### Fixed
+
+- Running denvig inside a git worktree (including subdirectories and nested layouts) now resolves the worktree's own config, dependencies, and refs
 
 ## [0.7.0-alpha.2] - 2026-05-28
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import {
 } from './lib/cli-help.ts'
 import { createCliLogTracker } from './lib/cli-logs.ts'
 import { expandTilde, getGlobalConfig } from './lib/config.ts'
-import { getGitHubSlug } from './lib/project/git.ts'
+import { findDetachedWorktreeRoot, getGitHubSlug } from './lib/project/git.ts'
 import { DenvigProject } from './lib/project.ts'
 import { resolveProjectId } from './lib/project-id.ts'
 import { listProjects } from './lib/projects.ts'
@@ -62,16 +62,25 @@ async function main() {
     const resolved = await resolveProjectId(projectFlag, expandTilde)
     projectPath = resolved.path
   } else {
-    // Check if current directory matches any projectPaths pattern
-    const projects = await listProjects()
-    const match = projects.find(
-      (p) => currentDir === p.path || currentDir.startsWith(`${p.path}/`),
-    )
-    if (match) {
-      projectPath = match.path
+    // A detached worktree resolves to its own checkout: `retrieve` roots the
+    // project at the primary and makes this worktree the active one. This is
+    // checked first so worktrees resolve even when the project glob doesn't
+    // match their (possibly nested) location.
+    const detachedWorktreeRoot = findDetachedWorktreeRoot(currentDir)
+    if (detachedWorktreeRoot) {
+      projectPath = detachedWorktreeRoot
     } else {
-      // Fall back to current directory
-      projectPath = currentDir
+      // Check if current directory matches any projectPaths pattern
+      const projects = await listProjects()
+      const match = projects.find(
+        (p) => currentDir === p.path || currentDir.startsWith(`${p.path}/`),
+      )
+      if (match) {
+        projectPath = match.path
+      } else {
+        // Fall back to current directory
+        projectPath = currentDir
+      }
     }
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,7 +105,7 @@ async function main() {
   // Quick actions
   const quickActions = [
     ...(globalConfig.quickActions ?? []),
-    ...(project?.config?.quickActions ?? []),
+    ...(project?.activeWorktree.config?.quickActions ?? []),
   ].sort()
   if (quickActions.includes(commandName as (typeof quickActions)[number])) {
     args = ['run', ...process.argv.slice(2)]

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -31,9 +31,9 @@ export const configCommand = new Command({
   subcommands: {
     verify: configVerifyCommand,
   },
-  handler: async ({ project, flags }) => {
+  handler: async ({ worktree, flags }) => {
     const globalConfig = await getGlobalConfig()
-    const projectConfig = project.config
+    const projectConfig = worktree.config
 
     if (flags.json) {
       const { $sources: globalSources, ...globalConfigWithoutSources } =
@@ -47,7 +47,7 @@ export const configCommand = new Command({
             config: globalConfigWithoutSources,
           },
           project: {
-            slug: project.slug,
+            slug: worktree.slug,
             sources: projectSources,
             config: projectConfigWithoutSources,
           },
@@ -66,9 +66,9 @@ export const configCommand = new Command({
 
     console.log('')
     console.log(
-      `Project: ${project.config.$sources.map((path) => prettyPath(path)).join(', ') || 'default'}`,
+      `Project: ${worktree.config.$sources.map((path) => prettyPath(path)).join(', ') || 'default'}`,
     )
-    console.log(`  slug: ${project.slug}`)
+    console.log(`  slug: ${worktree.slug}`)
     printConfig(projectConfig)
 
     return { success: true, message: 'Configuration displayed.' }

--- a/src/commands/config/verify.ts
+++ b/src/commands/config/verify.ts
@@ -20,9 +20,9 @@ export const configVerifyCommand = new Command({
     },
   ],
   flags: [],
-  handler: async ({ project, args, flags }) => {
+  handler: async ({ worktree, args, flags }) => {
     const configPath = resolve(
-      project.path,
+      worktree.path,
       args.path?.toString() || '.denvig.yml',
     )
     const configRaw = await safeReadTextFile(configPath)

--- a/src/commands/deps/dedupe.ts
+++ b/src/commands/deps/dedupe.ts
@@ -18,10 +18,10 @@ export const depsDedupeCommand = new Command({
       defaultValue: false,
     },
   ],
-  handler: async ({ project, flags }) => {
+  handler: async ({ worktree, flags }) => {
     const apply = flags.apply as boolean
 
-    const results = await project.deduplicateDependencies({ dryRun: !apply })
+    const results = await worktree.deduplicateDependencies({ dryRun: !apply })
 
     if (results.length === 0) {
       console.error(

--- a/src/commands/deps/list.ts
+++ b/src/commands/deps/list.ts
@@ -24,10 +24,10 @@ export const depsListCommand = new Command({
       defaultValue: undefined,
     },
   ],
-  handler: async ({ project, flags }) => {
+  handler: async ({ worktree, flags }) => {
     const ecosystemFilter = flags.ecosystem as string | undefined
     const maxDepth = (flags.depth as number) ?? 0
-    const dependencies = await project.dependencies()
+    const dependencies = await worktree.dependencies()
 
     if (dependencies.length === 0) {
       if (flags.json) {

--- a/src/commands/deps/outdated.ts
+++ b/src/commands/deps/outdated.ts
@@ -97,7 +97,7 @@ export const depsOutdatedCommand = new Command({
       defaultValue: 'auto',
     },
   ],
-  handler: async ({ project, flags }) => {
+  handler: async ({ worktree, flags }) => {
     const cache = !(flags['no-cache'] as boolean)
     const semverFilter = flags.semver as 'patch' | 'minor' | 'major' | undefined
     const ecosystemFilter = flags.ecosystem as string | undefined
@@ -116,7 +116,7 @@ export const depsOutdatedCommand = new Command({
       return { success: false, message: 'Invalid --semver value.' }
     }
 
-    const outdated = await project.outdatedDependencies({ cache })
+    const outdated = await worktree.outdatedDependencies({ cache })
     let entries = outdated
 
     // Helper to get current version from versions array
@@ -153,7 +153,7 @@ export const depsOutdatedCommand = new Command({
       releaseLatencyMs = null
     } else if (latencyValue === 'auto') {
       // Read from pnpm-workspace.yaml if available, otherwise default to 24h
-      const pnpmConfig = await readPnpmReleaseAgeConfig(project.path)
+      const pnpmConfig = await readPnpmReleaseAgeConfig(worktree.path)
       if (pnpmConfig) {
         releaseLatencyMs = pnpmConfig.minimumReleaseAgeMs
         releaseLatencyExclude = pnpmConfig.exclude

--- a/src/commands/deps/why.ts
+++ b/src/commands/deps/why.ts
@@ -98,13 +98,13 @@ export const depsWhyCommand = new Command({
     },
   ],
   completions: async ({ project }) => {
-    const dependencies = await project.dependencies()
+    const dependencies = await project.activeWorktree.dependencies()
     return dependencies.map((d) => d.name)
   },
-  handler: async ({ project, args, flags }) => {
+  handler: async ({ worktree, args, flags }) => {
     const dependencyName = args.dependency as string
 
-    const allDependencies = await project.dependencies()
+    const allDependencies = await worktree.dependencies()
     const dep = allDependencies.find((d) => d.name === dependencyName)
 
     if (!dep) {
@@ -177,7 +177,7 @@ export const depsWhyCommand = new Command({
         0,
       )
 
-      const outdated = await project
+      const outdated = await worktree
         .outdatedDependencies({ cache: true, depth: outdatedDepth })
         .catch(() => [])
 
@@ -248,8 +248,8 @@ export const depsWhyCommand = new Command({
           dependency: dependencyName,
           found: true,
           project: {
-            name: project.name,
-            path: project.path,
+            name: worktree.name,
+            path: worktree.path,
           },
           dependencies: depChains,
           devDependencies: devDepChains,

--- a/src/commands/gateway/status.ts
+++ b/src/commands/gateway/status.ts
@@ -43,13 +43,13 @@ export const gatewayStatusCommand = new Command({
   example: 'gateway status',
   args: [],
   flags: [],
-  handler: async ({ project, flags }) => {
+  handler: async ({ worktree, flags }) => {
     const globalConfig = await getGlobalConfig()
     const gateway = globalConfig.experimental?.gateway
 
     if (flags.json) {
       const nginxService = getNginxServiceStatus()
-      const services = project.config.services || {}
+      const services = worktree.config.services || {}
       const serviceStatuses = []
 
       for (const [name, config] of Object.entries(services)) {
@@ -59,7 +59,7 @@ export const gatewayStatusCommand = new Command({
           const certDir = secure ? await findCertForDomain(domain) : null
           const sslPaths = certDir ? await resolveSslPaths(certDir) : null
           const nginxPath = gateway?.enabled
-            ? getNginxConfigPath(project.id, name, gateway.configsPath)
+            ? getNginxConfigPath(worktree.id, name, gateway.configsPath)
             : null
 
           serviceStatuses.push({
@@ -121,7 +121,7 @@ export const gatewayStatusCommand = new Command({
     console.log('')
 
     // Show services with gateway config
-    const services = project.config.services || {}
+    const services = worktree.config.services || {}
     const gatewayServices = Object.entries(services).filter(
       ([, config]) => config.http?.domain,
     )
@@ -154,7 +154,7 @@ export const gatewayStatusCommand = new Command({
       const certDir = secure ? await findCertForDomain(domain) : null
       const sslPaths = certDir ? await resolveSslPaths(certDir) : null
       const nginxPath = getNginxConfigPath(
-        project.id,
+        worktree.id,
         name,
         gateway.configsPath,
       )

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -15,7 +15,7 @@ export const pluginsCommand = new Command({
     > = {}
 
     for (const [key, plugin] of Object.entries(plugins)) {
-      const actions = await plugin.actions(project)
+      const actions = await plugin.actions(project.activeWorktree)
       pluginData[key] = {
         name: plugin.name,
         actions,

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -1,7 +1,7 @@
 import { Command } from '../../lib/command.ts'
 import { formatTable } from '../../lib/formatters/table.ts'
 import { prettyPath } from '../../lib/path.ts'
-import { DenvigProject, shortProjectId } from '../../lib/project.ts'
+import { DenvigProject } from '../../lib/project.ts'
 import {
   getProjectInfo,
   type ProjectInfo,
@@ -27,17 +27,14 @@ const getStatusIcon = (status: ServiceStatus): string => {
   }
 }
 
-/** A row in the rendered tree: a project, or one of its worktrees. */
+/** A row in the rendered list: a project, or one of its worktrees. */
 type ProjectRow = {
   status: ServiceStatus
-  id: string
   /** Project name for the primary row, branch name for worktree rows. */
   label: string
   path: string
+  /** 0 for a project, 1 for one of its worktrees. */
   depth: number
-  isLast: boolean
-  hasChildren: boolean
-  parentPath: boolean[]
 }
 
 /**
@@ -120,34 +117,23 @@ export const projectsListCommand = new Command({
     const launchctlList = await launchctl.list('denvig.')
 
     const rows: ProjectRow[] = []
-    for (let i = 0; i < families.length; i++) {
-      const family = families[i]
-      const isLastFamily = i === families.length - 1
+    for (const family of families) {
       const worktrees = family.worktrees.filter((wt) => !wt.isPrimary)
 
       const primary = family.primaryWorktree
       rows.push({
         status: await worktreeStatus(family, primary, launchctlList),
-        id: primary.id,
         label: primary.config.name || primary.slug,
         path: primary.path,
         depth: 0,
-        isLast: isLastFamily,
-        hasChildren: worktrees.length > 0,
-        parentPath: [],
       })
 
-      for (let j = 0; j < worktrees.length; j++) {
-        const worktree = worktrees[j]
+      for (const worktree of worktrees) {
         rows.push({
           status: await worktreeStatus(family, worktree, launchctlList),
-          id: worktree.id,
           label: worktree.branch,
           path: worktree.path,
           depth: 1,
-          isLast: j === worktrees.length - 1,
-          hasChildren: false,
-          parentPath: [isLastFamily],
         })
       }
     }
@@ -158,19 +144,16 @@ export const projectsListCommand = new Command({
           header: 'Name',
           accessor: (r) => {
             const icon = getStatusIcon(r.status)
-            return icon ? `${icon} ${r.label}` : r.label
+            // Reserve the indicator slot so projects without a service still
+            // line up with those that have one. Worktrees indent one extra char.
+            const indicator = icon ? `${icon} ` : '  '
+            const indent = r.depth > 0 ? ' ' : ''
+            return `${indent}${indicator}${r.label}`
           },
         },
-        { header: 'ID', accessor: (r) => shortProjectId(r.id) },
         { header: 'Path', accessor: (r) => prettyPath(r.path) },
       ],
       data: rows,
-      tree: {
-        getDepth: (r) => r.depth,
-        getIsLast: (r) => r.isLast,
-        getHasChildren: (r) => r.hasChildren,
-        getParentPath: (r) => r.parentPath,
-      },
     })
 
     for (const line of lines) {

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -1,5 +1,4 @@
 import { Command } from '../../lib/command.ts'
-import { formatTable } from '../../lib/formatters/table.ts'
 import { prettyPath } from '../../lib/path.ts'
 import { DenvigProject } from '../../lib/project.ts'
 import {
@@ -35,8 +34,6 @@ type ProjectRow = {
   path: string
   /** 0 for a project, 1 for one of its worktrees. */
   depth: number
-  /** Whether a worktree row is the last child of its project. */
-  isLastChild: boolean
 }
 
 /**
@@ -128,42 +125,28 @@ export const projectsListCommand = new Command({
         label: primary.config.name || primary.slug,
         path: primary.path,
         depth: 0,
-        isLastChild: false,
       })
 
-      for (let j = 0; j < worktrees.length; j++) {
-        const worktree = worktrees[j]
+      for (const worktree of worktrees) {
         rows.push({
           status: await worktreeStatus(family, worktree, launchctlList),
           label: worktree.branch,
           path: worktree.path,
           depth: 1,
-          isLastChild: j === worktrees.length - 1,
         })
       }
     }
 
-    const lines = formatTable({
-      columns: [
-        // Service indicator, kept in its own left-aligned column so every
-        // project's status icon lines up regardless of name indentation.
-        { header: '', accessor: (r) => getStatusIcon(r.status) },
-        {
-          header: 'Name',
-          accessor: (r) => {
-            // Worktrees are nested under their project with the same tree
-            // connector `denvig deps` uses.
-            const prefix = r.depth > 0 ? (r.isLastChild ? '└── ' : '├── ') : ''
-            return `${prefix}${r.label}`
-          },
-        },
-        { header: 'Path', accessor: (r) => prettyPath(r.path) },
-      ],
-      data: rows,
-    })
+    // Worktrees are nested under their project with a single `└` connector.
+    const nameCell = (r: ProjectRow) => (r.depth > 0 ? `└ ${r.label}` : r.label)
+    const nameWidth = Math.max(...rows.map((r) => nameCell(r).length))
 
-    for (const line of lines) {
-      console.log(line)
+    for (const r of rows) {
+      // Service icon in a fixed left column, one space, the name (padded), one
+      // space, then the path.
+      const icon = getStatusIcon(r.status) || ' '
+      const name = nameCell(r).padEnd(nameWidth)
+      console.log(`${icon} ${name} ${prettyPath(r.path)}`)
     }
 
     console.log('')

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -8,7 +8,11 @@ import {
   type ServiceStatus,
 } from '../../lib/projectInfo.ts'
 import { listProjects } from '../../lib/projects.ts'
-import launchctl from '../../lib/services/launchctl.ts'
+import launchctl, {
+  type LaunchctlListItem,
+} from '../../lib/services/launchctl.ts'
+
+import type { Worktree } from '../../lib/project/worktree.ts'
 
 type ProjectInfoJSON = Omit<ProjectInfo, 'serviceStatus'>
 
@@ -21,6 +25,50 @@ const getStatusIcon = (status: ServiceStatus): string => {
     default:
       return ''
   }
+}
+
+/** A row in the rendered tree: a project, or one of its worktrees. */
+type ProjectRow = {
+  status: ServiceStatus
+  id: string
+  /** Project name for the primary row, branch name for worktree rows. */
+  label: string
+  path: string
+  depth: number
+  isLast: boolean
+  hasChildren: boolean
+  parentPath: boolean[]
+}
+
+/**
+ * Group listed project paths into families keyed by primary checkout. Sibling
+ * worktrees and the primary all collapse to a single family, so each project
+ * appears once regardless of how many of its checkouts the glob matched.
+ */
+const groupIntoFamilies = async (paths: string[]): Promise<DenvigProject[]> => {
+  const families = new Map<string, DenvigProject>()
+  for (const path of paths) {
+    const project = await DenvigProject.retrieve(path)
+    const key = project.primaryWorktree.path
+    if (!families.has(key)) {
+      project.activeWorktree = project.primaryWorktree
+      families.set(key, project)
+    }
+  }
+  return [...families.values()].sort((a, b) =>
+    a.primaryWorktree.path.localeCompare(b.primaryWorktree.path),
+  )
+}
+
+/** Service status for a single worktree, reusing the shared info builder. */
+const worktreeStatus = async (
+  project: DenvigProject,
+  worktree: Worktree,
+  launchctlList: LaunchctlListItem[],
+): Promise<ServiceStatus> => {
+  project.activeWorktree = worktree
+  const info = await getProjectInfo(project, { launchctlList })
+  return info.serviceStatus
 }
 
 export const projectsListCommand = new Command({
@@ -51,44 +99,78 @@ export const projectsListCommand = new Command({
       return { success: true, message: 'No projects found.' }
     }
 
-    // JSON output: skip launchctl calls for performance
+    const families = await groupIntoFamilies(projectPaths.map((p) => p.path))
+
+    // JSON output: one entry per project family, worktrees nested via the
+    // existing `worktrees` field. Skips launchctl calls for performance.
     if (flags.json) {
       const projects: ProjectInfoJSON[] = []
-      for (const projectPath of projectPaths) {
-        const proj = await DenvigProject.retrieve(projectPath.path)
-        const info = await getProjectInfo(proj, { includeServiceStatus: false })
+      for (const family of families) {
+        const info = await getProjectInfo(family, {
+          includeServiceStatus: false,
+        })
         const { serviceStatus: _, ...infoWithoutStatus } = info
         projects.push(infoWithoutStatus)
       }
-      const sortedProjects = projects.sort((a, b) =>
-        a.path.localeCompare(b.path),
-      )
-      console.log(JSON.stringify(sortedProjects))
+      console.log(JSON.stringify(projects))
       return { success: true, message: 'Projects listed successfully.' }
     }
 
-    // CLI output: pre-fetch launchctl list once to avoid N shell calls
+    // CLI output: pre-fetch launchctl list once to avoid N shell calls.
     const launchctlList = await launchctl.list('denvig.')
 
-    const projects: ProjectInfo[] = []
+    const rows: ProjectRow[] = []
+    for (let i = 0; i < families.length; i++) {
+      const family = families[i]
+      const isLastFamily = i === families.length - 1
+      const worktrees = family.worktrees.filter((wt) => !wt.isPrimary)
 
-    for (const projectPath of projectPaths) {
-      const proj = await DenvigProject.retrieve(projectPath.path)
-      const info = await getProjectInfo(proj, { launchctlList })
-      projects.push(info)
+      const primary = family.primaryWorktree
+      rows.push({
+        status: await worktreeStatus(family, primary, launchctlList),
+        id: primary.id,
+        label: primary.config.name || primary.slug,
+        path: primary.path,
+        depth: 0,
+        isLast: isLastFamily,
+        hasChildren: worktrees.length > 0,
+        parentPath: [],
+      })
+
+      for (let j = 0; j < worktrees.length; j++) {
+        const worktree = worktrees[j]
+        rows.push({
+          status: await worktreeStatus(family, worktree, launchctlList),
+          id: worktree.id,
+          label: worktree.branch,
+          path: worktree.path,
+          depth: 1,
+          isLast: j === worktrees.length - 1,
+          hasChildren: false,
+          parentPath: [isLastFamily],
+        })
+      }
     }
-
-    // Sort by absolute path ascending
-    const sortedProjects = projects.sort((a, b) => a.path.localeCompare(b.path))
 
     const lines = formatTable({
       columns: [
-        { header: '', accessor: (p) => getStatusIcon(p.serviceStatus) },
-        { header: 'ID', accessor: (p) => shortProjectId(p.id) },
-        { header: 'Name', accessor: (p) => p.config?.name || p.slug },
-        { header: 'Path', accessor: (p) => prettyPath(p.path) },
+        {
+          header: 'Name',
+          accessor: (r) => {
+            const icon = getStatusIcon(r.status)
+            return icon ? `${icon} ${r.label}` : r.label
+          },
+        },
+        { header: 'ID', accessor: (r) => shortProjectId(r.id) },
+        { header: 'Path', accessor: (r) => prettyPath(r.path) },
       ],
-      data: sortedProjects,
+      data: rows,
+      tree: {
+        getDepth: (r) => r.depth,
+        getIsLast: (r) => r.isLast,
+        getHasChildren: (r) => r.hasChildren,
+        getParentPath: (r) => r.parentPath,
+      },
     })
 
     for (const line of lines) {
@@ -97,7 +179,7 @@ export const projectsListCommand = new Command({
 
     console.log('')
     console.log(
-      `${projects.length} project${projects.length === 1 ? '' : 's'} found`,
+      `${families.length} project${families.length === 1 ? '' : 's'} found`,
     )
 
     return { success: true, message: 'Projects listed successfully.' }

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -35,6 +35,8 @@ type ProjectRow = {
   path: string
   /** 0 for a project, 1 for one of its worktrees. */
   depth: number
+  /** Whether a worktree row is the last child of its project. */
+  isLastChild: boolean
 }
 
 /**
@@ -126,29 +128,33 @@ export const projectsListCommand = new Command({
         label: primary.config.name || primary.slug,
         path: primary.path,
         depth: 0,
+        isLastChild: false,
       })
 
-      for (const worktree of worktrees) {
+      for (let j = 0; j < worktrees.length; j++) {
+        const worktree = worktrees[j]
         rows.push({
           status: await worktreeStatus(family, worktree, launchctlList),
           label: worktree.branch,
           path: worktree.path,
           depth: 1,
+          isLastChild: j === worktrees.length - 1,
         })
       }
     }
 
     const lines = formatTable({
       columns: [
+        // Service indicator, kept in its own left-aligned column so every
+        // project's status icon lines up regardless of name indentation.
+        { header: '', accessor: (r) => getStatusIcon(r.status) },
         {
           header: 'Name',
           accessor: (r) => {
-            const icon = getStatusIcon(r.status)
-            // Reserve the indicator slot so projects without a service still
-            // line up with those that have one. Worktrees indent one extra char.
-            const indicator = icon ? `${icon} ` : '  '
-            const indent = r.depth > 0 ? ' ' : ''
-            return `${indent}${indicator}${r.label}`
+            // Worktrees are nested under their project with the same tree
+            // connector `denvig deps` uses.
+            const prefix = r.depth > 0 ? (r.isLastChild ? '└── ' : '├── ') : ''
+            return `${prefix}${r.label}`
           },
         },
         { header: 'Path', accessor: (r) => prettyPath(r.path) },

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -20,11 +20,11 @@ export const runCommand = new Command({
   flags: [],
   acceptsExtraArgs: true,
   completions: async ({ project }) => {
-    const actions = await project.actions
+    const actions = await project.activeWorktree.actions
     return Object.keys(actions)
   },
-  handler: async ({ project, args, flags, extraArgs = [] }) => {
-    const actions = await project.actions
+  handler: async ({ worktree, args, flags, extraArgs = [] }) => {
+    const actions = await worktree.actions
 
     if (!args.action) {
       if (flags.json) {
@@ -59,7 +59,7 @@ export const runCommand = new Command({
     const commands = actions[args.action]
     if (!commands) {
       console.error(
-        `Action "${args.action}" not found in project ${project.name}.`,
+        `Action "${args.action}" not found in project ${worktree.name}.`,
       )
       return { success: false, message: `Action "${args.action}" not found.` }
     }
@@ -72,7 +72,7 @@ export const runCommand = new Command({
       // Prepare environment with color forcing for better terminal output
       const env = {
         ...process.env,
-        DENVIG_PROJECT: project.slug,
+        DENVIG_PROJECT: worktree.slug,
       }
 
       // Check if we're in a TTY environment
@@ -99,7 +99,7 @@ export const runCommand = new Command({
       }
 
       const child = spawn(commandName, commandArgs, {
-        cwd: project.path,
+        cwd: worktree.path,
         env,
         stdio: 'inherit',
       })

--- a/src/commands/services/list.test.ts
+++ b/src/commands/services/list.test.ts
@@ -12,7 +12,7 @@ describe('servicesListCommand', () => {
   it('should have correct usage', () => {
     ok(
       servicesListCommand.usage ===
-        'services list [--all] [--global] [--worktree <branch>] [--status <status>]',
+        'services list [--all] [--worktrees] [--global] [--worktree <branch>] [--status <status>]',
     )
   })
 })

--- a/src/commands/services/list.ts
+++ b/src/commands/services/list.ts
@@ -170,19 +170,54 @@ export const servicesListCommand = new Command({
       }
     }
 
-    // Collect a project's services, nesting its worktree services beneath it
-    // when --worktrees is set.
+    // Resolve a checkout's services into a name -> response map.
+    const servicesByName = async (manager: ServiceManager) => {
+      const map = new Map<string, ServiceResponse>()
+      for (const service of await manager.listServices()) {
+        const response = await manager.getServiceResponse(service.name, {
+          launchctlList,
+        })
+        if (response) map.set(service.name, response)
+      }
+      return map
+    }
+
+    // Collect a project's services. With --worktrees, services are grouped by
+    // name: the primary's instance first, then the same service from each
+    // worktree nested beneath it.
     const collectFamily = async (family: DenvigProject, out: ServiceRow[]) => {
       const primary = family.primaryWorktree
-      await collectFromManager(
-        new ServiceManager(primary),
-        0,
-        primary.slug,
-        out,
-      )
-      if (showWorktrees) {
-        for (const wt of family.worktrees.filter((w) => !w.isPrimary)) {
-          await collectFromManager(new ServiceManager(wt), 1, wt.branch, out)
+      const primaryServices = await servicesByName(new ServiceManager(primary))
+
+      if (!showWorktrees) {
+        for (const name of [...primaryServices.keys()].sort()) {
+          const service = primaryServices.get(name)
+          if (service) out.push({ service, depth: 0, label: primary.slug })
+        }
+        return
+      }
+
+      const worktrees = []
+      for (const wt of family.worktrees.filter((w) => !w.isPrimary)) {
+        worktrees.push({
+          branch: wt.branch,
+          services: await servicesByName(new ServiceManager(wt)),
+        })
+      }
+
+      const names = new Set<string>(primaryServices.keys())
+      for (const wt of worktrees) {
+        for (const name of wt.services.keys()) names.add(name)
+      }
+
+      for (const name of [...names].sort()) {
+        const service = primaryServices.get(name)
+        if (service) out.push({ service, depth: 0, label: primary.slug })
+        for (const wt of worktrees) {
+          const wtService = wt.services.get(name)
+          if (wtService) {
+            out.push({ service: wtService, depth: 1, label: wt.branch })
+          }
         }
       }
     }

--- a/src/commands/services/list.ts
+++ b/src/commands/services/list.ts
@@ -25,13 +25,21 @@ export const servicesListCommand = new Command({
   name: 'services:list',
   description: 'List services for the current project',
   usage:
-    'services list [--all] [--global] [--worktree <branch>] [--status <status>]',
+    'services list [--all] [--worktrees] [--global] [--worktree <branch>] [--status <status>]',
   example: 'services list',
   args: [],
   flags: [
     {
       name: 'all',
       description: 'List services across all projects and global services',
+      required: false,
+      type: 'boolean',
+      defaultValue: false,
+    },
+    {
+      name: 'worktrees',
+      description:
+        "Nest each project's worktree services beneath it. Pair with --all to show worktrees for every project.",
       required: false,
       type: 'boolean',
       defaultValue: false,
@@ -64,6 +72,7 @@ export const servicesListCommand = new Command({
   handler: async ({ project, worktree, flags }) => {
     const all = flags.all as boolean
     const globalOnly = flags.global as boolean
+    const showWorktrees = flags.worktrees as boolean
     const worktreeFlag =
       typeof flags.worktree === 'string' ? flags.worktree : null
     const statusFlag = typeof flags.status === 'string' ? flags.status : null
@@ -87,6 +96,17 @@ export const servicesListCommand = new Command({
 
     if ((all || globalOnly) && worktreeFlag !== null) {
       const message = '--worktree cannot be combined with --all or --global.'
+      if (flags.json) {
+        console.log(JSON.stringify({ success: false, message }))
+      } else {
+        console.error(message)
+      }
+      return { success: false, message }
+    }
+
+    if (showWorktrees && (globalOnly || worktreeFlag !== null)) {
+      const message =
+        '--worktrees cannot be combined with --global or --worktree.'
       if (flags.json) {
         console.log(JSON.stringify({ success: false, message }))
       } else {
@@ -123,53 +143,112 @@ export const servicesListCommand = new Command({
     // Pre-fetch launchctl list once to avoid N shell calls
     const launchctlList = await launchctl.list('denvig.')
 
+    // A rendered row: a service plus where it sits in the project/worktree tree.
+    type ServiceRow = {
+      service: ServiceResponse
+      /** 0 for a project's own services, 1 for a worktree's. */
+      depth: 0 | 1
+      /** Project column text: project slug at depth 0, branch at depth 1. */
+      label: string
+    }
+
     const collectFromManager = async (
       manager: ServiceManager,
-      out: ServiceResponse[],
+      depth: 0 | 1,
+      label: string,
+      out: ServiceRow[],
     ) => {
       const services = await manager.listServices()
+      services.sort((a, b) => a.name.localeCompare(b.name))
       for (const service of services) {
         const response = await manager.getServiceResponse(service.name, {
           launchctlList,
         })
         if (response) {
-          out.push(response)
+          out.push({ service: response, depth, label })
         }
       }
     }
 
-    const allServices: ServiceResponse[] = []
+    // Collect a project's services, nesting its worktree services beneath it
+    // when --worktrees is set.
+    const collectFamily = async (family: DenvigProject, out: ServiceRow[]) => {
+      const primary = family.primaryWorktree
+      await collectFromManager(
+        new ServiceManager(primary),
+        0,
+        primary.slug,
+        out,
+      )
+      if (showWorktrees) {
+        for (const wt of family.worktrees.filter((w) => !w.isPrimary)) {
+          await collectFromManager(new ServiceManager(wt), 1, wt.branch, out)
+        }
+      }
+    }
+
+    // Group listed paths into families keyed by primary checkout so each
+    // project appears once regardless of how many checkouts the glob matched.
+    const familiesFromPaths = async (paths: string[]) => {
+      const families = new Map<string, DenvigProject>()
+      for (const path of paths) {
+        const proj = await DenvigProject.retrieve(path)
+        const key = proj.primaryWorktree.path
+        if (!families.has(key)) families.set(key, proj)
+      }
+      return [...families.values()].sort((a, b) =>
+        a.primaryWorktree.slug.localeCompare(b.primaryWorktree.slug),
+      )
+    }
+
+    const allServices: ServiceRow[] = []
     let projectCount = 0
 
     if (globalOnly) {
       const globalProject = await createGlobalProject()
       if (Object.keys(globalProject.config.services || {}).length > 0) {
         projectCount = 1
-        await collectFromManager(new ServiceManager(globalProject), allServices)
-      }
-    } else if (all) {
-      const projectInfos = await listProjects()
-      for (const projectInfo of projectInfos) {
-        const proj = await DenvigProject.retrieve(projectInfo.path)
         await collectFromManager(
-          new ServiceManager(proj.activeWorktree),
+          new ServiceManager(globalProject),
+          0,
+          globalProject.slug,
           allServices,
         )
       }
-      projectCount = projectInfos.length
+    } else if (all) {
+      const families = await familiesFromPaths(
+        (await listProjects()).map((p) => p.path),
+      )
+      for (const family of families) {
+        await collectFamily(family, allServices)
+      }
+      projectCount = families.length
 
       const globalProject = await createGlobalProject()
       if (Object.keys(globalProject.config.services || {}).length > 0) {
         projectCount += 1
-        await collectFromManager(new ServiceManager(globalProject), allServices)
+        await collectFromManager(
+          new ServiceManager(globalProject),
+          0,
+          globalProject.slug,
+          allServices,
+        )
       }
+    } else if (showWorktrees) {
+      projectCount = 1
+      await collectFamily(project, allServices)
     } else {
       projectCount = 1
-      await collectFromManager(new ServiceManager(activeWorktree), allServices)
+      await collectFromManager(
+        new ServiceManager(activeWorktree),
+        0,
+        activeWorktree.slug,
+        allServices,
+      )
     }
 
     const filteredServices = statusFilter
-      ? allServices.filter((s) => statusFilter.includes(s.status))
+      ? allServices.filter((r) => statusFilter.includes(r.service.status))
       : allServices
 
     if (filteredServices.length === 0) {
@@ -187,26 +266,12 @@ export const servicesListCommand = new Command({
       return { success: true, message: 'No services configured.' }
     }
 
-    const currentProjectSlug = activeWorktree.slug
-    const sortedServices = filteredServices.sort((a, b) => {
-      const aIsCurrent = a.project.slug === currentProjectSlug
-      const bIsCurrent = b.project.slug === currentProjectSlug
-
-      if (aIsCurrent && !bIsCurrent) return -1
-      if (!aIsCurrent && bIsCurrent) return 1
-
-      const projectCompare = a.project.slug.localeCompare(b.project.slug)
-      if (projectCompare !== 0) return projectCompare
-
-      return a.name.localeCompare(b.name)
-    })
-
     if (flags.json) {
-      console.log(JSON.stringify(sortedServices))
+      console.log(JSON.stringify(filteredServices.map((r) => r.service)))
       return { success: true, message: 'Services listed successfully.' }
     }
 
-    const showProjectColumn = all || globalOnly
+    const showProjectColumn = all || globalOnly || showWorktrees
     const formatUrlCell = (s: ServiceResponse): string => {
       if (!s.url) return '-'
       const showLocal =
@@ -219,20 +284,26 @@ export const servicesListCommand = new Command({
       columns: [
         {
           header: '',
-          accessor: (s) => getStatusIcon(s.status),
+          accessor: (r) => getStatusIcon(r.service.status),
         },
         ...(showProjectColumn
           ? [
               {
                 header: 'Project',
-                accessor: (s: ServiceResponse) => s.project.slug,
+                // Worktrees are nested under their project with a single `└`
+                // connector, matching `denvig projects`.
+                accessor: (r: ServiceRow) =>
+                  r.depth > 0 ? `└ ${r.label}` : r.label,
               },
             ]
           : []),
-        { header: 'Name', accessor: (s: ServiceResponse) => s.name },
-        { header: 'URL', accessor: formatUrlCell },
+        { header: 'Name', accessor: (r: ServiceRow) => r.service.name },
+        {
+          header: 'URL',
+          accessor: (r: ServiceRow) => formatUrlCell(r.service),
+        },
       ],
-      data: sortedServices,
+      data: filteredServices,
     })
 
     for (const line of lines) {

--- a/src/commands/services/list.ts
+++ b/src/commands/services/list.ts
@@ -8,7 +8,7 @@ import {
   ServiceManager,
   type ServiceResponse,
 } from '../../lib/services/manager.ts'
-import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
+import { resolveWorktree } from '../../lib/services/worktree.ts'
 
 const getStatusIcon = (status: 'running' | 'error' | 'stopped'): string => {
   switch (status) {
@@ -61,7 +61,7 @@ export const servicesListCommand = new Command({
   completions: () => {
     return []
   },
-  handler: async ({ project: currentProject, flags }) => {
+  handler: async ({ project, worktree, flags }) => {
     const all = flags.all as boolean
     const globalOnly = flags.global as boolean
     const worktreeFlag =
@@ -105,10 +105,10 @@ export const servicesListCommand = new Command({
       return { success: false, message }
     }
 
-    let project = currentProject
+    let activeWorktree = worktree
     if (worktreeFlag !== null) {
       try {
-        project = await resolveWorktreeProject(currentProject, worktreeFlag)
+        activeWorktree = resolveWorktree(project, worktreeFlag)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         if (flags.json) {
@@ -151,7 +151,10 @@ export const servicesListCommand = new Command({
       const projectInfos = await listProjects()
       for (const projectInfo of projectInfos) {
         const proj = await DenvigProject.retrieve(projectInfo.path)
-        await collectFromManager(new ServiceManager(proj), allServices)
+        await collectFromManager(
+          new ServiceManager(proj.activeWorktree),
+          allServices,
+        )
       }
       projectCount = projectInfos.length
 
@@ -162,7 +165,7 @@ export const servicesListCommand = new Command({
       }
     } else {
       projectCount = 1
-      await collectFromManager(new ServiceManager(project), allServices)
+      await collectFromManager(new ServiceManager(activeWorktree), allServices)
     }
 
     const filteredServices = statusFilter
@@ -184,7 +187,7 @@ export const servicesListCommand = new Command({
       return { success: true, message: 'No services configured.' }
     }
 
-    const currentProjectSlug = project.slug
+    const currentProjectSlug = activeWorktree.slug
     const sortedServices = filteredServices.sort((a, b) => {
       const aIsCurrent = a.project.slug === currentProjectSlug
       const bIsCurrent = b.project.slug === currentProjectSlug

--- a/src/commands/services/logs.ts
+++ b/src/commands/services/logs.ts
@@ -6,7 +6,7 @@ import {
   getServiceCompletions,
   getServiceContext,
 } from '../../lib/services/identifier.ts'
-import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
+import { resolveWorktree } from '../../lib/services/worktree.ts'
 
 export const logsCommand = new Command({
   name: 'services:logs',
@@ -48,13 +48,13 @@ export const logsCommand = new Command({
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project: currentProject, args, flags }) => {
+  handler: async ({ project, worktree, args, flags }) => {
     const nameArg = args.name as string
 
-    let project = currentProject
+    let activeWorktree = worktree
     if (typeof flags.worktree === 'string') {
       try {
-        project = await resolveWorktreeProject(currentProject, flags.worktree)
+        activeWorktree = resolveWorktree(project, flags.worktree)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         if (flags.json) {
@@ -65,6 +65,7 @@ export const logsCommand = new Command({
         return { success: false, message }
       }
     }
+    project.activeWorktree = activeWorktree
 
     const { manager, serviceName: name } = await getServiceContext(
       nameArg,

--- a/src/commands/services/restart.ts
+++ b/src/commands/services/restart.ts
@@ -8,7 +8,7 @@ import {
 } from '../../lib/services/identifier.ts'
 import { reconcileAfterCommand } from '../../lib/services/reconcileLogger.ts'
 import { resolveServicePortForCli } from '../../lib/services/resolvePort.ts'
-import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
+import { resolveWorktree } from '../../lib/services/worktree.ts'
 
 export const servicesRestartCommand = new Command({
   name: 'services:restart',
@@ -61,13 +61,13 @@ export const servicesRestartCommand = new Command({
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project: currentProject, args, flags }) => {
+  handler: async ({ project, worktree, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
 
-    let project = currentProject
+    let activeWorktree = worktree
     if (typeof flags.worktree === 'string') {
       try {
-        project = await resolveWorktreeProject(currentProject, flags.worktree)
+        activeWorktree = resolveWorktree(project, flags.worktree)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         if (flags.json) {
@@ -78,6 +78,7 @@ export const servicesRestartCommand = new Command({
         return { success: false, message }
       }
     }
+    project.activeWorktree = activeWorktree
 
     const {
       manager,
@@ -86,7 +87,7 @@ export const servicesRestartCommand = new Command({
     } = await getServiceContext(serviceArg, project)
 
     const projectPrefix =
-      targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
+      targetProject.slug !== activeWorktree.slug ? `${targetProject.slug}/` : ''
 
     const serviceConfig = targetProject.config.services?.[serviceName]
     if (serviceConfig) {

--- a/src/commands/services/start.ts
+++ b/src/commands/services/start.ts
@@ -8,7 +8,7 @@ import {
 } from '../../lib/services/identifier.ts'
 import { reconcileAfterCommand } from '../../lib/services/reconcileLogger.ts'
 import { resolveServicePortForCli } from '../../lib/services/resolvePort.ts'
-import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
+import { resolveWorktree } from '../../lib/services/worktree.ts'
 
 export const servicesStartCommand = new Command({
   name: 'services:start',
@@ -61,13 +61,13 @@ export const servicesStartCommand = new Command({
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project: currentProject, args, flags }) => {
+  handler: async ({ project, worktree, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
 
-    let project = currentProject
+    let activeWorktree = worktree
     if (typeof flags.worktree === 'string') {
       try {
-        project = await resolveWorktreeProject(currentProject, flags.worktree)
+        activeWorktree = resolveWorktree(project, flags.worktree)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         if (flags.json) {
@@ -78,6 +78,7 @@ export const servicesStartCommand = new Command({
         return { success: false, message }
       }
     }
+    project.activeWorktree = activeWorktree
 
     const {
       manager,
@@ -86,7 +87,7 @@ export const servicesStartCommand = new Command({
     } = await getServiceContext(serviceArg, project)
 
     const projectPrefix =
-      targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
+      targetProject.slug !== activeWorktree.slug ? `${targetProject.slug}/` : ''
 
     const serviceConfig = targetProject.config.services?.[serviceName]
     if (serviceConfig) {

--- a/src/commands/services/status.ts
+++ b/src/commands/services/status.ts
@@ -9,7 +9,7 @@ import {
   getServiceCompletions,
   getServiceContext,
 } from '../../lib/services/identifier.ts'
-import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
+import { resolveWorktree } from '../../lib/services/worktree.ts'
 
 export const servicesStatusCommand = new Command({
   name: 'services:status',
@@ -37,13 +37,13 @@ export const servicesStatusCommand = new Command({
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project: currentProject, args, flags }) => {
+  handler: async ({ project, worktree, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
 
-    let project = currentProject
+    let activeWorktree = worktree
     if (typeof flags.worktree === 'string') {
       try {
-        project = await resolveWorktreeProject(currentProject, flags.worktree)
+        activeWorktree = resolveWorktree(project, flags.worktree)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         if (flags.json) {
@@ -54,6 +54,7 @@ export const servicesStatusCommand = new Command({
         return { success: false, message }
       }
     }
+    project.activeWorktree = activeWorktree
 
     const {
       manager,
@@ -67,7 +68,7 @@ export const servicesStatusCommand = new Command({
 
     if (!response) {
       const projectInfo =
-        targetProject.slug !== project.slug
+        targetProject.slug !== activeWorktree.slug
           ? ` in project "${targetProject.slug}"`
           : ''
       if (flags.json) {
@@ -96,7 +97,7 @@ export const servicesStatusCommand = new Command({
     }
 
     const projectPrefix =
-      targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
+      targetProject.slug !== activeWorktree.slug ? `${targetProject.slug}/` : ''
 
     const statusText =
       response.status === 'running'

--- a/src/commands/services/stop.ts
+++ b/src/commands/services/stop.ts
@@ -6,7 +6,7 @@ import {
   getServiceContext,
 } from '../../lib/services/identifier.ts'
 import { reconcileAfterCommand } from '../../lib/services/reconcileLogger.ts'
-import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
+import { resolveWorktree } from '../../lib/services/worktree.ts'
 
 export const servicesStopCommand = new Command({
   name: 'services:stop',
@@ -34,13 +34,13 @@ export const servicesStopCommand = new Command({
   completions: ({ project }) => {
     return getServiceCompletions(project)
   },
-  handler: async ({ project: currentProject, args, flags }) => {
+  handler: async ({ project, worktree, args, flags }) => {
     const serviceArg = z.string().parse(args.name)
 
-    let project = currentProject
+    let activeWorktree = worktree
     if (typeof flags.worktree === 'string') {
       try {
-        project = await resolveWorktreeProject(currentProject, flags.worktree)
+        activeWorktree = resolveWorktree(project, flags.worktree)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         if (flags.json) {
@@ -51,6 +51,7 @@ export const servicesStopCommand = new Command({
         return { success: false, message }
       }
     }
+    project.activeWorktree = activeWorktree
 
     const {
       manager,
@@ -59,7 +60,7 @@ export const servicesStopCommand = new Command({
     } = await getServiceContext(serviceArg, project)
 
     const projectPrefix =
-      targetProject.slug !== project.slug ? `${targetProject.slug}/` : ''
+      targetProject.slug !== activeWorktree.slug ? `${targetProject.slug}/` : ''
 
     if (!flags.json) {
       console.log(`Stopping ${projectPrefix}${serviceName}...`)

--- a/src/commands/services/teardown.ts
+++ b/src/commands/services/teardown.ts
@@ -1,6 +1,6 @@
 import { Command } from '../../lib/command.ts'
 import { reconcileAfterCommand } from '../../lib/services/reconcileLogger.ts'
-import { resolveWorktreeProject } from '../../lib/services/worktree.ts'
+import { resolveWorktree } from '../../lib/services/worktree.ts'
 import { teardownGlobal, teardownProject } from '../../lib/teardown.ts'
 
 export const servicesTeardownCommand = new Command({
@@ -32,7 +32,7 @@ export const servicesTeardownCommand = new Command({
       type: 'string',
     },
   ],
-  handler: async ({ project: currentProject, flags }) => {
+  handler: async ({ project, worktree, flags }) => {
     const removeLogs = flags['remove-logs'] as boolean
     const global = flags.global as boolean
     const worktreeFlag =
@@ -48,10 +48,10 @@ export const servicesTeardownCommand = new Command({
       return { success: false, message }
     }
 
-    let project = currentProject
+    let activeWorktree = worktree
     if (worktreeFlag !== null) {
       try {
-        project = await resolveWorktreeProject(currentProject, worktreeFlag)
+        activeWorktree = resolveWorktree(project, worktreeFlag)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         if (flags.json) {
@@ -62,6 +62,7 @@ export const servicesTeardownCommand = new Command({
         return { success: false, message }
       }
     }
+    project.activeWorktree = activeWorktree
 
     if (global) {
       // Global teardown - all denvig services across all projects
@@ -100,7 +101,7 @@ export const servicesTeardownCommand = new Command({
 
     // Project-specific teardown
     if (!flags.json) {
-      console.log(`Tearing down all services for ${project.slug}...`)
+      console.log(`Tearing down all services for ${activeWorktree.slug}...`)
     }
 
     const result = await teardownProject(project, { removeLogs })

--- a/src/lib/actions/actions.ts
+++ b/src/lib/actions/actions.ts
@@ -1,7 +1,7 @@
 import plugins from '../plugins.ts'
 import { mergeActions } from './mergeActions.ts'
 
-import type { DenvigProject } from '../project.ts'
+import type { Worktree } from '../project/worktree.ts'
 import type { Actions } from './types.ts'
 
 /**
@@ -13,9 +13,7 @@ import type { Actions } from './types.ts'
  * - deno.json tasks
  * - package.json scripts
  */
-export const detectActions = async (
-  project: DenvigProject,
-): Promise<Actions> => {
+export const detectActions = async (project: Worktree): Promise<Actions> => {
   let actions: Actions = {}
 
   // Project

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -1,4 +1,5 @@
 import type { DenvigProject } from './project'
+import type { Worktree } from './project/worktree'
 
 type CommandOptions<
   ArgDefinitions extends ArgDefinition[],
@@ -66,6 +67,8 @@ type CommandHandler<
   FlagDefinitions extends FlagDefinition[],
 > = (context: {
   project: DenvigProject
+  /** The active checkout for this command (cwd's worktree, or `--worktree`). */
+  worktree: Worktree
   args: ParsedArgs<ArgDefinitions>
   flags: ParsedFlags<FlagDefinitions>
   extraArgs?: string[]
@@ -117,7 +120,13 @@ export class Command<
     extraArgs?: string[],
   ): Promise<CommandResponse> {
     try {
-      return await this.handler({ project, args, flags, extraArgs })
+      return await this.handler({
+        project,
+        worktree: project.activeWorktree,
+        args,
+        flags,
+        extraArgs,
+      })
     } catch (e: unknown) {
       console.error(`Error executing command "${this.name}":`, e)
       return { success: false, message: 'fail' }

--- a/src/lib/dependencies.ts
+++ b/src/lib/dependencies.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import plugins from './plugins.ts'
 
-import type { DenvigProject } from './project.ts'
+import type { Worktree } from './project/worktree.ts'
 
 // Re-export dependency types from shared types file
 export type {
@@ -95,7 +95,7 @@ export const dedupeDependencies = (
 }
 
 export const detectDependencies = async (
-  project: DenvigProject,
+  project: Worktree,
 ): Promise<ProjectDependencySchema[]> => {
   // Run all plugin dependency detections in parallel
   const pluginResults = await Promise.all(

--- a/src/lib/gateway/configure.ts
+++ b/src/lib/gateway/configure.ts
@@ -99,7 +99,14 @@ export async function configureGateway(): Promise<ConfigureGatewayResult | null>
   await Promise.all(
     projects.map(async (info) => {
       const project = await DenvigProject.retrieve(info.path)
-      projectsById.set(project.id, { slug: project.slug, path: project.path })
+      // Routes are keyed by the checkout's id, so map every worktree (the
+      // primary and each detached worktree) back to its slug and path.
+      for (const worktree of project.worktrees) {
+        projectsById.set(worktree.id, {
+          slug: worktree.slug,
+          path: worktree.path,
+        })
+      }
     }),
   )
   const globalProject = await createGlobalProject()

--- a/src/lib/packageJson.ts
+++ b/src/lib/packageJson.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 
-import type { DenvigProject } from './project'
+import type { Worktree } from './project/worktree'
 
 export type PackageJson = {
   name: string
@@ -13,7 +13,7 @@ export type PackageJson = {
  * Read the contents of a package.json file in a given project.
  */
 export const readPackageJson = async (
-  project: DenvigProject,
+  project: Worktree,
 ): Promise<PackageJson | null> => {
   const packageJsonPath = `${project.path}/package.json`
   try {

--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -2,7 +2,7 @@ import type {
   OutdatedDependencySchema,
   ProjectDependencySchema,
 } from './dependencies'
-import type { DenvigProject } from './project'
+import type { Worktree } from './project/worktree'
 
 /**
  * Options for outdatedDependencies method
@@ -50,16 +50,16 @@ export type DeduplicateResult = {
 type PluginOptions = {
   name: string
 
-  actions: (project: DenvigProject) => Promise<Record<string, string[]>>
+  actions: (project: Worktree) => Promise<Record<string, string[]>>
 
-  dependencies?: (project: DenvigProject) => Promise<ProjectDependencySchema[]>
+  dependencies?: (project: Worktree) => Promise<ProjectDependencySchema[]>
 
   /**
    * Get outdated dependencies for the project.
    * Returns an array of outdated dependencies with version info.
    */
   outdatedDependencies?: (
-    project: DenvigProject,
+    project: Worktree,
     options?: OutdatedDependenciesOptions,
   ) => Promise<OutdatedDependencySchema[]>
 
@@ -68,7 +68,7 @@ type PluginOptions = {
    * Returns the analysis result, and applies changes if dryRun is false.
    */
   deduplicateDependencies?: (
-    project: DenvigProject,
+    project: Worktree,
     options?: DeduplicateDependenciesOptions,
   ) => Promise<DeduplicateResult | null>
 }

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -1,17 +1,12 @@
-import { readdir } from 'node:fs/promises'
-
-import { detectActions } from './actions/actions.ts'
-import { type ConfigWithSourcePaths, getProjectConfig } from './config.ts'
-import {
-  detectDependencies,
-  type OutdatedDependencySchema,
-  type ProjectDependencySchema,
-} from './dependencies.ts'
-import plugins from './plugins.ts'
-import { detectProjectWorktrees, type ProjectWorktree } from './project/git.ts'
-import { projectRefs } from './project/refs.ts'
+import { detectProjectWorktrees, readGitInfo } from './project/git.ts'
+import { Worktree } from './project/worktree.ts'
 
 import type { ProjectConfigSchema } from '../schemas/config.ts'
+import type { ConfigWithSourcePaths } from './config.ts'
+import type {
+  OutdatedDependencySchema,
+  ProjectDependencySchema,
+} from './dependencies.ts'
 import type {
   DeduplicateDependenciesOptions,
   DeduplicateResult,
@@ -26,52 +21,73 @@ export function shortProjectId(id: string): string {
   return id.slice(0, 8)
 }
 
+/**
+ * A project is the primary git checkout plus every detached worktree that
+ * descends from it. Identity (`id`, `slug`, `refs`, `path`) is the primary
+ * checkout's, while path-sensitive operations (config, dependencies, actions)
+ * are delegated to the *active* worktree — the checkout the command is acting
+ * on (the cwd's checkout by default, or one selected via `--worktree`).
+ */
 export class DenvigProject {
-  private _path: string
-  private _slug: string
-  private _id: string
-  private _refs: string[]
-  private _worktreesCache: ProjectWorktree[] | null = null
-  config: ConfigWithSourcePaths<ProjectConfigSchema>
-  private _rootFilesCache: string[] | null = null
+  /** The primary checkout (`main`). Defines the project's identity. */
+  readonly primaryWorktree: Worktree
+  /** Every checkout: the primary plus all detached worktrees. */
+  readonly worktrees: Worktree[]
+  /** The checkout this project instance is acting on. */
+  activeWorktree: Worktree
 
-  private constructor(
-    projectPath: string,
-    config: ConfigWithSourcePaths<ProjectConfigSchema>,
-    rootFiles?: string[],
-  ) {
-    this._path = projectPath
-    this._refs = projectRefs(projectPath)
-    const githubRef = this._refs.find((ref) => ref.startsWith('github:'))
-    const localRef = this._refs.find((ref) =>
-      ref.startsWith('local:'),
-    ) as string
-    const idRef = this._refs.find((ref) => ref.startsWith('id:')) as string
-    this._slug = githubRef ?? localRef
-    this._id = idRef.slice('id:'.length)
-    this.config = config
-    if (rootFiles) {
-      this._rootFilesCache = rootFiles
-    }
+  private constructor(primaryWorktree: Worktree, worktrees: Worktree[]) {
+    this.primaryWorktree = primaryWorktree
+    this.worktrees = worktrees
+    this.activeWorktree = primaryWorktree
   }
 
   /**
-   * Retrieve a DenvigProject by looking up its config and metadata.
+   * Retrieve a project from any path inside it (the primary checkout or a
+   * detached worktree). The project's identity is rooted at the primary, and
+   * the checkout matching `projectPath` becomes the active worktree.
    */
   static async retrieve(projectPath: string): Promise<DenvigProject> {
-    const [config, rootFiles] = await Promise.all([
-      getProjectConfig(projectPath),
-      readdir(projectPath).catch(() => [] as string[]),
+    const info = readGitInfo(projectPath)
+
+    // Non-git path: a standalone single-checkout project.
+    if (!info) {
+      const only = await Worktree.retrieve(projectPath, 'main', true)
+      const project = new DenvigProject(only, [only])
+      project.activeWorktree = only
+      return project
+    }
+
+    const primaryPath = info.worktree.primaryPath
+    const detached = detectProjectWorktrees(projectPath)
+
+    const [primaryWorktree, ...detachedWorktrees] = await Promise.all([
+      Worktree.retrieve(primaryPath, 'main', true),
+      ...detached.map((wt) => Worktree.retrieve(wt.path, wt.branch, false)),
     ])
-    return new DenvigProject(projectPath, config, rootFiles)
+
+    const worktrees = [primaryWorktree, ...detachedWorktrees]
+    const project = new DenvigProject(primaryWorktree, worktrees)
+
+    // The active worktree is the checkout the given path lives in.
+    project.activeWorktree =
+      worktrees.find((wt) => wt.path === projectPath) ?? primaryWorktree
+
+    return project
   }
 
-  get slug(): string {
-    return this._slug
+  /** Select a worktree by branch. `main` resolves to the primary checkout. */
+  worktree(branch: string): Worktree | null {
+    if (branch === 'main') return this.primaryWorktree
+    return this.worktrees.find((wt) => wt.branch === branch) ?? null
   }
 
   get id(): string {
-    return this._id
+    return this.activeWorktree.id
+  }
+
+  get slug(): string {
+    return this.activeWorktree.slug
   }
 
   /**
@@ -79,133 +95,62 @@ export class DenvigProject {
    * of each ref (`id:`, `local:`, `github:`, `git:`).
    */
   get refs(): string[] {
-    return this._refs
-  }
-
-  /**
-   * Detached git worktrees that belong to this project. The primary
-   * checkout is intentionally excluded, so this is `[]` for projects
-   * without any `git worktree add`-style sibling checkouts. Computed
-   * lazily on first access.
-   */
-  get worktrees(): ProjectWorktree[] {
-    if (this._worktreesCache === null) {
-      this._worktreesCache = detectProjectWorktrees(this._path)
-    }
-    return this._worktreesCache
+    return this.activeWorktree.refs
   }
 
   get name(): string {
-    return this.config.name ?? this._path.split('/').pop() ?? 'unknown'
+    return this.activeWorktree.name
   }
 
   get path(): string {
-    return this._path
+    return this.activeWorktree.path
+  }
+
+  get config(): ConfigWithSourcePaths<ProjectConfigSchema> {
+    return this.activeWorktree.config
   }
 
   get packageManagers(): string[] {
-    const rootFiles = this.rootFiles
-    const packageManagers = []
-
-    if (rootFiles.includes('pnpm-lock.yaml')) {
-      packageManagers.push('pnpm')
-    } else if (rootFiles.includes('package-lock.json')) {
-      packageManagers.push('npm')
-    } else if (rootFiles.includes('yarn.lock')) {
-      packageManagers.push('yarn')
-    }
-    if (rootFiles.includes('deno.json') || rootFiles.includes('deno.jsonc')) {
-      packageManagers.push('deno')
-    }
-    if (rootFiles.includes('pyproject.toml')) {
-      packageManagers.push('uv')
-    }
-
-    return packageManagers
+    return this.activeWorktree.packageManagers
   }
 
   get primaryPackageManager(): string | null {
-    return this.packageManagers[0] || null
+    return this.activeWorktree.primaryPackageManager
   }
 
   async dependencies(): Promise<ProjectDependencySchema[]> {
-    return await detectDependencies(this)
+    return this.activeWorktree.dependencies()
   }
 
   async outdatedDependencies(
     options?: OutdatedDependenciesOptions,
   ): Promise<OutdatedDependencySchema[]> {
-    // Run all plugin outdated checks in parallel
-    const pluginResults = await Promise.all(
-      Object.values(plugins).map((plugin) =>
-        plugin.outdatedDependencies
-          ? plugin.outdatedDependencies(this, options)
-          : Promise.resolve([]),
-      ),
-    )
-
-    // Flatten all results into a single array
-    return pluginResults.flat()
+    return this.activeWorktree.outdatedDependencies(options)
   }
 
   async deduplicateDependencies(
     options?: DeduplicateDependenciesOptions,
   ): Promise<DeduplicateResult[]> {
-    const results = await Promise.all(
-      Object.values(plugins).map((plugin) =>
-        plugin.deduplicateDependencies
-          ? plugin.deduplicateDependencies(this, options)
-          : Promise.resolve(null),
-      ),
-    )
-
-    return results.filter(
-      (result): result is DeduplicateResult => result !== null,
-    )
+    return this.activeWorktree.deduplicateDependencies(options)
   }
 
-  /**
-   * Return all actions that can be run for the current project.
-   */
+  /** Return all actions that can be run for the active worktree. */
   get actions() {
-    return detectActions(this)
+    return this.activeWorktree.actions
   }
 
-  /**
-   *  Return all services defined in the project configuration.
-   */
+  /** Return all services defined in the active worktree's configuration. */
   get services() {
-    return this.config.services || {}
+    return this.activeWorktree.services
   }
 
-  /**
-   * List all files in the root of a project.
-   * Pre-loaded during create(), falls back to empty array.
-   */
+  /** List all files in the root of the active worktree. */
   get rootFiles(): string[] {
-    return this._rootFilesCache ?? []
+    return this.activeWorktree.rootFiles
   }
 
-  /**
-   * Find all files recursively with a given name in the project.
-   */
+  /** Find all files recursively with a given name in the active worktree. */
   async findFilesByName(fileName: string): Promise<string[]> {
-    const results: string[] = []
-
-    const walk = async (dir: string) => {
-      const files = await readdir(dir, { withFileTypes: true })
-      for (const file of files) {
-        if (file.isDirectory()) {
-          if (file.name !== 'node_modules') {
-            await walk(`${dir}/${file.name}`)
-          }
-        } else if (file.name === fileName) {
-          results.push(`${dir}/${file.name}`)
-        }
-      }
-    }
-
-    walk(this.path)
-    return results
+    return this.activeWorktree.findFilesByName(fileName)
   }
 }

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -1,18 +1,6 @@
 import { detectProjectWorktrees, readGitInfo } from './project/git.ts'
 import { Worktree } from './project/worktree.ts'
 
-import type { ProjectConfigSchema } from '../schemas/config.ts'
-import type { ConfigWithSourcePaths } from './config.ts'
-import type {
-  OutdatedDependencySchema,
-  ProjectDependencySchema,
-} from './dependencies.ts'
-import type {
-  DeduplicateDependenciesOptions,
-  DeduplicateResult,
-  OutdatedDependenciesOptions,
-} from './plugin.ts'
-
 /**
  * Truncate a project ID for display purposes.
  * Returns the first 8 characters of the ID.
@@ -23,10 +11,13 @@ export function shortProjectId(id: string): string {
 
 /**
  * A project is the primary git checkout plus every detached worktree that
- * descends from it. Identity (`id`, `slug`, `refs`, `path`) is the primary
- * checkout's, while path-sensitive operations (config, dependencies, actions)
- * are delegated to the *active* worktree — the checkout the command is acting
- * on (the cwd's checkout by default, or one selected via `--worktree`).
+ * descends from it. Its identity (`id`, `slug`, `refs`, `path`, `name`) is the
+ * primary checkout's.
+ *
+ * Everything path-sensitive (config, dependencies, actions, services) lives on
+ * a {@link Worktree}. Use `activeWorktree` for the checkout a command is acting
+ * on, `primaryWorktree` for the project root, or `worktree(branch)` to select a
+ * specific one.
  */
 export class DenvigProject {
   /** The primary checkout (`main`). Defines the project's identity. */
@@ -53,9 +44,7 @@ export class DenvigProject {
     // Non-git path: a standalone single-checkout project.
     if (!info) {
       const only = await Worktree.retrieve(projectPath, 'main', true)
-      const project = new DenvigProject(only, [only])
-      project.activeWorktree = only
-      return project
+      return new DenvigProject(only, [only])
     }
 
     const primaryPath = info.worktree.primaryPath
@@ -82,75 +71,29 @@ export class DenvigProject {
     return this.worktrees.find((wt) => wt.branch === branch) ?? null
   }
 
+  /** Project identity, rooted at the primary checkout. */
   get id(): string {
-    return this.activeWorktree.id
+    return this.primaryWorktree.id
   }
 
   get slug(): string {
-    return this.activeWorktree.slug
+    return this.primaryWorktree.slug
   }
 
   /**
-   * All identifiers for this project. See `projectRefs()` for the format
+   * All identifiers for the project. See `projectRefs()` for the format
    * of each ref (`id:`, `local:`, `github:`, `git:`).
    */
   get refs(): string[] {
-    return this.activeWorktree.refs
+    return this.primaryWorktree.refs
   }
 
   get name(): string {
-    return this.activeWorktree.name
+    return this.primaryWorktree.name
   }
 
+  /** Absolute path of the primary checkout. */
   get path(): string {
-    return this.activeWorktree.path
-  }
-
-  get config(): ConfigWithSourcePaths<ProjectConfigSchema> {
-    return this.activeWorktree.config
-  }
-
-  get packageManagers(): string[] {
-    return this.activeWorktree.packageManagers
-  }
-
-  get primaryPackageManager(): string | null {
-    return this.activeWorktree.primaryPackageManager
-  }
-
-  async dependencies(): Promise<ProjectDependencySchema[]> {
-    return this.activeWorktree.dependencies()
-  }
-
-  async outdatedDependencies(
-    options?: OutdatedDependenciesOptions,
-  ): Promise<OutdatedDependencySchema[]> {
-    return this.activeWorktree.outdatedDependencies(options)
-  }
-
-  async deduplicateDependencies(
-    options?: DeduplicateDependenciesOptions,
-  ): Promise<DeduplicateResult[]> {
-    return this.activeWorktree.deduplicateDependencies(options)
-  }
-
-  /** Return all actions that can be run for the active worktree. */
-  get actions() {
-    return this.activeWorktree.actions
-  }
-
-  /** Return all services defined in the active worktree's configuration. */
-  get services() {
-    return this.activeWorktree.services
-  }
-
-  /** List all files in the root of the active worktree. */
-  get rootFiles(): string[] {
-    return this.activeWorktree.rootFiles
-  }
-
-  /** Find all files recursively with a given name in the active worktree. */
-  async findFilesByName(fileName: string): Promise<string[]> {
-    return this.activeWorktree.findFilesByName(fileName)
+    return this.primaryWorktree.path
   }
 }

--- a/src/lib/project/git.test.ts
+++ b/src/lib/project/git.test.ts
@@ -8,6 +8,7 @@ import { inspect } from 'node:util'
 
 import {
   detectProjectWorktrees,
+  findDetachedWorktreeRoot,
   getGitHubSlug,
   normaliseGitRemote,
   parseGitHubRemoteUrl,
@@ -500,5 +501,53 @@ describe('detectProjectWorktrees()', () => {
       { path: realWorktree, branch: 'branch-a' },
       { path: realWorktree2, branch: 'branch-b' },
     ])
+  })
+})
+
+describe('findDetachedWorktreeRoot()', () => {
+  beforeEach(() => {
+    fs.mkdirSync(mockProjectPath, { recursive: true })
+    execSync('git init -q -b main', { cwd: mockProjectPath })
+    execSync('git config user.email "test@denvig.test"', {
+      cwd: mockProjectPath,
+    })
+    execSync('git config user.name "Denvig Test"', { cwd: mockProjectPath })
+    execSync('git commit --allow-empty -q -m "Initial commit"', {
+      cwd: mockProjectPath,
+    })
+  })
+  afterEach(() => {
+    fs.rmSync(mockProjectPath, { recursive: true, force: true })
+    fs.rmSync(worktreePath, { recursive: true, force: true })
+  })
+
+  it('returns null for a primary checkout', () => {
+    strictEqual(findDetachedWorktreeRoot(mockProjectPath), null)
+  })
+
+  it('returns null from a subdirectory of a primary checkout', () => {
+    const subDir = path.join(mockProjectPath, 'src', 'commands')
+    fs.mkdirSync(subDir, { recursive: true })
+    strictEqual(findDetachedWorktreeRoot(subDir), null)
+  })
+
+  it('returns null for a path outside any git checkout', () => {
+    strictEqual(findDetachedWorktreeRoot('/tmp'), null)
+  })
+
+  it('returns the worktree root from a detached worktree', () => {
+    execSync(`git worktree add ${worktreePath} -b test-branch`, {
+      cwd: mockProjectPath,
+    })
+    strictEqual(findDetachedWorktreeRoot(worktreePath), worktreePath)
+  })
+
+  it('walks up to the worktree root from a worktree subdirectory', () => {
+    execSync(`git worktree add ${worktreePath} -b test-branch`, {
+      cwd: mockProjectPath,
+    })
+    const subDir = path.join(worktreePath, 'src')
+    fs.mkdirSync(subDir, { recursive: true })
+    strictEqual(findDetachedWorktreeRoot(subDir), worktreePath)
   })
 })

--- a/src/lib/project/git.ts
+++ b/src/lib/project/git.ts
@@ -152,6 +152,35 @@ export const detectGitWorktree = (path: string): GitWorktree | null => {
   return readGitInfo(resolve(path))?.worktree ?? null
 }
 
+/**
+ * Walk up from `path` to find the root of the detached git worktree it lives
+ * in. Returns the worktree checkout directory when the nearest `.git` marker is
+ * a *file* (the hallmark of a detached worktree), or null when the nearest
+ * marker is a directory (a primary checkout) or there is no git checkout at all.
+ *
+ * This lets the CLI resolve a worktree — even from a subdirectory or a nested
+ * layout the project glob doesn't match — to its own checkout, while leaving
+ * primary checkouts and non-worktree project directories to the normal
+ * resolution path.
+ */
+export const findDetachedWorktreeRoot = (path: string): string | null => {
+  let current = resolve(path)
+  while (true) {
+    const marker = resolve(current, '.git')
+    try {
+      const stat = statSync(marker)
+      // First `.git` wins: a file means a detached worktree, a directory means
+      // the primary checkout (so the cwd is not inside a detached worktree).
+      return stat.isFile() ? current : null
+    } catch {
+      // No marker here; keep walking up.
+    }
+    const parent = resolve(current, '..')
+    if (parent === current) return null
+    current = parent
+  }
+}
+
 export type ProjectWorktree = {
   /** Absolute path of the detached worktree's checkout. */
   path: string

--- a/src/lib/project/worktree.ts
+++ b/src/lib/project/worktree.ts
@@ -1,0 +1,177 @@
+import { readdir } from 'node:fs/promises'
+
+import { detectActions } from '../actions/actions.ts'
+import { type ConfigWithSourcePaths, getProjectConfig } from '../config.ts'
+import {
+  detectDependencies,
+  type OutdatedDependencySchema,
+  type ProjectDependencySchema,
+} from '../dependencies.ts'
+import plugins from '../plugins.ts'
+import { projectRefs } from './refs.ts'
+
+import type { ProjectConfigSchema } from '../../schemas/config.ts'
+import type {
+  DeduplicateDependenciesOptions,
+  DeduplicateResult,
+  OutdatedDependenciesOptions,
+} from '../plugin.ts'
+
+/**
+ * A single git checkout belonging to a project — either the primary checkout
+ * or a detached worktree. Everything path-sensitive (config, dependencies,
+ * actions, refs) lives here, since these all differ between checkouts.
+ *
+ * A worktree's `refs`, `id` and `slug` are derived from its own path, so they
+ * match the values the legacy `DenvigProject` produced for that checkout. This
+ * keeps service state keys (which are derived from these) stable across the
+ * project-owns-worktrees refactor.
+ */
+export class Worktree {
+  /** Absolute path of this checkout. */
+  readonly path: string
+  /** Branch checked out here. The primary checkout always reports `main`. */
+  readonly branch: string
+  /** True when this is the project's primary checkout. */
+  readonly isPrimary: boolean
+  /** All identifiers for this checkout. See `projectRefs()` for the format. */
+  readonly refs: string[]
+  readonly slug: string
+  readonly id: string
+  config: ConfigWithSourcePaths<ProjectConfigSchema>
+  private _rootFilesCache: string[] | null = null
+
+  private constructor(
+    path: string,
+    branch: string,
+    isPrimary: boolean,
+    config: ConfigWithSourcePaths<ProjectConfigSchema>,
+    rootFiles?: string[],
+  ) {
+    this.path = path
+    this.branch = branch
+    this.isPrimary = isPrimary
+    this.refs = projectRefs(path)
+    const githubRef = this.refs.find((ref) => ref.startsWith('github:'))
+    const localRef = this.refs.find((ref) => ref.startsWith('local:')) as string
+    const idRef = this.refs.find((ref) => ref.startsWith('id:')) as string
+    this.slug = githubRef ?? localRef
+    this.id = idRef.slice('id:'.length)
+    this.config = config
+    if (rootFiles) {
+      this._rootFilesCache = rootFiles
+    }
+  }
+
+  /** Retrieve a worktree by looking up its config and root files. */
+  static async retrieve(
+    path: string,
+    branch: string,
+    isPrimary: boolean,
+  ): Promise<Worktree> {
+    const [config, rootFiles] = await Promise.all([
+      getProjectConfig(path),
+      readdir(path).catch(() => [] as string[]),
+    ])
+    return new Worktree(path, branch, isPrimary, config, rootFiles)
+  }
+
+  get name(): string {
+    return this.config.name ?? this.path.split('/').pop() ?? 'unknown'
+  }
+
+  /** List of files in the root of this checkout. */
+  get rootFiles(): string[] {
+    return this._rootFilesCache ?? []
+  }
+
+  get packageManagers(): string[] {
+    const rootFiles = this.rootFiles
+    const packageManagers = []
+
+    if (rootFiles.includes('pnpm-lock.yaml')) {
+      packageManagers.push('pnpm')
+    } else if (rootFiles.includes('package-lock.json')) {
+      packageManagers.push('npm')
+    } else if (rootFiles.includes('yarn.lock')) {
+      packageManagers.push('yarn')
+    }
+    if (rootFiles.includes('deno.json') || rootFiles.includes('deno.jsonc')) {
+      packageManagers.push('deno')
+    }
+    if (rootFiles.includes('pyproject.toml')) {
+      packageManagers.push('uv')
+    }
+
+    return packageManagers
+  }
+
+  get primaryPackageManager(): string | null {
+    return this.packageManagers[0] || null
+  }
+
+  async dependencies(): Promise<ProjectDependencySchema[]> {
+    return await detectDependencies(this)
+  }
+
+  async outdatedDependencies(
+    options?: OutdatedDependenciesOptions,
+  ): Promise<OutdatedDependencySchema[]> {
+    const pluginResults = await Promise.all(
+      Object.values(plugins).map((plugin) =>
+        plugin.outdatedDependencies
+          ? plugin.outdatedDependencies(this, options)
+          : Promise.resolve([]),
+      ),
+    )
+
+    return pluginResults.flat()
+  }
+
+  async deduplicateDependencies(
+    options?: DeduplicateDependenciesOptions,
+  ): Promise<DeduplicateResult[]> {
+    const results = await Promise.all(
+      Object.values(plugins).map((plugin) =>
+        plugin.deduplicateDependencies
+          ? plugin.deduplicateDependencies(this, options)
+          : Promise.resolve(null),
+      ),
+    )
+
+    return results.filter(
+      (result): result is DeduplicateResult => result !== null,
+    )
+  }
+
+  /** All actions that can be run for this checkout. */
+  get actions() {
+    return detectActions(this)
+  }
+
+  /** All services defined in this checkout's configuration. */
+  get services() {
+    return this.config.services || {}
+  }
+
+  /** Find all files recursively with a given name in this checkout. */
+  async findFilesByName(fileName: string): Promise<string[]> {
+    const results: string[] = []
+
+    const walk = async (dir: string) => {
+      const files = await readdir(dir, { withFileTypes: true })
+      for (const file of files) {
+        if (file.isDirectory()) {
+          if (file.name !== 'node_modules') {
+            await walk(`${dir}/${file.name}`)
+          }
+        } else if (file.name === fileName) {
+          results.push(`${dir}/${file.name}`)
+        }
+      }
+    }
+
+    await walk(this.path)
+    return results
+  }
+}

--- a/src/lib/projectInfo.test.ts
+++ b/src/lib/projectInfo.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test'
 import { createMockProject } from '../test/mock.ts'
 import { getProjectInfo } from './projectInfo.ts'
 
-import type { DenvigProject } from './project.ts'
+import type { Worktree } from './project/worktree.ts'
 
 describe('getProjectInfo()', () => {
   it('should return project info with correct slug', async () => {
@@ -30,7 +30,7 @@ describe('getProjectInfo()', () => {
 
   it('should return null config when no $sources', async () => {
     const project = createMockProject({
-      config: { name: 'test', $sources: [] } as DenvigProject['config'],
+      config: { name: 'test', $sources: [] } as Worktree['config'],
     })
     const info = await getProjectInfo(project)
 
@@ -42,7 +42,7 @@ describe('getProjectInfo()', () => {
       config: {
         name: 'configured-project',
         $sources: ['/path/to/.denvig.yml'],
-      } as DenvigProject['config'],
+      } as Worktree['config'],
     })
     const info = await getProjectInfo(project)
 

--- a/src/lib/projectInfo.ts
+++ b/src/lib/projectInfo.ts
@@ -74,7 +74,9 @@ export const getProjectInfo = async (
     name: project.name,
     path: project.path,
     refs: project.refs,
-    worktrees: project.worktrees,
+    worktrees: project.worktrees
+      .filter((wt) => !wt.isPrimary)
+      .map((wt) => ({ path: wt.path, branch: wt.branch })),
     config: hasConfig ? configWithoutSources : null,
     serviceStatus,
   }

--- a/src/lib/projectInfo.ts
+++ b/src/lib/projectInfo.ts
@@ -34,16 +34,17 @@ export const getProjectInfo = async (
   project: DenvigProject,
   options?: GetProjectInfoOptions,
 ): Promise<ProjectInfo> => {
-  const hasConfig = project.config.$sources.length > 0
+  const active = project.activeWorktree
+  const hasConfig = active.config.$sources.length > 0
   const includeServiceStatus = options?.includeServiceStatus ?? true
 
   // Extract config without internal $sources property
-  const { $sources: _, ...configWithoutSources } = project.config
+  const { $sources: _, ...configWithoutSources } = active.config
 
   // Determine service status (only when requested)
   let serviceStatus: ServiceStatus = 'none'
   if (includeServiceStatus) {
-    const services = project.config.services || {}
+    const services = active.config.services || {}
     const serviceNames = Object.keys(services)
 
     if (serviceNames.length > 0) {
@@ -51,7 +52,7 @@ export const getProjectInfo = async (
       const launchctlList =
         options?.launchctlList ?? (await launchctl.list('denvig.'))
 
-      const manager = new ServiceManager(project)
+      const manager = new ServiceManager(active)
       let hasRunningService = false
 
       for (const serviceName of serviceNames) {
@@ -69,11 +70,11 @@ export const getProjectInfo = async (
   }
 
   return {
-    id: project.id,
-    slug: project.slug,
-    name: project.name,
-    path: project.path,
-    refs: project.refs,
+    id: active.id,
+    slug: active.slug,
+    name: active.name,
+    path: active.path,
+    refs: active.refs,
     worktrees: project.worktrees
       .filter((wt) => !wt.isPrimary)
       .map((wt) => ({ path: wt.path, branch: wt.branch })),

--- a/src/lib/rubygems/parse.ts
+++ b/src/lib/rubygems/parse.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 
 import type { ProjectDependencySchema } from '../dependencies.ts'
-import type { DenvigProject } from '../project.ts'
+import type { Worktree } from '../project/worktree.ts'
 
 type GemfileDependency = {
   name: string
@@ -189,7 +189,7 @@ export const parseGemfileLock = (content: string): GemfileLockData => {
  * Parse Ruby dependencies from Gemfile and Gemfile.lock
  */
 export const parseRubyDependencies = async (
-  project: DenvigProject,
+  project: Worktree,
 ): Promise<ProjectDependencySchema[]> => {
   const gemfilePath = `${project.path}/Gemfile`
   const lockfilePath = `${project.path}/Gemfile.lock`

--- a/src/lib/services/identifier.ts
+++ b/src/lib/services/identifier.ts
@@ -9,6 +9,8 @@ import {
 } from './global.ts'
 import { ServiceManager, type ServiceManagerProject } from './manager.ts'
 
+import type { Worktree } from '../project/worktree.ts'
+
 export type ServiceIdentifier = {
   projectSlug: string
   projectId?: string
@@ -185,7 +187,7 @@ export const getServiceContext = async (
     currentProject.slug,
   )
 
-  let project: ServiceManagerProject
+  let worktree: Worktree
 
   // Handle global slug from parseServiceIdentifier
   if (isGlobalSlug(projectSlug)) {
@@ -200,31 +202,31 @@ export const getServiceContext = async (
       currentProject.id === projectId ||
       currentProject.id.startsWith(projectId)
     ) {
-      project = currentProject.activeWorktree
+      worktree = currentProject.activeWorktree
     } else {
       const projectPath = await resolveProjectIdToPath(projectId)
       if (projectPath) {
-        project = (await DenvigProject.retrieve(projectPath)).activeWorktree
+        worktree = (await DenvigProject.retrieve(projectPath)).activeWorktree
       } else {
         throw new Error(`Project with ID "${projectId}" not found`)
       }
     }
   } else if (projectSlug === currentProject.slug) {
-    project = currentProject.activeWorktree
+    worktree = currentProject.activeWorktree
   } else {
     // Try to resolve the slug to a path
     const projectPath = await resolveProjectSlugToPath(projectSlug)
     if (projectPath) {
-      project = (await DenvigProject.retrieve(projectPath)).activeWorktree
+      worktree = (await DenvigProject.retrieve(projectPath)).activeWorktree
     } else {
       // Fallback: treat as path (original behavior)
-      project = (await DenvigProject.retrieve(projectSlug)).activeWorktree
+      worktree = (await DenvigProject.retrieve(projectSlug)).activeWorktree
     }
   }
 
-  const manager = new ServiceManager(project)
+  const manager = new ServiceManager(worktree)
 
-  return { project, manager, serviceName }
+  return { project: worktree, manager, serviceName }
 }
 
 /**

--- a/src/lib/services/identifier.ts
+++ b/src/lib/services/identifier.ts
@@ -172,9 +172,10 @@ export const getServiceContext = async (
   if (parsed.serviceName !== undefined && parsed.serviceName !== '') {
     const projectPath = await resolveProjectPath(parsed, expandTilde)
     if (projectPath) {
-      const project = await DenvigProject.retrieve(projectPath)
-      const manager = new ServiceManager(project)
-      return { project, manager, serviceName: parsed.serviceName }
+      const worktree = (await DenvigProject.retrieve(projectPath))
+        .activeWorktree
+      const manager = new ServiceManager(worktree)
+      return { project: worktree, manager, serviceName: parsed.serviceName }
     }
   }
 
@@ -199,25 +200,25 @@ export const getServiceContext = async (
       currentProject.id === projectId ||
       currentProject.id.startsWith(projectId)
     ) {
-      project = currentProject
+      project = currentProject.activeWorktree
     } else {
       const projectPath = await resolveProjectIdToPath(projectId)
       if (projectPath) {
-        project = await DenvigProject.retrieve(projectPath)
+        project = (await DenvigProject.retrieve(projectPath)).activeWorktree
       } else {
         throw new Error(`Project with ID "${projectId}" not found`)
       }
     }
   } else if (projectSlug === currentProject.slug) {
-    project = currentProject
+    project = currentProject.activeWorktree
   } else {
     // Try to resolve the slug to a path
     const projectPath = await resolveProjectSlugToPath(projectSlug)
     if (projectPath) {
-      project = await DenvigProject.retrieve(projectPath)
+      project = (await DenvigProject.retrieve(projectPath)).activeWorktree
     } else {
       // Fallback: treat as path (original behavior)
-      project = await DenvigProject.retrieve(projectSlug)
+      project = (await DenvigProject.retrieve(projectSlug)).activeWorktree
     }
   }
 
@@ -237,7 +238,9 @@ export const getServiceCompletions = async (
   const completions: string[] = []
 
   // Add current project services without prefix for convenience
-  for (const serviceName of Object.keys(currentProject.services)) {
+  for (const serviceName of Object.keys(
+    currentProject.activeWorktree.services,
+  )) {
     completions.push(serviceName)
   }
 
@@ -255,7 +258,7 @@ export const getServiceCompletions = async (
       const project = await DenvigProject.retrieve(projectInfo.path)
       const slugWithoutPrefix = projectInfo.slug.replace(/^(github|local):/, '')
 
-      for (const serviceName of Object.keys(project.services)) {
+      for (const serviceName of Object.keys(project.activeWorktree.services)) {
         // Add slug-based completion
         completions.push(`${slugWithoutPrefix}/${serviceName}`)
         // Add id-based completion for exact matching (useful for worktrees)

--- a/src/lib/services/worktree.test.ts
+++ b/src/lib/services/worktree.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import { DenvigProject } from '../project.ts'
-import { resolveWorktreeProject } from './worktree.ts'
+import { resolveWorktree } from './worktree.ts'
 
 const primaryPath = '/tmp/denvig-test-worktree-primary'
 const worktreePath = `${primaryPath}+feature`
@@ -19,7 +19,7 @@ const initRepo = () => {
   })
 }
 
-describe('resolveWorktreeProject()', () => {
+describe('resolveWorktree()', () => {
   beforeEach(() => initRepo())
   afterEach(() => {
     fs.rmSync(primaryPath, { recursive: true, force: true })
@@ -31,9 +31,11 @@ describe('resolveWorktreeProject()', () => {
       cwd: primaryPath,
     })
     const primary = await DenvigProject.retrieve(primaryPath)
-    const worktreeProject = await resolveWorktreeProject(primary, 'feature')
+    const worktree = resolveWorktree(primary, 'feature')
     const realWorktreePath = fs.realpathSync(worktreePath)
-    assert.strictEqual(worktreeProject.path, realWorktreePath)
+    assert.strictEqual(worktree.path, realWorktreePath)
+    assert.strictEqual(worktree.branch, 'feature')
+    assert.strictEqual(worktree.isPrimary, false)
   })
 
   it('resolves "main" to the primary checkout when called from a worktree', async () => {
@@ -41,15 +43,16 @@ describe('resolveWorktreeProject()', () => {
       cwd: primaryPath,
     })
     const worktreeProject = await DenvigProject.retrieve(worktreePath)
-    const primaryProject = await resolveWorktreeProject(worktreeProject, 'main')
+    const primary = resolveWorktree(worktreeProject, 'main')
     const realPrimaryPath = fs.realpathSync(primaryPath)
-    assert.strictEqual(primaryProject.path, realPrimaryPath)
+    assert.strictEqual(primary.path, realPrimaryPath)
+    assert.strictEqual(primary.isPrimary, true)
   })
 
   it('throws when the branch does not match any worktree', async () => {
     const primary = await DenvigProject.retrieve(primaryPath)
-    await assert.rejects(
-      () => resolveWorktreeProject(primary, 'nonexistent'),
+    assert.throws(
+      () => resolveWorktree(primary, 'nonexistent'),
       /Worktree with branch "nonexistent" not found/,
     )
   })

--- a/src/lib/services/worktree.ts
+++ b/src/lib/services/worktree.ts
@@ -1,32 +1,27 @@
-import { readGitInfo } from '../project/git.ts'
-import { DenvigProject } from '../project.ts'
+import type { Worktree } from '../project/worktree.ts'
+import type { DenvigProject } from '../project.ts'
 
 /**
- * Resolve a worktree branch name to a `DenvigProject`. The branch `main`
- * always resolves to the primary checkout (matching the convention used by
- * `projectRefs`). Other branches are looked up against the project's detached
- * worktrees.
+ * Resolve a worktree branch name to the matching {@link Worktree} of a project.
+ * The branch `main` always resolves to the primary checkout (matching the
+ * convention used by `projectRefs`). Other branches are looked up against the
+ * project's detached worktrees.
  *
  * Throws when the branch does not match any worktree (or the primary).
  */
-export const resolveWorktreeProject = async (
-  currentProject: DenvigProject,
+export const resolveWorktree = (
+  project: DenvigProject,
   branch: string,
-): Promise<DenvigProject> => {
-  if (branch === 'main') {
-    const info = readGitInfo(currentProject.path)
-    if (info?.worktree.primaryPath) {
-      return await DenvigProject.retrieve(info.worktree.primaryPath)
-    }
-  }
-
-  const worktree = currentProject.worktrees.find((w) => w.branch === branch)
+): Worktree => {
+  const worktree = project.worktree(branch)
   if (!worktree) {
-    const available = currentProject.worktrees.map((w) => w.branch)
+    const available = project.worktrees
+      .filter((wt) => !wt.isPrimary)
+      .map((wt) => wt.branch)
     const hint = available.length
       ? ` Available worktrees: ${available.join(', ')}`
       : ''
     throw new Error(`Worktree with branch "${branch}" not found.${hint}`)
   }
-  return await DenvigProject.retrieve(worktree.path)
+  return worktree
 }

--- a/src/lib/teardown.ts
+++ b/src/lib/teardown.ts
@@ -144,14 +144,15 @@ export async function teardownProject(
   project: DenvigProject,
   options?: TeardownOptions,
 ): Promise<ProjectTeardownResult> {
-  const manager = new ServiceManager(project)
+  const worktree = project.activeWorktree
+  const manager = new ServiceManager(worktree)
   const services = await manager.teardownAll({
     removeLogs: options?.removeLogs,
   })
 
   return {
     success: true,
-    project: project.slug,
+    project: worktree.slug,
     services,
     logsRemoved: options?.removeLogs ?? false,
   }

--- a/src/lib/uv/parse.ts
+++ b/src/lib/uv/parse.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { parseToml } from './toml.ts'
 
 import type { ProjectDependencySchema } from '../dependencies.ts'
-import type { DenvigProject } from '../project.ts'
+import type { Worktree } from '../project/worktree.ts'
 
 type PyProjectDependency = {
   name: string
@@ -159,7 +159,7 @@ export const parseUvLock = (content: string): UvLockData => {
  * Parse Python dependencies from pyproject.toml and uv.lock
  */
 export const parseUvDependencies = async (
-  project: DenvigProject,
+  project: Worktree,
 ): Promise<ProjectDependencySchema[]> => {
   const pyprojectPath = `${project.path}/pyproject.toml`
   const lockfilePath = `${project.path}/uv.lock`

--- a/src/plugins/deno.ts
+++ b/src/plugins/deno.ts
@@ -8,7 +8,7 @@ import { definePlugin } from '../lib/plugin.ts'
 import { pathExists } from '../lib/safeReadFile.ts'
 
 import type { ProjectDependencySchema } from '../lib/dependencies.ts'
-import type { DenvigProject } from '../lib/project.ts'
+import type { Worktree } from '../lib/project/worktree.ts'
 
 // Cache for parsed dependencies by project path
 const dependenciesCache = new Map<string, ProjectDependencySchema[]>()
@@ -101,7 +101,7 @@ const readJsonFile = async (
 const plugin = definePlugin({
   name: 'deno',
 
-  actions: async (project: DenvigProject) => {
+  actions: async (project: Worktree) => {
     const rootFiles = project.rootFiles
     const hasDenoConfig =
       rootFiles.includes('deno.json') || rootFiles.includes('deno.jsonc')
@@ -155,7 +155,7 @@ const plugin = definePlugin({
   },
 
   dependencies: async (
-    project: DenvigProject,
+    project: Worktree,
   ): Promise<ProjectDependencySchema[]> => {
     if (!(await pathExists(`${project.path}/deno.lock`))) {
       return []
@@ -286,7 +286,7 @@ const plugin = definePlugin({
     return result
   },
 
-  outdatedDependencies: async (project: DenvigProject, options) => {
+  outdatedDependencies: async (project: Worktree, options) => {
     if (!(await pathExists(`${project.path}/deno.lock`))) {
       return []
     }

--- a/src/plugins/npm.ts
+++ b/src/plugins/npm.ts
@@ -1,12 +1,12 @@
 import { readPackageJson } from '../lib/packageJson.ts'
 import { definePlugin } from '../lib/plugin.ts'
 
-import type { DenvigProject } from '../lib/project.ts'
+import type { Worktree } from '../lib/project/worktree.ts'
 
 const plugin = definePlugin({
   name: 'npm',
 
-  actions: async (project: DenvigProject) => {
+  actions: async (project: Worktree) => {
     const rootFiles = project.rootFiles
     const hasPackageJson = rootFiles.includes('package.json')
     const hasNpmLock = rootFiles.includes('package-lock.json')

--- a/src/plugins/pnpm.ts
+++ b/src/plugins/pnpm.ts
@@ -18,7 +18,7 @@ import {
 import { pathExists } from '../lib/safeReadFile.ts'
 
 import type { ProjectDependencySchema } from '../lib/dependencies.ts'
-import type { DenvigProject } from '../lib/project.ts'
+import type { Worktree } from '../lib/project/worktree.ts'
 
 // Cache for parsed dependencies by project path
 const dependenciesCache = new Map<string, ProjectDependencySchema[]>()
@@ -74,7 +74,7 @@ const resolveAlias = (
 const plugin = definePlugin({
   name: 'pnpm',
 
-  actions: async (project: DenvigProject) => {
+  actions: async (project: Worktree) => {
     const hasPnpmLock = project.rootFiles.includes('pnpm-lock.yaml')
     const canHandle = hasPnpmLock
 
@@ -103,7 +103,7 @@ const plugin = definePlugin({
   },
 
   dependencies: async (
-    project: DenvigProject,
+    project: Worktree,
   ): Promise<ProjectDependencySchema[]> => {
     if (!(await pathExists(`${project.path}/pnpm-lock.yaml`))) {
       return []
@@ -259,7 +259,7 @@ const plugin = definePlugin({
     return result
   },
 
-  outdatedDependencies: async (project: DenvigProject, options) => {
+  outdatedDependencies: async (project: Worktree, options) => {
     if (!(await pathExists(`${project.path}/pnpm-lock.yaml`))) {
       return []
     }

--- a/src/plugins/ruby.ts
+++ b/src/plugins/ruby.ts
@@ -4,7 +4,7 @@ import { parseRubyDependencies } from '../lib/rubygems/parse.ts'
 import { pathExists } from '../lib/safeReadFile.ts'
 
 import type { ProjectDependencySchema } from '../lib/dependencies.ts'
-import type { DenvigProject } from '../lib/project.ts'
+import type { Worktree } from '../lib/project/worktree.ts'
 
 // Cache for parsed dependencies by project path
 const dependenciesCache = new Map<string, ProjectDependencySchema[]>()
@@ -12,7 +12,7 @@ const dependenciesCache = new Map<string, ProjectDependencySchema[]>()
 const plugin = definePlugin({
   name: 'ruby',
 
-  actions: async (project: DenvigProject) => {
+  actions: async (project: Worktree) => {
     const rootFiles = project.rootFiles
     const hasGemfile = rootFiles.includes('Gemfile')
     const hasRakefile = rootFiles.includes('Rakefile')
@@ -48,7 +48,7 @@ const plugin = definePlugin({
   },
 
   dependencies: async (
-    project: DenvigProject,
+    project: Worktree,
   ): Promise<ProjectDependencySchema[]> => {
     const hasGemfile = project.rootFiles.includes('Gemfile')
     if (!hasGemfile) {

--- a/src/plugins/uv.ts
+++ b/src/plugins/uv.ts
@@ -3,7 +3,7 @@ import { uvOutdated } from '../lib/uv/outdated.ts'
 import { parseUvDependencies } from '../lib/uv/parse.ts'
 
 import type { ProjectDependencySchema } from '../lib/dependencies.ts'
-import type { DenvigProject } from '../lib/project.ts'
+import type { Worktree } from '../lib/project/worktree.ts'
 
 // Cache for parsed dependencies by project path
 const dependenciesCache = new Map<string, ProjectDependencySchema[]>()
@@ -11,7 +11,7 @@ const dependenciesCache = new Map<string, ProjectDependencySchema[]>()
 const plugin = definePlugin({
   name: 'uv',
 
-  actions: async (project: DenvigProject) => {
+  actions: async (project: Worktree) => {
     const rootFiles = project.rootFiles
     const hasPyProject = rootFiles.includes('pyproject.toml')
     const hasUvLock = rootFiles.includes('uv.lock')
@@ -29,7 +29,7 @@ const plugin = definePlugin({
   },
 
   dependencies: async (
-    project: DenvigProject,
+    project: Worktree,
   ): Promise<ProjectDependencySchema[]> => {
     const hasPyProject = project.rootFiles.includes('pyproject.toml')
     const hasUvLock = project.rootFiles.includes('uv.lock')

--- a/src/plugins/yarn.ts
+++ b/src/plugins/yarn.ts
@@ -14,7 +14,7 @@ import { definePlugin } from '../lib/plugin.ts'
 import { pathExists } from '../lib/safeReadFile.ts'
 
 import type { ProjectDependencySchema } from '../lib/dependencies.ts'
-import type { DenvigProject } from '../lib/project.ts'
+import type { Worktree } from '../lib/project/worktree.ts'
 
 // Cache for parsed dependencies by project path
 const dependenciesCache = new Map<string, ProjectDependencySchema[]>()
@@ -64,7 +64,7 @@ function extractPackageName(key: string): string {
 const plugin = definePlugin({
   name: 'yarn',
 
-  actions: async (project: DenvigProject) => {
+  actions: async (project: Worktree) => {
     const hasPackageJson = project.rootFiles.includes('package.json')
     const hasYarnLock = project.rootFiles.includes('yarn.lock')
     const canHandle = hasPackageJson && hasYarnLock
@@ -93,7 +93,7 @@ const plugin = definePlugin({
   },
 
   dependencies: async (
-    project: DenvigProject,
+    project: Worktree,
   ): Promise<ProjectDependencySchema[]> => {
     const lockfilePath = `${project.path}/yarn.lock`
     const packageJsonPath = `${project.path}/package.json`
@@ -349,7 +349,7 @@ const plugin = definePlugin({
     return result
   },
 
-  outdatedDependencies: async (project: DenvigProject, options) => {
+  outdatedDependencies: async (project: Worktree, options) => {
     if (!(await pathExists(`${project.path}/yarn.lock`))) {
       return []
     }

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -9,16 +9,19 @@ export type MockProjectOptions = {
   slug?: string
   name?: string
   path?: string
-  config?: DenvigProject['config']
+  config?: Worktree['config']
 }
 
 /**
  * Create a mock DenvigProject for testing.
- * This creates a minimal mock with stub properties.
+ *
+ * The returned mock is backed by a single primary {@link Worktree} (exposed as
+ * `activeWorktree`/`primaryWorktree`) and also carries `config` at the top
+ * level so it satisfies `ServiceManagerProject` for service tests.
  */
 export const createMockProject = (
   options: MockProjectOptions | string = {},
-): DenvigProject => {
+): DenvigProject & { config: Worktree['config'] } => {
   // Support legacy signature: createMockProject(slug, path?)
   if (typeof options === 'string') {
     options = { slug: options }
@@ -33,14 +36,29 @@ export const createMockProject = (
     $sources: [],
   }
 
+  const worktree = {
+    id,
+    slug,
+    name,
+    path,
+    config,
+    isPrimary: true,
+    branch: 'main',
+    refs: [],
+    rootFiles: [],
+  } as unknown as Worktree
+
   return {
     id,
     slug,
     name,
     path,
     config,
-    worktrees: [],
-  } as unknown as DenvigProject
+    primaryWorktree: worktree,
+    activeWorktree: worktree,
+    worktrees: [worktree],
+    worktree: (branch: string) => (branch === 'main' ? worktree : null),
+  } as unknown as DenvigProject & { config: Worktree['config'] }
 }
 
 /**

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 
 import { projectId } from '../lib/project/refs.ts'
 
+import type { Worktree } from '../lib/project/worktree.ts'
 import type { DenvigProject } from '../lib/project.ts'
 
 export type MockProjectOptions = {
@@ -38,16 +39,15 @@ export const createMockProject = (
     name,
     path,
     config,
+    worktrees: [],
   } as unknown as DenvigProject
 }
 
 /**
- * Create a mock DenvigProject that reads from a real directory.
+ * Create a mock Worktree that reads from a real directory.
  * Use this when tests need actual filesystem access (e.g., plugin tests).
  */
-export const createMockProjectFromPath = (
-  projectPath: string,
-): DenvigProject => {
+export const createMockProjectFromPath = (projectPath: string): Worktree => {
   return {
     path: projectPath,
     rootFiles: fs.readdirSync(projectPath),
@@ -68,5 +68,5 @@ export const createMockProjectFromPath = (
       walk(projectPath)
       return results
     },
-  } as DenvigProject
+  } as unknown as Worktree
 }


### PR DESCRIPTION
## Summary

Reworks the project model so a **project is the primary git checkout that owns its worktrees** (the primary plus every detached worktree), instead of each checkout being a separate `DenvigProject`. This fixes worktree resolution and lets `denvig projects` / `denvig services` group worktrees under their project rather than listing them as standalone entries.

Builds on the revert of #202 (#204), then introduces the proper model in phased commits.

## Model

- **`Worktree`** (new) — a single checkout, carrying everything path-sensitive: `config`, `dependencies()`, `outdatedDependencies()`, `deduplicateDependencies()`, `actions`, `services`, `rootFiles`, and per-checkout `refs`/`id`/`slug` (identical values to the old per-checkout `DenvigProject`, so service state keys stay stable).
- **`DenvigProject`** — the project family: `id`/`slug`/`refs`/`path`/`name` are the **primary** checkout's identity; it owns `worktrees` (primary + detached), exposes `activeWorktree`, and `worktree(branch)` to select one.
- **Command context** now includes the active `worktree` alongside `project`; commands read path-sensitive data from the worktree.

## Behaviour changes

- Running denvig inside a worktree (incl. subdirectories and nested layouts the project glob doesn't match) now resolves the worktree's own config, dependencies, and refs. Detection walks up to the nearest `.git`; a `.git` *file* means a detached worktree.
- **`denvig projects`** lists one row per project and nests its worktrees beneath it with a single `└` connector. The service icon sits in a fixed left column; sibling worktrees that the glob matched no longer appear as separate top-level projects.
- **`denvig services list --worktrees`** nests each project's worktree services beneath it using the same `└` connector. Services are grouped by name, so a service's worktree instances sit directly under the primary's. Pair with `--all` to show worktrees for every project; `--all` now groups services by project family (one row per project) instead of listing glob-matched sibling worktrees separately. `--worktrees` can't be combined with `--global` or `--worktree`.
- `projects --json` / SDK `projects.list` return one entry per project with worktrees nested.

## Services / gateway

- `ServiceManager` is always constructed from a `Worktree`, so launchctl labels, `state.json` keys, and gateway routes remain per-checkout — no orphaned services on upgrade.
- `--worktree <branch>` selects the project's own cached `Worktree` (`resolveWorktree`) instead of re-retrieving a fresh project.
- The gateway maps every worktree's id (not just the primary) back to its slug/path when rebuilding nginx.

## Testing

- `pnpm run check-types`, `pnpm run lint`, `pnpm run codegen`, `pnpm run build` all clean.
- Full suite: 632 pass / 2 fail — the 2 failures (`run.test.ts`, pnpm `examples` actions) are pre-existing and unrelated (fail identically on the base).
- Verified with the installed binary: worktree resolution (`info`/`outdated`/`run`/`services`), the nested `projects` tree, `projects --json`, and `services list --worktrees`/`--all --worktrees`.
