### PR TITLE
Fix gateway domain reconciliation: orphaned worktree services and spurious restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed
 
 - `denvig run` again resolves actions whose names contain a colon (e.g. `compile:darwin-x64`) instead of mistaking the colon for an `ecosystem:action` prefix
+- Services left behind by a deleted worktree are now cleaned up automatically, so a service can reclaim its domain instead of being stuck routing to `http://localhost:<port>` with no gateway config
 
 ## [0.7.0-alpha.3] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - `denvig run` again resolves actions whose names contain a colon (e.g. `compile:darwin-x64`) instead of mistaking the colon for an `ecosystem:action` prefix
 - Services left behind by a deleted worktree are now cleaned up automatically, so a service can reclaim its domain instead of being stuck routing to `http://localhost:<port>` with no gateway config
+- A `services` command no longer reports spurious restarts of unrelated services (e.g. `↻ restarted … config changed since last bootstrap`); liveness is left to launchd, so a momentarily-down service is no longer needlessly re-bootstrapped
 
 ## [0.7.0-alpha.3] - 2026-05-30
 

--- a/packages/sdk/src/lib/gateway/configure.ts
+++ b/packages/sdk/src/lib/gateway/configure.ts
@@ -1,6 +1,5 @@
 import { getGlobalConfig } from '../config.ts'
-import { DenvigProject } from '../project.ts'
-import { listProjects } from '../projects.ts'
+import { resolveProjectCheckouts } from '../projects.ts'
 import { createGlobalProject } from '../services/global.ts'
 import { readState } from '../services/state.ts'
 import { writeGatewayHtmlFiles } from './html.ts'
@@ -93,22 +92,9 @@ export async function configureGateway(): Promise<ConfigureGatewayResult | null>
 
   // Resolve project metadata (slug + path) by ID. The route only stores
   // the project ID, but the nginx template wants the slug and absolute
-  // path for comments and the document root.
-  const projects = await listProjects({ withConfig: true })
-  const projectsById = new Map<string, { slug: string; path: string }>()
-  await Promise.all(
-    projects.map(async (info) => {
-      const project = await DenvigProject.retrieve(info.path)
-      // Routes are keyed by the checkout's id, so map every worktree (the
-      // primary and each detached worktree) back to its slug and path.
-      for (const worktree of project.worktrees) {
-        projectsById.set(worktree.id, {
-          slug: worktree.slug,
-          path: worktree.path,
-        })
-      }
-    }),
-  )
+  // path for comments and the document root. Routes are keyed by the
+  // checkout's id, so this maps every worktree back to its slug and path.
+  const projectsById = await resolveProjectCheckouts()
   const globalProject = await createGlobalProject()
   projectsById.set(globalProject.id, {
     slug: globalProject.slug,

--- a/packages/sdk/src/lib/projects.ts
+++ b/packages/sdk/src/lib/projects.ts
@@ -2,6 +2,7 @@ import { readdir } from 'node:fs/promises'
 
 import { expandTilde, getGlobalConfig } from './config.ts'
 import { projectSlug } from './project/refs.ts'
+import { DenvigProject } from './project.ts'
 import { isDirectory, pathExists } from './safeReadFile.ts'
 
 export type ProjectInfo = {
@@ -109,4 +110,39 @@ export const listProjects = async (
   ).filter((project): project is ProjectInfo => project !== null)
 
   return projects.sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+/** Slug and path of a single resolvable checkout. */
+export type CheckoutMeta = {
+  slug: string
+  path: string
+}
+
+/**
+ * Map every resolvable checkout id to its slug and path. This covers the
+ * primary checkout and each detached worktree of every configured project.
+ *
+ * Service state and gateway routes only record a project id, so the gateway
+ * and the reconciler use this map to resolve that id back to a real checkout.
+ * An id that is absent from the map belongs to a worktree that has since been
+ * deleted — its services and routes are orphaned. The global project is not
+ * included here; callers that need it add it themselves.
+ */
+export const resolveProjectCheckouts = async (): Promise<
+  Map<string, CheckoutMeta>
+> => {
+  const projects = await listProjects({ withConfig: true })
+  const byId = new Map<string, CheckoutMeta>()
+  await Promise.all(
+    projects.map(async (info) => {
+      const project = await DenvigProject.retrieve(info.path)
+      for (const worktree of project.worktrees) {
+        byId.set(worktree.id, {
+          slug: worktree.slug,
+          path: worktree.path,
+        })
+      }
+    }),
+  )
+  return byId
 }

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -270,6 +270,13 @@ export class ServiceManager {
    *   leave the existing route alone (`false`). When undefined and the
    *   domain has no existing owner, the route is registered as the
    *   natural owner (`defaultService: true`).
+   * @param options.reviveIfNotRunning - When the service is already
+   *   bootstrapped with an unchanged plist but isn't currently running,
+   *   bootout and bootstrap again to kick it (`true`, the default — what an
+   *   explicit `start` wants). The reconciler passes `false`: a bootstrapped
+   *   service's liveness is launchd's job (`KeepAlive` respawns it, one-shot
+   *   services are meant to stay exited), so re-bootstrapping an unchanged
+   *   plist is needless churn that fights launchd.
    */
   async startService(
     name: string,
@@ -277,6 +284,7 @@ export class ServiceManager {
       port?: number
       portResolved?: boolean
       claimDomain?: boolean
+      reviveIfNotRunning?: boolean
     },
   ): Promise<ServiceResult> {
     const config = this.getServiceConfig(name)
@@ -491,10 +499,15 @@ export class ServiceManager {
           message: `Failed to bootstrap service: ${bootstrapResult.output}`,
         }
       }
-    } else if (plistChanged || !isLive) {
-      // Plist changed, or the service is bootstrapped but no longer running
-      // (e.g. it crashed and isn't being restarted). Bootout and bootstrap
-      // again to give launchd a fresh start.
+    } else if (
+      plistChanged ||
+      (options?.reviveIfNotRunning !== false && !isLive)
+    ) {
+      // Plist changed, or (for an explicit start) the service is bootstrapped
+      // but no longer running and the caller asked to revive it. Bootout and
+      // bootstrap again to give launchd a fresh start. The reconciler opts out
+      // (`reviveIfNotRunning: false`): a bootstrapped service's liveness is
+      // launchd's to manage, so it leaves an unchanged plist alone.
       const bootoutResult = await launchctl.bootout(label)
       if (!bootoutResult.success) {
         return {

--- a/packages/sdk/src/lib/services/reconcile.ts
+++ b/packages/sdk/src/lib/services/reconcile.ts
@@ -197,6 +197,9 @@ export const reconcileServices = async (): Promise<ReconcileResult> => {
       const start = await manager.startService(entry.serviceName, {
         port: entry.port,
         portResolved: true,
+        // Liveness is launchd's job — only re-bootstrap on a real plist
+        // change, never just because the process is momentarily down.
+        reviveIfNotRunning: false,
       })
       if (!start.success) {
         result.errors.push({

--- a/packages/sdk/src/lib/services/reconcile.ts
+++ b/packages/sdk/src/lib/services/reconcile.ts
@@ -1,6 +1,16 @@
+import { unlink } from 'node:fs/promises'
+
+import { configureGateway } from '../gateway/configure.ts'
+import { resolveProjectCheckouts } from '../projects.ts'
+import { createGlobalProject } from './global.ts'
 import launchctl from './launchctl.ts'
 import { ServiceManager, type ServiceManagerProject } from './manager.ts'
-import { readState, type ServiceStateEntry } from './state.ts'
+import {
+  readState,
+  removeGatewayRoutesForService,
+  removeServiceState,
+  type ServiceStateEntry,
+} from './state.ts'
 
 export type ReconcileAction =
   | { type: 'started'; project: string; service: string; reason: string }
@@ -73,7 +83,11 @@ const projectFromStateEntry = (
  * Reconcile actual launchctl state with the desired state recorded in
  * `~/.denvig/state.json`.
  *
- * Three categories of action:
+ * Categories of action:
+ * 0. A service whose recorded checkout no longer resolves to a real
+ *    project (a deleted worktree) is orphaned → bootout it, drop its plist
+ *    and remove its state and gateway routes so the project that
+ *    legitimately owns its domain can reclaim it.
  * 1. State says running, launchctl agrees, plist matches → no-op.
  * 2. State says running, but launchctl is missing the service or the
  *    plist on disk differs from what the snapshot would produce → call
@@ -111,6 +125,56 @@ export const reconcileServices = async (): Promise<ReconcileResult> => {
     const colon = rest.indexOf(':')
     if (colon === -1) return null
     return `${LABEL_PREFIX}${rest.slice(0, colon)}.${rest.slice(colon + 1)}`
+  }
+
+  // Pass 0: prune orphaned services and routes. A service whose recorded
+  // checkout no longer resolves to its captured project id (the worktree was
+  // deleted) would otherwise be resurrected by pass 1 on every run —
+  // recreating the checkout directory, re-bootstrapping a launchd agent and
+  // holding the service's gateway domain hostage from the project that
+  // legitimately owns it. Tearing it down here lets the real service reclaim
+  // its domain in pass 1.
+  const checkouts = await resolveProjectCheckouts()
+  const knownProjectIds = new Set(checkouts.keys())
+  knownProjectIds.add((await createGlobalProject()).id)
+
+  let prunedOrphan = false
+  for (const [key, entry] of Object.entries(state.services)) {
+    if (!entry.project || !entry.serviceName) continue
+    if (knownProjectIds.has(entry.project.id)) continue
+
+    prunedOrphan = true
+    const project = projectFromStateEntry(entry)
+    let label: string | null
+    if (project) {
+      const manager = new ServiceManager(project)
+      label = manager.getServiceLabel(entry.serviceName)
+      await unlink(manager.getPlistPath(entry.serviceName)).catch(() => {})
+    } else {
+      label = labelFromKey(key)
+    }
+    if (label) {
+      await launchctl.bootout(label)
+      // Already handled — keep pass 2 from booting the stale label again.
+      protectedLabels.add(label)
+    }
+    await removeServiceState(entry.project.id, entry.serviceName)
+    await removeGatewayRoutesForService(entry.project.id, entry.serviceName)
+    delete state.services[key]
+    result.actions.push({
+      type: 'stopped',
+      project: entry.project.slug,
+      service: entry.serviceName,
+      reason: 'checkout no longer exists; removed orphaned service',
+    })
+  }
+
+  // Sweep any remaining gateway routes whose owner no longer resolves —
+  // covers routes left behind without a matching service entry.
+  for (const [, route] of Object.entries(state.gatewayRoutes)) {
+    if (knownProjectIds.has(route.project)) continue
+    prunedOrphan = true
+    await removeGatewayRoutesForService(route.project, route.service)
   }
 
   // Pass 1: drive state entries with desiredStatus 'running' towards being
@@ -194,6 +258,12 @@ export const reconcileServices = async (): Promise<ReconcileResult> => {
         message: `Failed to bootout: ${bootoutResult.output}`,
       })
     }
+  }
+
+  // Regenerate nginx after pruning orphans so the domain the real service
+  // reclaimed in pass 1 is rendered (and the orphan's stale config dropped).
+  if (prunedOrphan) {
+    await configureGateway()
   }
 
   return result


### PR DESCRIPTION
## Summary

Fixes two gateway/service bugs where the reconciler did the wrong thing, both surfacing after the SDK refactor merged.

### Deleted worktrees left orphaned services holding their domain

A service started in a git worktree registers its gateway route under that worktree's project id. When the worktree was deleted without a teardown, the route lingered as `running` forever:

- the reconciler kept resurrecting the launchd agent (re-creating the deleted checkout directory),
- the orphaned route held the service's domain hostage, so the project that legitimately owns it could never reclaim it,
- nginx generation silently skipped the route because the orphaned id resolved to no real checkout.

The result: the owning project's service fell back to `http://localhost:<port>` with no gateway config, and `services status` showed the bare localhost URL.

**Fix:** reconcile now resolves every recorded service/route project id against the set of real checkouts. Any whose checkout no longer exists is torn down (bootout + plist + state + routes) before the start pass, so the real service reclaims its domain and nginx is regenerated to match. The checkout-id resolution is shared with gateway configuration.

### Spurious "restarted … config changed" on unrelated services

Every `services` command runs the reconciler afterwards. For a service that was bootstrapped but not currently live, it forced a bootout + bootstrap **even when the plist on disk was byte-identical** — and reported it as `↻ restarted … config changed since last bootstrap`, though nothing had changed.

For a `KeepAlive` service that launchd is already respawning (or a one-shot meant to stay exited), this was needless churn that fought launchd, and it appeared on every unrelated command:

```
$ denvig services stop hello
Stopping hello...
↻ restarted github:marcqualie/denvig-api/api — config changed since last bootstrap
✓ hello stopped successfully
```

**Fix:** a bootstrapped service's liveness is launchd's job. `startService` gains a `reviveIfNotRunning` option (default `true`, so an explicit `start` still kicks a dead service); the reconciler passes `false`, so it only re-bootstraps on a genuine plist change. The "config changed" reason is now accurate, and unrelated commands stay quiet.

## Verification

- Reproduced the orphaned-route case live: orphan torn down (agent + plist + port freed), `hello.denvig.me` reclaimed by the main checkout with its cert, nginx config written, `curl https://hello.denvig.me` → **HTTP 200**.
- `services status hello` now reports `https://hello.denvig.me` instead of `http://localhost:8080`.
- Reconcile run repeatedly → idempotent (0 non-skip actions); a genuine plist change still restarts, now correctly labeled.
- `stop hello` / `start hello` print only their own lines — no spurious cross-service restart.
- `lint`, `codegen`, `check-types`, full test suite (528 SDK + 114 CLI), and `build` (3/3) all green; confirmed through the installed binary.
