### PR TITLE
Publish @denvig/sdk, @denvig/cli and denvig to npm cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `denvig run` again resolves actions whose names contain a colon (e.g. `compile:darwin-x64`) instead of mistaking the colon for an `ecosystem:action` prefix
 - Services left behind by a deleted worktree are now cleaned up automatically, so a service can reclaim its domain instead of being stuck routing to `http://localhost:<port>` with no gateway config
 - A `services` command no longer reports spurious restarts of unrelated services (e.g. `↻ restarted … config changed since last bootstrap`); liveness is left to launchd, so a momentarily-down service is no longer needlessly re-bootstrapped
+- The `@denvig/sdk/testing` import now resolves when installed from npm (it previously pointed at source files that weren't shipped)
 
 ## [0.7.0-alpha.3] - 2026-05-30
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "description": "Workspace root for the denvig CLI and its packages",
   "type": "module",
+  "files": [],
   "scripts": {
     "build": "turbo run build",
     "check-types": "turbo run check-types",

--- a/packages/denvig/package.json
+++ b/packages/denvig/package.json
@@ -10,6 +10,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/sdk/LICENSE
+++ b/packages/sdk/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright © 2026 Marc Qualie, https://marcqualie.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -54,7 +54,14 @@
     },
     "./testing": {
       "denvig-source": "./src/test/mock.ts",
-      "default": "./src/test/mock.ts"
+      "import": {
+        "types": "./dist/testing.d.ts",
+        "default": "./dist/testing.js"
+      },
+      "require": {
+        "types": "./dist/testing.d.ts",
+        "default": "./dist/testing.cjs"
+      }
     }
   },
   "publishConfig": {

--- a/packages/sdk/rolldown.config.ts
+++ b/packages/sdk/rolldown.config.ts
@@ -10,6 +10,7 @@ const input = {
   internal: 'src/internal.ts',
   utils: 'src/utils.ts',
   fs: 'src/fs.ts',
+  testing: 'src/test/mock.ts',
 }
 
 export default defineConfig([


### PR DESCRIPTION
Makes `@denvig/sdk`, `@denvig/cli` and `denvig` safe to publish together (same version via `bin/prepare-release` + `pnpm -r publish` on tag) and clean to import from other apps.

- **`@denvig/sdk/testing` now resolves when installed** — it pointed only at `src/test/mock.ts`, which the `dist/`-only tarball doesn't ship. Now built to `dist/testing.{js,cjs,d.ts}` with proper `import`/`require`/`types` conditions (`denvig-source` still points at source for the workspace's own tests).
- **Added the missing `LICENSE` to `@denvig/sdk`** — it was listed in `files` but absent, so npm silently omitted it.
- **Added `publishConfig.access: public` to `denvig`** for parity with the scoped packages.
- **Added `files: []` to the private workspace root** so an accidental non-recursive `pnpm publish` can't pack the repo (caps the tarball to package.json/README/LICENSE).

Verified by packing all three and installing them into an isolated consumer project: ESM + CJS imports, every subpath (`/utils` `/fs` `/internal` `/testing`), the cross-package re-exports, the `denvig` bin, and `.d.ts` for each entry all resolve. `pnpm -r publish --dry-run` confirms all three publish in lockstep at a fresh version.
