### PR TITLE
Bump pnpm to 11.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- `denvig run` no longer duplicates the command echo when running a pnpm `package.json` script (pnpm's own echo is suppressed, leaving denvig's single `$ …` line)
 - The CLI is now published as `@denvig/cli`; the `denvig` package re-exports it (available as `denvig/cli`) and keeps its existing SDK import
 - The SDK now runs in-process instead of shelling out to the CLI, so `DenvigSDK` calls execute directly and return data without spawning a subprocess
 - The SDK is also published standalone as `@denvig/sdk` (re-exported as `denvig/sdk`); the `DenvigSDK` constructor now only takes `client` and `cwd`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@denvig/workspace",
   "version": "0.7.0-alpha.3",
   "private": true,
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@11.5.2",
   "license": "MIT",
   "description": "Workspace root for the denvig CLI and its packages",
   "type": "module",

--- a/packages/cli/src/commands/run.test.ts
+++ b/packages/cli/src/commands/run.test.ts
@@ -9,8 +9,9 @@ describe('commands / run', () => {
 
     strictEqual(result.code, 0)
     // Should have some output from the lint process
-    match(result.stdout, /pnpm run lint/)
-    match(result.stdout, /biome check/)
+    match(result.stdout, /pnpm --reporter=silent run lint/)
+    // biome's own output (the `> biome check` echo is silenced by pnpm now)
+    match(result.stdout, /Checked \d+ files/)
     // Stderr may contain lint warnings/errors, but that's okay as long as exit code is 0
   })
 
@@ -48,8 +49,8 @@ describe('commands / run', () => {
     )
 
     // Ensure single-line actions still work normally
-    match(result.stdout, /build: pnpm run build/)
-    match(result.stdout, /test: pnpm run test/)
+    match(result.stdout, /build: pnpm --reporter=silent run build/)
+    match(result.stdout, /test: pnpm --reporter=silent run test/)
 
     strictEqual(result.stderr, '')
   })

--- a/packages/cli/src/test/examples/pnpm/actions.test.ts
+++ b/packages/cli/src/test/examples/pnpm/actions.test.ts
@@ -26,7 +26,7 @@ describe('examples / pnpm / actions', () => {
       },
     })
 
-    match(result.stdout, /\$ pnpm run hello/)
+    match(result.stdout, /\$ pnpm --reporter=silent run hello/)
     doesNotMatch(result.stdout, /\$ npm run hello/)
     match(result.stdout, /Hello from pnpm example!/)
     strictEqual(result.stderr, '')

--- a/packages/sdk/src/lib/cli-logs.test.ts
+++ b/packages/sdk/src/lib/cli-logs.test.ts
@@ -160,8 +160,10 @@ describe('cli-logs', () => {
         path: '/test/path',
       })
 
-      // Simulate some work
-      await new Promise((resolve) => setTimeout(resolve, 10))
+      // Simulate some work. Sleep comfortably longer than the asserted
+      // threshold: `duration` is integer-ms (`Date.now()` deltas), so a 10ms
+      // sleep can measure as 9ms at a millisecond boundary and flake.
+      await new Promise((resolve) => setTimeout(resolve, 50))
 
       await tracker.finish(0)
 

--- a/packages/sdk/src/plugins/pnpm.ts
+++ b/packages/sdk/src/plugins/pnpm.ts
@@ -87,7 +87,12 @@ const plugin = definePlugin({
     const isWorkspace = project.rootFiles.includes('pnpm-workspace.yaml')
     const actions: Record<string, string[]> = {
       ...Object.entries(scripts)
-        .map(([key, _script]) => [key, `pnpm run ${key}`])
+        // `--reporter=silent` (before `run`, so it targets pnpm rather than
+        // the script) suppresses pnpm's own command echo. denvig already
+        // prints its own `$ …` line, and pnpm 11 otherwise echoes the resolved
+        // script command to stderr — double output, and noise the action
+        // runner would surface as a failure.
+        .map(([key, _script]) => [key, `pnpm --reporter=silent run ${key}`])
         .reduce(
           (acc, [key, script]) => {
             acc[key] = [script]


### PR DESCRIPTION
Bumps the pinned `packageManager` from pnpm 10.14.0 to the latest v11 (**11.5.2**).

Both workflows read the version from `packageManager` via `pnpm/action-setup`, so this moves local dev and CI to pnpm 11 together — no other files pin a pnpm version.

### pnpm 11 compatibility fix
pnpm 11 changed its script reporter: running a `package.json` script now echoes the resolved command to **stderr** (pnpm 10 printed a `>` banner to stdout). `denvig run <pnpm script>` forwards that, producing a duplicate echo on top of denvig's own `$ …` line and failing the example action tests on empty-stderr.

Fix: denvig generates pnpm script actions as `pnpm --reporter=silent run <script>` (flag before `run` so it targets pnpm, not the script). pnpm stays quiet, denvig's echo is the single source of truth, and output is consistent across pnpm versions. Example/run tests updated to the new echo and to assert on the tool's real output.

### Verified on 11.5.2
- Lockfile stays at `v9.0` (shared across pnpm 9–11) — **no churn**, frozen CI installs unaffected.
- `lint`, `check-types`, `codegen` (no file changes), and the full test suite (528 SDK + 114 CLI) all pass.
- `denvig run hello` → clean stdout, empty stderr.

First local install after pulling will rebuild `node_modules` (pnpm 11 purges a tree created by pnpm 10); CI does this automatically with `CI=true`.

Groundwork for staged publishing (`pnpm stage`, added in pnpm 11.3.0), which lands in a follow-up PR.
