### PR TITLE
Stage npm releases for review before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,10 @@ jobs:
             *-rc.*)    echo "NPM_TAG=rc"     >> "$GITHUB_ENV" ;;
             *)         echo "NPM_TAG=latest" >> "$GITHUB_ENV" ;;
           esac
-        # Publishes every public workspace package (@denvig/cli, then denvig)
-        # in dependency order, rewriting the workspace: protocol to the
-        # concrete version. The private workspace root is skipped.
-      - run: pnpm -r publish --no-git-checks --access public --tag "$NPM_TAG"
+        # Stages every public workspace package for review instead of
+        # publishing it live: the OIDC token can stage but not approve, so a
+        # maintainer runs `pnpm stage approve` (with 2FA) — or `stage reject` —
+        # to promote the staged versions. The workspace: protocol is rewritten
+        # to concrete versions just as `pnpm publish` does; the private root is
+        # skipped.
+      - run: pnpm -r stage publish --no-git-checks --access public --tag "$NPM_TAG"


### PR DESCRIPTION
Stages releases for review instead of publishing them live: swaps `pnpm -r publish` for `pnpm -r stage publish` in the release workflow.

The OIDC trusted-publishing token can stage but **cannot approve**, so a maintainer reviews the staged versions and runs `pnpm stage approve` (with 2FA) — or `pnpm stage reject` — to promote them. That adds a human gate on top of trusted publishing. `pnpm stage` rewrites the `workspace:` protocol exactly like `pnpm publish` and skips the private root.

Requires pnpm ≥ 11.3.0, already on main via #212.

**Note:** a package that's never been published can't be staged. `@denvig/sdk` and `@denvig/cli` aren't on npm yet, so their first release needs a one-time normal `pnpm publish`; every release after that stages.
