### PR TITLE
Only assign random ports to services with an http block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Denvig Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Services without an `http` block no longer get a random port allocated or show a `localhost` URL; only http services are assigned ports
 
 ## [0.7.0-alpha.4] - 2026-06-06
 

--- a/packages/sdk/src/lib/services/manager.test.ts
+++ b/packages/sdk/src/lib/services/manager.test.ts
@@ -1,11 +1,13 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: The print function is overridden for mocking, easier to use any */
 import { ok, strictEqual } from 'node:assert'
-import { hostname } from 'node:os'
-import { describe, it } from 'node:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { hostname, tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import { createMockInternalProject } from '../../test/mock.ts'
 import launchctl from './launchctl.ts'
 import { ServiceManager } from './manager.ts'
+import { updateServiceState } from './state.ts'
 
 describe('ServiceManager', () => {
   describe('listServices()', () => {
@@ -208,6 +210,168 @@ describe('ServiceManager', () => {
         result.success,
         `Expected env build to succeed but got: ${result.success === false ? result.message : 'unknown'}`,
       )
+    })
+  })
+
+  describe('resolveServicePort()', () => {
+    let originalHome: string | undefined
+    let tmpHome = ''
+
+    beforeEach(() => {
+      originalHome = process.env.HOME
+      tmpHome = mkdtempSync(`${tmpdir()}/denvig-manager-ports-`)
+      process.env.HOME = tmpHome
+    })
+    afterEach(() => {
+      if (originalHome !== undefined) process.env.HOME = originalHome
+      else delete process.env.HOME
+      rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    it('returns no port for a service without an http block', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        worker: { command: 'node worker.js' },
+      }
+      const manager = new ServiceManager(project)
+
+      const resolved = await manager.resolveServicePort('worker')
+
+      ok(resolved.success)
+      strictEqual(resolved.port, undefined)
+      strictEqual(resolved.source, 'none')
+      strictEqual(resolved.conflict, false)
+    })
+
+    it('returns no port for a non-http service even with forceRandom', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        worker: { command: 'node worker.js' },
+      }
+      const manager = new ServiceManager(project)
+
+      const resolved = await manager.resolveServicePort('worker', {
+        forceRandom: true,
+      })
+
+      ok(resolved.success)
+      strictEqual(resolved.port, undefined)
+    })
+
+    it('ignores a stale state port for a non-http service', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        worker: { command: 'node worker.js' },
+      }
+      await updateServiceState(project.id, 'worker', {
+        cwd: project.path,
+        port: 8123,
+        domains: [],
+        desiredStatus: 'running',
+      })
+      const manager = new ServiceManager(project)
+
+      const resolved = await manager.resolveServicePort('worker')
+
+      ok(resolved.success)
+      strictEqual(resolved.port, undefined)
+    })
+
+    it('allocates a random port for a service with an http block but no port', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        web: { command: 'node server.js', http: {} },
+      }
+      const manager = new ServiceManager(project)
+
+      const resolved = await manager.resolveServicePort('web')
+
+      ok(resolved.success)
+      strictEqual(resolved.source, 'allocated')
+      ok(
+        resolved.port !== undefined &&
+          resolved.port >= 8000 &&
+          resolved.port <= 9999,
+      )
+    })
+
+    it('reuses the state port for an http service', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        web: { command: 'node server.js', http: {} },
+      }
+      await updateServiceState(project.id, 'web', {
+        cwd: project.path,
+        port: 8123,
+        domains: [],
+        desiredStatus: 'running',
+      })
+      const manager = new ServiceManager(project)
+
+      const resolved = await manager.resolveServicePort('web')
+
+      ok(resolved.success)
+      strictEqual(resolved.port, 8123)
+      strictEqual(resolved.source, 'state')
+    })
+  })
+
+  describe('getEffectivePort()', () => {
+    let originalHome: string | undefined
+    let tmpHome = ''
+
+    beforeEach(() => {
+      originalHome = process.env.HOME
+      tmpHome = mkdtempSync(`${tmpdir()}/denvig-manager-ports-`)
+      process.env.HOME = tmpHome
+    })
+    afterEach(() => {
+      if (originalHome !== undefined) process.env.HOME = originalHome
+      else delete process.env.HOME
+      rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    it('returns undefined for a non-http service even when state has a port', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        worker: { command: 'node worker.js' },
+      }
+      await updateServiceState(project.id, 'worker', {
+        cwd: project.path,
+        port: 8123,
+        domains: [],
+        desiredStatus: 'running',
+      })
+      const manager = new ServiceManager(project)
+
+      strictEqual(await manager.getEffectivePort('worker'), undefined)
+      strictEqual(await manager.getServiceLocalUrl('worker'), null)
+    })
+
+    it('returns the state port for an http service', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        web: { command: 'node server.js', http: { port: 4000 } },
+      }
+      await updateServiceState(project.id, 'web', {
+        cwd: project.path,
+        port: 8123,
+        domains: [],
+        desiredStatus: 'running',
+      })
+      const manager = new ServiceManager(project)
+
+      strictEqual(await manager.getEffectivePort('web'), 8123)
+    })
+
+    it('falls back to the config port for an http service without state', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        web: { command: 'node server.js', http: { port: 4000 } },
+      }
+      const manager = new ServiceManager(project)
+
+      strictEqual(await manager.getEffectivePort('web'), 4000)
     })
   })
 

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -165,15 +165,17 @@ export class ServiceManager {
    * Decide which port to run a service on.
    *
    * Resolution order:
-   * 1. If `forceRandom`, always allocate a fresh random port (preferring the
+   * 1. If the service has no `http` block it never needs a port — return
+   *    no port, ignoring any state entry and the `forceRandom` flag.
+   * 2. If `forceRandom`, always allocate a fresh random port (preferring the
    *    previously-allocated one when free).
-   * 2. If state already records a port for this service, reuse it. State is
+   * 3. If state already records a port for this service, reuse it. State is
    *    authoritative once allocated so restarts stay on the same port and
    *    don't re-prompt about the config port being busy. Run
    *    `services teardown` to reset.
-   * 3. Otherwise try the config port — falling back to a random port and
+   * 4. Otherwise try the config port — falling back to a random port and
    *    flagging `conflict: true` when it's already in use.
-   * 4. Otherwise (no config port, no state) allocate a random port.
+   * 5. Otherwise (no config port, no state) allocate a random port.
    */
   async resolveServicePort(
     name: string,
@@ -196,7 +198,19 @@ export class ServiceManager {
       }
     }
 
-    const configPort = config.http?.port
+    // Services without an `http` block don't serve HTTP traffic, so they
+    // never need a port — even when an older version recorded one in state
+    // or the caller asked for a random port.
+    if (!config.http) {
+      return {
+        success: true,
+        port: undefined,
+        source: 'none',
+        conflict: false,
+      }
+    }
+
+    const configPort = config.http.port
     const previous = await getServiceState(this.project.id, name)
 
     if (options?.forceRandom) {
@@ -1071,12 +1085,16 @@ export class ServiceManager {
 
   /**
    * Get the effective runtime port for a service, considering state-tracked
-   * allocations first and falling back to the config port.
+   * allocations first and falling back to the config port. Services without
+   * an `http` block never have a port, even when an older version recorded
+   * one in state.
    */
   async getEffectivePort(name: string): Promise<number | undefined> {
+    const config = this.getServiceConfig(name)
+    if (!config?.http) return undefined
     const state = await getServiceState(this.project.id, name)
     if (state?.port !== undefined) return state.port
-    return this.getServiceConfig(name)?.http?.port
+    return config.http.port
   }
 
   /**

--- a/packages/sdk/src/lib/services/reconcile.ts
+++ b/packages/sdk/src/lib/services/reconcile.ts
@@ -195,7 +195,9 @@ export const reconcileServices = async (): Promise<ReconcileResult> => {
     protectedLabels.add(label)
     try {
       const start = await manager.startService(entry.serviceName, {
-        port: entry.port,
+        // Non-http services never need a port — drop any stale allocation
+        // recorded by an older version.
+        port: entry.config?.http ? entry.port : undefined,
         portResolved: true,
         // Liveness is launchd's job — only re-bootstrap on a real plist
         // change, never just because the process is momentarily down.

--- a/packages/sdk/src/lib/services/state.test.ts
+++ b/packages/sdk/src/lib/services/state.test.ts
@@ -60,6 +60,38 @@ describe('service state', () => {
     })
   })
 
+  it('clears the port when explicitly set to undefined', async () => {
+    await updateServiceState('abc123', 'api', {
+      cwd: '/tmp/proj',
+      port: 8080,
+      domains: [],
+      desiredStatus: 'running',
+    })
+    await updateServiceState('abc123', 'api', {
+      cwd: '/tmp/proj',
+      port: undefined,
+      domains: [],
+      desiredStatus: 'running',
+    })
+    const entry = await getServiceState('abc123', 'api')
+    assert.strictEqual(entry?.port, undefined)
+  })
+
+  it('preserves the port when the key is omitted', async () => {
+    await updateServiceState('abc123', 'api', {
+      cwd: '/tmp/proj',
+      port: 8080,
+      domains: [],
+      desiredStatus: 'running',
+    })
+    await updateServiceState('abc123', 'api', {
+      cwd: '/tmp/proj',
+      desiredStatus: 'stopped',
+    })
+    const entry = await getServiceState('abc123', 'api')
+    assert.strictEqual(entry?.port, 8080)
+  })
+
   it('marks a service stopped while preserving the port', async () => {
     await updateServiceState('abc123', 'api', {
       cwd: '/tmp/proj',

--- a/packages/sdk/src/lib/services/state.ts
+++ b/packages/sdk/src/lib/services/state.ts
@@ -141,7 +141,12 @@ export const getServiceState = async (
   return state.services[serviceStateKey(projectId, serviceName)] ?? null
 }
 
-/** Merge new fields into a service's state entry. Creates the entry if missing. */
+/**
+ * Merge new fields into a service's state entry. Creates the entry if
+ * missing. Passing an explicit `port: undefined` clears a previously
+ * recorded port (used when a service no longer needs one); omitting the
+ * key preserves it.
+ */
 export const updateServiceState = async (
   projectId: string,
   serviceName: string,
@@ -152,7 +157,7 @@ export const updateServiceState = async (
   const existing = state.services[key]
   state.services[key] = {
     cwd: entry.cwd,
-    port: entry.port ?? existing?.port,
+    port: 'port' in entry ? entry.port : existing?.port,
     domains: entry.domains ?? existing?.domains ?? [],
     desiredStatus: entry.desiredStatus ?? existing?.desiredStatus ?? 'running',
     project: entry.project ?? existing?.project,


### PR DESCRIPTION
Fixes #214

## Problem

Every service was allocated a random port on start, regardless of whether it actually serves HTTP traffic. Non-http services (e.g. background workers) ended up with a port recorded in state and a `http://localhost:<port>` URL shown in `services list` / `services status`.

## Changes

- `resolveServicePort()` returns no port for services without an `http` block — before any state lookup, random allocation, or `--random-port` handling.
- `getEffectivePort()` has the same guard, so non-http services no longer show a localhost URL even when an older version recorded a port in state.
- `updateServiceState()` now distinguishes an explicit `port: undefined` (clears a previously recorded port) from omitting the key (preserves it), so the next start of a non-http service self-heals stale state.
- The reconciler drops the state port when the config snapshot has no `http` block instead of re-applying it.

## Behaviour after this change

| Service config | Port behaviour |
| --- | --- |
| no `http` block | never allocated a port, no URL shown |
| `http: {}` | random port allocated on start (unchanged) |
| `http.port` set | config port used; random only on conflict, with confirmation in interactive sessions (unchanged) |

## Testing

- 8 new test cases covering `resolveServicePort()`, `getEffectivePort()` and the state port-clearing semantics
- Full suite (538 tests), lint, codegen and build all pass
- Verified against this repo's own `wontlaunch` service (no `http` block), which now shows `-` instead of a URL