### PR TITLE
Exclude link: and workspace: dependencies from deps outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Services without an `http` block no longer get a random port allocated or show a `localhost` URL; only http services are assigned ports
+- `denvig deps outdated` no longer lists `link:` or `workspace:` dependencies, since they point at local code
 
 ## [0.7.0-alpha.4] - 2026-06-06
 

--- a/packages/sdk/src/lib/npm/outdated.test.ts
+++ b/packages/sdk/src/lib/npm/outdated.test.ts
@@ -1,7 +1,7 @@
-import { strictEqual } from 'node:assert'
-import { describe, it } from 'node:test'
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { describe, it, mock } from 'node:test'
 
-import { extractDepInfo } from './outdated.ts'
+import { extractDepInfo, isLocalDependency, npmOutdated } from './outdated.ts'
 
 describe('extractDepInfo()', () => {
   it('returns the first version entry for plain importer specifiers', () => {
@@ -64,5 +64,80 @@ describe('extractDepInfo()', () => {
       ],
     })
     strictEqual(info?.specifier, 'catalog:')
+  })
+})
+
+describe('isLocalDependency()', () => {
+  it('returns true for workspace: specifiers', () => {
+    strictEqual(
+      isLocalDependency({ current: 'link:../cli', specifier: 'workspace:*' }),
+      true,
+    )
+  })
+
+  it('returns true for link: specifiers', () => {
+    strictEqual(
+      isLocalDependency({
+        current: 'link:../local-pkg',
+        specifier: 'link:../local-pkg',
+      }),
+      true,
+    )
+  })
+
+  it('returns true when only the resolved version is a link:', () => {
+    strictEqual(
+      isLocalDependency({ current: 'link:../cli', specifier: '*' }),
+      true,
+    )
+  })
+
+  it('returns false for regular semver dependencies', () => {
+    strictEqual(
+      isLocalDependency({ current: '1.2.3', specifier: '^1.2.0' }),
+      false,
+    )
+  })
+})
+
+describe('npmOutdated()', () => {
+  it('excludes link: and workspace: dependencies without querying the registry', async () => {
+    const fetchMock = mock.method(globalThis, 'fetch', async () => {
+      throw new Error('unexpected registry fetch for a local dependency')
+    })
+
+    try {
+      const result = await npmOutdated([
+        {
+          id: 'npm:@denvig-test/workspace-pkg',
+          name: '@denvig-test/workspace-pkg',
+          ecosystem: 'npm',
+          versions: [
+            {
+              resolved: 'link:../workspace-pkg',
+              specifier: 'workspace:*',
+              source: 'packages/app#dependencies',
+            },
+          ],
+        },
+        {
+          id: 'npm:@denvig-test/linked-pkg',
+          name: '@denvig-test/linked-pkg',
+          ecosystem: 'npm',
+          versions: [
+            {
+              resolved: 'link:../linked-pkg',
+              specifier: 'link:../linked-pkg',
+              source: '.#dependencies',
+            },
+          ],
+        },
+      ])
+
+      deepStrictEqual(result, [])
+      strictEqual(fetchMock.mock.callCount(), 0)
+    } finally {
+      fetchMock.mock.restore()
+    }
   })
 })

--- a/packages/sdk/src/lib/npm/outdated.ts
+++ b/packages/sdk/src/lib/npm/outdated.ts
@@ -148,6 +148,20 @@ export const extractDepInfo = (
 }
 
 /**
+ * Check whether a dependency points at local code rather than the registry.
+ * `link:` and `workspace:` dependencies live on disk, so the registry can
+ * never have a newer version of them.
+ */
+export const isLocalDependency = (info: {
+  current: string
+  specifier: string
+}): boolean => {
+  const isLocalSpec = (value: string) =>
+    value.startsWith('link:') || value.startsWith('workspace:')
+  return isLocalSpec(info.specifier) || isLocalSpec(info.current)
+}
+
+/**
  * Check npm packages for outdated versions.
  * Takes a list of dependencies and returns info about which are outdated.
  */
@@ -164,6 +178,7 @@ export const npmOutdated = async (
   const fetchPromises = toCheck.map(async (dep) => {
     const info = extractDepInfo(dep)
     if (!info) return
+    if (isLocalDependency(info)) return
 
     const npmInfo = await fetchNpmPackageInfo(dep.name, !useCache)
     if (!npmInfo) return


### PR DESCRIPTION
## Summary

`denvig deps outdated` was listing `link:` and `workspace:` dependencies and comparing them against the npm registry, so workspace packages like `@denvig/cli` (`link:../cli`) showed up as outdated against their published versions.

These dependencies point at local code, so the registry can never have a newer version of them.

## Changes

- `npmOutdated` now skips dependencies whose specifier or resolved version starts with `link:` or `workspace:`, before making any registry request. This covers the npm, pnpm, yarn, and deno plugins, which all share this code path.
- Added an exported `isLocalDependency` helper with unit tests, plus an integration test that runs `npmOutdated` over `link:`/`workspace:` deps with a mocked `fetch` and asserts they are excluded and the registry is never queried.

## Before

```
Package                     Current      Wanted       Latest
------------------------------------------------------------------------
@denvig/cli                 link:../cli  -            0.7.0-alpha.4 (4d)
@denvig/sdk                 link:../sdk  -            0.7.0-alpha.4 (4d)
@types/node          (dev)  25.9.1 (3w)  25.9.2 (5d)  25.9.2 (5d)
```

## After

```
Package                     Current      Wanted       Latest
-----------------------------------------------------------------
@types/node          (dev)  25.9.1 (3w)  25.9.2 (5d)  25.9.2 (5d)
```

## Testing

- `pnpm run test` — 543 tests pass
- `pnpm run lint` and `pnpm run codegen` — clean
- Verified `bin/denvig-dev outdated` no longer lists the workspace packages