### PR TITLE
Resolve service names from local path identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Service commands accept `local:` and bare path identifiers again (e.g. `denvig services start local:~/src/owner/project/dev`), inferring the service name from the final path segment
 - Services without an `http` block no longer get a random port allocated or show a `localhost` URL; only http services are assigned ports
 - `denvig deps outdated` no longer lists `link:` or `workspace:` dependencies, since they point at local code
 

--- a/packages/sdk/src/lib/services/identifier.test.ts
+++ b/packages/sdk/src/lib/services/identifier.test.ts
@@ -1,7 +1,10 @@
-import { deepStrictEqual } from 'node:assert'
-import { describe, it } from 'node:test'
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, it } from 'node:test'
 
-import { parseServiceIdentifier } from './identifier.ts'
+import { createMockInternalProject } from '../../test/mock.ts'
+import { getServiceContext, parseServiceIdentifier } from './identifier.ts'
 
 describe('parseServiceIdentifier', () => {
   it('should parse a plain service name as current project', () => {
@@ -37,5 +40,56 @@ describe('parseServiceIdentifier', () => {
       projectSlug: 'global',
       serviceName: '',
     })
+  })
+})
+
+describe('getServiceContext local path identifiers', () => {
+  let originalHome: string | undefined
+  let tmpHome = ''
+  let projectDir = ''
+
+  beforeEach(() => {
+    originalHome = process.env.HOME
+    tmpHome = mkdtempSync(`${tmpdir()}/denvig-identifier-`)
+    process.env.HOME = tmpHome
+    projectDir = `${tmpHome}/src/owner/myapp`
+    mkdirSync(projectDir, { recursive: true })
+    writeFileSync(
+      `${projectDir}/.denvig.yml`,
+      'name: MyApp\nservices:\n  dev:\n    command: echo dev\n',
+      'utf-8',
+    )
+  })
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome
+    else delete process.env.HOME
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  const currentProject = () =>
+    createMockInternalProject({ path: '/tmp/elsewhere' })
+
+  it('infers the service name from the final segment of a local: identifier', async () => {
+    const ctx = await getServiceContext(
+      `local:${projectDir}/dev`,
+      currentProject(),
+    )
+    strictEqual(ctx.serviceName, 'dev')
+    strictEqual(ctx.project.path, projectDir)
+  })
+
+  it('expands ~ in local: identifiers', async () => {
+    const ctx = await getServiceContext(
+      'local:~/src/owner/myapp/dev',
+      currentProject(),
+    )
+    strictEqual(ctx.serviceName, 'dev')
+    strictEqual(ctx.project.path, projectDir)
+  })
+
+  it('infers the service name from a bare path identifier', async () => {
+    const ctx = await getServiceContext(`${projectDir}/dev`, currentProject())
+    strictEqual(ctx.serviceName, 'dev')
+    strictEqual(ctx.project.path, projectDir)
   })
 })

--- a/packages/sdk/src/lib/services/identifier.ts
+++ b/packages/sdk/src/lib/services/identifier.ts
@@ -2,6 +2,7 @@ import { expandTilde } from '../config.ts'
 import { DenvigProject } from '../project.ts'
 import { parseProjectId, resolveProjectPath } from '../project-id.ts'
 import { listProjects } from '../projects.ts'
+import { isDirectory } from '../safeReadFile.ts'
 import {
   createGlobalProject,
   createGlobalServiceManager,
@@ -178,6 +179,30 @@ export const getServiceContext = async (
         .activeWorktree
       const manager = new ServiceManager(worktree)
       return { project: worktree, manager, serviceName: parsed.serviceName }
+    }
+  }
+
+  // `local:` and bare-path identifiers carry the service as their final
+  // path segment (e.g. `local:~/src/owner/project/dev`), which
+  // parseProjectId can't split on its own. Infer it from config: when the
+  // parent path is a directory whose project defines the final segment as
+  // a service, target that service.
+  if (
+    (parsed.type === 'local' || parsed.type === 'path') &&
+    parsed.serviceName === undefined
+  ) {
+    const slashIndex = parsed.value.lastIndexOf('/')
+    if (slashIndex > 0) {
+      const candidateService = parsed.value.slice(slashIndex + 1)
+      const candidatePath = expandTilde(parsed.value.slice(0, slashIndex))
+      if (await isDirectory(candidatePath)) {
+        const worktree = (await DenvigProject.retrieve(candidatePath))
+          .activeWorktree
+        if (worktree.config.services?.[candidateService]) {
+          const manager = new ServiceManager(worktree)
+          return { project: worktree, manager, serviceName: candidateService }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a regression where `services` commands rejected `local:` and bare-path identifiers that include a service name, e.g.:

```
$ denvig services start local:~/src/marcqualie/synthelica/dev
Service "" not found in configuration
```

The service name resolved as an empty string, so the command always failed.

## Root cause

The unified project-id parsing introduced in #109 keeps the entire `local:` value intact and never splits off a trailing service segment (unlike `github:owner/repo/service`, which it does split). `getServiceContext` then fell through with an empty `serviceName`. This has been broken since that refactor — reproduced on `main` and in the released `v0.7.0-alpha.4`, not specific to any feature branch.

## Fix

When a `local:` or bare-path identifier carries no explicit service, `getServiceContext` now infers it from the final path segment — but only when the parent path is a directory whose project config actually defines that segment as a service. This matches the long-documented "service inferred from config" behaviour for local paths and avoids misreading a real directory path as a service name. Tilde (`~`) expansion is handled.

## Testing

- New `getServiceContext` tests cover `local:<abs path>/<service>`, `local:~/…/<service>` (with tilde expansion), and bare-path `<abs path>/<service>`.
- Verified live: `denvig services start local:~/src/marcqualie/synthelica/dev` → `✓ … started successfully → https://synthelica.denvig.me`.

Split out of #218 (the dynamic-domains branch), where this was found; it's an independent pre-existing fix.