### PR TITLE
Skip restart on services start when already running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `services start` (including `--claim-domains`) no longer restarts a service that is already running; it just refreshes the gateway so domain changes apply without interrupting the process
+
 ## [0.7.0-alpha.6] - 2026-06-13
 
 ### Added

--- a/packages/sdk/src/lib/services/manager.test.ts
+++ b/packages/sdk/src/lib/services/manager.test.ts
@@ -562,6 +562,64 @@ describe('ServiceManager', () => {
       )
     })
 
+    it('claims the domain without restarting an already-running service', async (t) => {
+      const original = createOriginalProject()
+      await seedRunningOriginal(original)
+      const worktree = createWorktreeProject()
+      const manager = new ServiceManager(worktree)
+
+      // Initial start on a temporary domain lays down the plist and state.
+      mockLaunchctlStart(t)
+      await manager.startService('hello', { port: 9001, portResolved: true })
+
+      // Re-run with --claim-domains while the service is live. The process must
+      // be left untouched (no bootout/bootstrap) and only the gateway route moves.
+      t.mock.restoreAll()
+      t.mock.method(launchctl, 'print', async () => ({
+        label: 'test',
+        pid: 123,
+        state: 'running',
+        status: 'running',
+      }))
+      const bootout = t.mock.method(launchctl, 'bootout', async () => ({
+        success: true,
+        output: '',
+      }))
+      const bootstrap = t.mock.method(launchctl, 'bootstrap', async () => ({
+        success: true,
+        output: '',
+      }))
+      t.mock.method(launchctl, 'enable', async () => ({
+        success: true,
+        output: '',
+      }))
+
+      const result = await manager.startService('hello', {
+        port: 9001,
+        portResolved: true,
+        claimDomains: true,
+      })
+      ok(result.success, result.message)
+      strictEqual(
+        bootout.mock.callCount(),
+        0,
+        'should not bootout a live service',
+      )
+      strictEqual(
+        bootstrap.mock.callCount(),
+        0,
+        'should not bootstrap a live service',
+      )
+
+      // The claim still takes effect: the configured domain now routes here.
+      const route = await getGatewayRoute('hello.denvig.me')
+      strictEqual(route?.project, worktree.id)
+      strictEqual(route?.port, 9001)
+      strictEqual(route?.defaultService, false)
+      // The temporary domain is released now the real one is claimed.
+      strictEqual(await getGatewayRoute('hello-feature-x.denvig.me'), null)
+    })
+
     it('stop removes the temporary domain and keeps it in state for the next start', async (t) => {
       const original = createOriginalProject()
       await seedRunningOriginal(original)

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -528,15 +528,25 @@ export class ServiceManager {
           message: `Failed to bootstrap service: ${bootstrapResult.output}`,
         }
       }
-    } else if (
-      plistChanged ||
-      (options?.reviveIfNotRunning !== false && !isLive)
-    ) {
-      // Plist changed, or (for an explicit start) the service is bootstrapped
-      // but no longer running and the caller asked to revive it. Bootout and
-      // bootstrap again to give launchd a fresh start. The reconciler opts out
-      // (`reviveIfNotRunning: false`): a bootstrapped service's liveness is
-      // launchd's to manage, so it leaves an unchanged plist alone.
+    } else if (isLive) {
+      // The service is already running — never tear it down on `start`. The
+      // gateway routes (including any newly claimed domains) were updated in
+      // state above and the caller refreshes the gateway, so domain changes
+      // take effect without restarting the process. A changed plist has been
+      // written to disk and applies on the next explicit `services restart`.
+      return {
+        name,
+        success: true,
+        message: plistChanged
+          ? 'Service already running; refreshed gateway (run `services restart` to apply config changes)'
+          : 'Service already running; refreshed gateway',
+      }
+    } else if (plistChanged || options?.reviveIfNotRunning !== false) {
+      // The service is bootstrapped but no longer running. Bootout and
+      // bootstrap again to give launchd a fresh start — for an explicit start
+      // (revival) or because the plist changed. The reconciler opts out of
+      // revival (`reviveIfNotRunning: false`): a bootstrapped service's
+      // liveness is launchd's to manage, so it leaves an unchanged plist alone.
       const bootoutResult = await launchctl.bootout(label)
       if (!bootoutResult.success) {
         return {
@@ -557,7 +567,8 @@ export class ServiceManager {
         }
       }
     } else {
-      // Already running with the same plist — nothing to do.
+      // Bootstrapped, idle, unchanged plist and the reconciler opted out of
+      // revival — nothing to do.
       return {
         name,
         success: true,


### PR DESCRIPTION
## Summary

`denvig services start <name> --claim-domains` would restart an already-running service whenever the regenerated launchd plist differed at all. The domain claim itself never needs a process restart — domains live in the nginx gateway, not the service process — so this was a needless interruption.

This change makes `services start` never tear down a service that is already **live**. It just refreshes the gateway so domain changes (including claims) take effect, leaving the running process untouched.

## Behaviour

- **Not bootstrapped** → bootstrap (fresh start) — unchanged
- **Already running** → skip bootout/bootstrap; gateway routes were already updated in state, so the caller's gateway refresh applies the domain change without interrupting the process. A changed plist is still written to disk and applies on the next explicit `services restart` (surfaced in the result message)
- **Bootstrapped but not running** → bootout + bootstrap to revive / apply plist changes — unchanged

`restartService` is unaffected: it boots the service out first, so by the time `startService` runs the service is no longer live and gets a clean bootstrap.

> Note: this applies to any already-running service on `start`, not only `--claim-domains`. The practical consequence is that editing a service's command/env and re-running `start` stages the new plist but won't restart the live process — run `services restart` to apply it.

## Testing

- Added a regression test: claim-domains on an already-running service moves the route to the new owner, releases the temporary domain, and asserts zero bootout/bootstrap calls
- Full suite green: 684 tests pass (566 SDK + 118 CLI), lint clean, codegen up to date
