### PR TITLE
Always enable the gateway, remove experimental config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- The gateway is now always enabled; the `experimental.gateway` config has been replaced by a top-level `gateway` config (with no `enabled` flag)
 - `services start` (including `--claim-domains`) no longer restarts a service that is already running; it just refreshes the gateway so domain changes apply without interrupting the process
 
 ## [0.7.0-alpha.6] - 2026-06-13

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -132,8 +132,8 @@ await denvig.certs.ca.remove()
 ### Gateway (Global Scope)
 
 ```typescript
-// Inspect the nginx gateway: whether it's enabled, the nginx process state,
-// and the gateway-configured services of the current project
+// Inspect the nginx gateway: the nginx process state and the
+// gateway-configured services of the current project
 const status = await denvig.gateway.status()
 
 // Reconcile running services and rebuild every nginx config from state

--- a/packages/cli/src/commands/gateway/configure.ts
+++ b/packages/cli/src/commands/gateway/configure.ts
@@ -12,13 +12,6 @@ export const gatewayConfigureCommand = new Command({
     const { reconcile: reconcileResult, gateway: result } =
       await sdk.gateway.configure()
 
-    if (!result) {
-      console.error(
-        'Gateway is not enabled. Add experimental.gateway.enabled: true to ~/.denvig/config.yml',
-      )
-      return { success: false, message: 'Gateway is not enabled' }
-    }
-
     if (flags.json) {
       console.log(
         JSON.stringify(

--- a/packages/cli/src/commands/gateway/status.ts
+++ b/packages/cli/src/commands/gateway/status.ts
@@ -13,7 +13,6 @@ export const gatewayStatusCommand = new Command({
     if (flags.json) {
       console.log(
         JSON.stringify({
-          enabled: status.enabled,
           handler: status.handler,
           nginx: status.nginx,
           nginxConf: status.nginxConf,
@@ -29,18 +28,6 @@ export const gatewayStatusCommand = new Command({
     console.log('Gateway Status')
     console.log('==============')
     console.log('')
-
-    if (!status.enabled) {
-      console.log('Status:  Disabled')
-      console.log('')
-      console.log('To enable gateway, add to ~/.denvig/config.yml:')
-      console.log('')
-      console.log('  experimental:')
-      console.log('    gateway:')
-      console.log('      enabled: true')
-      console.log('')
-      return { success: true, message: 'Gateway is disabled' }
-    }
 
     const statusLabel = status.nginx.running
       ? `Started (pid ${status.nginx.pid})`

--- a/packages/cli/src/commands/services/status.ts
+++ b/packages/cli/src/commands/services/status.ts
@@ -125,15 +125,14 @@ export const servicesStatusCommand = new Command({
       console.log(`Plist:   ${plistPath.replace(homedir(), '~')}`)
     }
 
-    // Show nginx config path if gateway is enabled and service has domain
+    // Show nginx config path if the service has a domain
     const globalConfig = await getGlobalConfig()
-    const gateway = globalConfig.experimental?.gateway
     const serviceConfig = manager.getServiceConfig(serviceName)
-    if (gateway?.enabled && serviceConfig?.http?.domain) {
+    if (serviceConfig?.http?.domain) {
       const nginxPath = getNginxConfigPath(
         targetProject.id,
         serviceName,
-        gateway.configsPath,
+        globalConfig.gateway.configsPath,
       )
       if (await pathExists(nginxPath)) {
         console.log(`Nginx:   ${nginxPath}`)

--- a/packages/sdk/schemas/config.global.json
+++ b/packages/sdk/schemas/config.global.json
@@ -93,29 +93,17 @@
       },
       "description": "Global services that can be managed from any directory"
     },
-    "experimental": {
+    "gateway": {
       "type": "object",
       "properties": {
-        "gateway": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "handler": {
-              "type": "string",
-              "enum": [
-                "nginx"
-              ]
-            },
-            "configsPath": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "enabled"
+        "handler": {
+          "type": "string",
+          "enum": [
+            "nginx"
           ]
+        },
+        "configsPath": {
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/packages/sdk/src/lib/config.ts
+++ b/packages/sdk/src/lib/config.ts
@@ -10,7 +10,7 @@ const GLOBAL_CONFIG_PATH = resolve(`${process.env.HOME}/.denvig/config.yml`)
 const DEFAULT_GLOBAL_CONFIG = {
   projectPaths: ['~/src/*/*', '~/.dotfiles'],
   quickActions: undefined,
-} satisfies GlobalConfigSchema
+} satisfies Partial<GlobalConfigSchema>
 
 export type ConfigWithSourcePaths<C> = C & {
   $sources: string[]

--- a/packages/sdk/src/lib/gateway/configure.ts
+++ b/packages/sdk/src/lib/gateway/configure.ts
@@ -47,8 +47,7 @@ type RouteGroup = {
 
 /**
  * Remove all denvig nginx configs and rebuild from the runtime gateway
- * routes recorded in `~/.denvig/state.json`. Returns null if gateway is
- * not enabled.
+ * routes recorded in `~/.denvig/state.json`.
  *
  * The state's `gatewayRoutes` map is the source of truth: each running
  * route generates an nginx server block that proxies the domain to the
@@ -56,14 +55,9 @@ type RouteGroup = {
  * pair are merged into a single nginx config so cnames sit alongside
  * the primary domain in the same `server_name` directive.
  */
-export async function configureGateway(): Promise<ConfigureGatewayResult | null> {
+export async function configureGateway(): Promise<ConfigureGatewayResult> {
   const globalConfig = await getGlobalConfig()
-  const gateway = globalConfig.experimental?.gateway
-  if (!gateway?.enabled) {
-    return null
-  }
-
-  const configsPath = gateway.configsPath
+  const configsPath = globalConfig.gateway.configsPath
 
   // Write gateway HTML files and nginx.conf
   await writeGatewayHtmlFiles()

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -1173,7 +1173,7 @@ export class ServiceManager {
    */
   async reconfigureGateway(): Promise<void> {
     const result = await configureGateway()
-    if (result && !result.success) {
+    if (!result.success) {
       console.warn(`[gateway] ${result.message}`)
     }
   }

--- a/packages/sdk/src/operations/gateway.ts
+++ b/packages/sdk/src/operations/gateway.ts
@@ -50,20 +50,18 @@ export type GatewayServiceStatus = {
   certFound: boolean
   /** The certificate directory backing the domain, if any. */
   certDir: string | null
-  /** The nginx config path for this service, or `null` when gateway is off. */
-  nginxConfigPath: string | null
+  /** The nginx config path for this service. */
+  nginxConfigPath: string
   nginxConfigExists: boolean
 }
 
 export type GatewayStatus = {
-  /** Whether the experimental gateway is enabled in the global config. */
-  enabled: boolean
   /** The gateway handler (currently always `nginx`). */
   handler: string
   /** Directory nginx server configs are written to. */
-  configsPath: string | null
+  configsPath: string
   /** Path of the generated nginx include file. */
-  nginxConf: string | null
+  nginxConf: string
   /** The nginx process state. */
   nginx: NginxProcessStatus
   /** Gateway-configured services for the resolved project. */
@@ -84,8 +82,7 @@ export const getGatewayStatus = async (
   options: GatewayStatusOptions = {},
 ): Promise<GatewayStatus> => {
   const globalConfig = await getGlobalConfig()
-  const gateway = globalConfig.experimental?.gateway
-  const enabled = gateway?.enabled ?? false
+  const gateway = globalConfig.gateway
 
   const services: GatewayServiceStatus[] = []
   const { project } = await resolveProjectContext({
@@ -102,9 +99,11 @@ export const getGatewayStatus = async (
       const secure = config.http?.secure ?? false
       const certDir = secure ? await findCertForDomain(domain) : null
       const sslPaths = certDir ? await resolveSslPaths(certDir) : null
-      const nginxConfigPath = gateway?.enabled
-        ? getNginxConfigPath(worktree.id, name, gateway.configsPath)
-        : null
+      const nginxConfigPath = getNginxConfigPath(
+        worktree.id,
+        name,
+        gateway.configsPath,
+      )
 
       services.push({
         name,
@@ -115,20 +114,15 @@ export const getGatewayStatus = async (
         certFound: !!sslPaths,
         certDir,
         nginxConfigPath,
-        nginxConfigExists: nginxConfigPath
-          ? await pathExists(nginxConfigPath)
-          : false,
+        nginxConfigExists: await pathExists(nginxConfigPath),
       })
     }
   }
 
   return {
-    enabled,
-    handler: gateway?.handler ?? 'nginx',
-    configsPath: gateway?.configsPath ?? null,
-    nginxConf: gateway?.configsPath
-      ? getNginxConfPath(gateway.configsPath)
-      : null,
+    handler: gateway.handler,
+    configsPath: gateway.configsPath,
+    nginxConf: getNginxConfPath(gateway.configsPath),
     nginx: getNginxProcessStatus(),
     services,
   }
@@ -136,8 +130,8 @@ export const getGatewayStatus = async (
 
 export type ConfigureGatewayOutput = {
   reconcile: ReconcileResult
-  /** The gateway rebuild result, or `null` when the gateway is not enabled. */
-  gateway: ConfigureGatewayResult | null
+  /** The gateway rebuild result. */
+  gateway: ConfigureGatewayResult
 }
 
 /**

--- a/packages/sdk/src/schemas/config.ts
+++ b/packages/sdk/src/schemas/config.ts
@@ -93,17 +93,12 @@ export const GlobalConfigSchema = z.object({
   services: ServicesConfigSchema.describe(
     'Global services that can be managed from any directory',
   ),
-  experimental: z
+  gateway: z
     .object({
-      gateway: z
-        .object({
-          enabled: z.boolean(),
-          handler: z.enum(['nginx']).default('nginx'),
-          configsPath: z.string().default(`/opt/homebrew/etc/nginx/servers`),
-        })
-        .optional(),
+      handler: z.enum(['nginx']).default('nginx'),
+      configsPath: z.string().default(`/opt/homebrew/etc/nginx/servers`),
     })
-    .optional(),
+    .prefault({}),
 })
 
 export type GlobalConfigSchema = z.infer<typeof GlobalConfigSchema>


### PR DESCRIPTION
## Summary

The gateway is no longer experimental. This removes the `experimental.gateway` config wrapper and every code gate that checked the `enabled` flag — 0.7.0 always has the gateway enabled.

## Changes

**Config schema**
- Replaced the optional `experimental.gateway` object (with its `enabled` flag) with a top-level `gateway` config containing just `handler` and `configsPath`. Uses `prefault({})` so it's always populated with defaults (`nginx` / `/opt/homebrew/etc/nginx/servers`); a custom `configsPath` still overrides cleanly.
- Regenerated `config.global.json` via codegen.

**Removed code gates**
- `configureGateway()` no longer early-returns `null` when disabled — it always returns a result.
- Removed the `enabled` field from `GatewayStatus` and tightened previously-nullable paths (`configsPath`, `nginxConf`, `nginxConfigPath`) to non-nullable.
- CLI `gateway configure` no longer has a "not enabled" error path.
- CLI `gateway status` no longer has a "Disabled" branch, and dropped the `enabled` field from `--json` output.
- CLI `services status` no longer gates the nginx config path display on the enabled flag.

**Docs & changelog**
- Updated `docs/sdk.md` and added a `[Unreleased]` CHANGELOG entry.

## Breaking change

The `enabled` field was removed from `sdk.gateway.status()` and the `gateway status --json` output. It was always `true` now that the gateway is always on, but external consumers reading that field should be aware.

## Verification

- `pnpm run codegen`, `lint`, `check-types`, `test` (566 passing), and `build` all pass.
- `denvig gateway status` (text + `--json`) works with the gateway always enabled.
