### PR TITLE
Reduce log disk usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - The gateway is now always enabled; the `experimental.gateway` config has been replaced by a top-level `gateway` config (with no `enabled` flag)
 - `services start` (including `--claim-domains`) no longer restarts a service that is already running; it just refreshes the gateway so domain changes apply without interrupting the process
+- Starting a service now keeps only the 10 most recent log files, removing older ones to save disk space
+- CLI usage logging is now disabled by default; set `DENVIG_CLI_LOGS_ENABLED=true` to enable it
+- CLI usage logs are now written to a daily file (`~/.denvig/logs/cli/{YYYY-MM-DD}.jsonl`) instead of a single growing file
 
 ## [0.7.0-alpha.6] - 2026-06-13
 

--- a/packages/sdk/src/lib/cli-logs.test.ts
+++ b/packages/sdk/src/lib/cli-logs.test.ts
@@ -24,6 +24,8 @@ describe('cli-logs', () => {
   beforeEach(async () => {
     // Clean up any existing log file before each test
     await rm(testLogPath, { force: true })
+    // Enable logging by default for these tests (it is disabled by default)
+    process.env.DENVIG_CLI_LOGS_ENABLED = 'true'
   })
 
   afterEach(async () => {
@@ -34,25 +36,25 @@ describe('cli-logs', () => {
   })
 
   describe('isCliLoggingEnabled()', () => {
-    it('should return true by default', () => {
+    it('should return false by default', () => {
       delete process.env.DENVIG_CLI_LOGS_ENABLED
-      assert.strictEqual(isCliLoggingEnabled(), true)
-    })
-
-    it('should return false when DENVIG_CLI_LOGS_ENABLED=0', () => {
-      process.env.DENVIG_CLI_LOGS_ENABLED = '0'
       assert.strictEqual(isCliLoggingEnabled(), false)
     })
 
-    it('should return true for any other value', () => {
-      process.env.DENVIG_CLI_LOGS_ENABLED = '1'
-      assert.strictEqual(isCliLoggingEnabled(), true)
-
+    it('should return true when DENVIG_CLI_LOGS_ENABLED=true', () => {
       process.env.DENVIG_CLI_LOGS_ENABLED = 'true'
       assert.strictEqual(isCliLoggingEnabled(), true)
+    })
+
+    it('should return false for any other value', () => {
+      process.env.DENVIG_CLI_LOGS_ENABLED = '1'
+      assert.strictEqual(isCliLoggingEnabled(), false)
+
+      process.env.DENVIG_CLI_LOGS_ENABLED = '0'
+      assert.strictEqual(isCliLoggingEnabled(), false)
 
       process.env.DENVIG_CLI_LOGS_ENABLED = 'false'
-      assert.strictEqual(isCliLoggingEnabled(), true)
+      assert.strictEqual(isCliLoggingEnabled(), false)
     })
   })
 

--- a/packages/sdk/src/lib/cli-logs.ts
+++ b/packages/sdk/src/lib/cli-logs.ts
@@ -19,22 +19,23 @@ export type CliLogEntry = {
 
 /**
  * Check if CLI logging is enabled.
- * Logging is enabled by default, but can be disabled via DENVIG_CLI_LOGS_ENABLED=0
+ * Logging is disabled by default, and can be enabled via DENVIG_CLI_LOGS_ENABLED=true
  */
 export const isCliLoggingEnabled = (): boolean => {
-  const envValue = process.env.DENVIG_CLI_LOGS_ENABLED
-  return envValue !== '0'
+  return process.env.DENVIG_CLI_LOGS_ENABLED === 'true'
 }
 
 /**
- * Get the path to the CLI logs file.
+ * Get the path to the CLI logs file for the current day.
+ * Logs are written to a daily file: ~/.denvig/logs/cli/{YYYY-MM-DD}.jsonl
  * Can be overridden via DENVIG_CLI_LOGS_PATH environment variable.
  */
 export const getCliLogsPath = (): string => {
   if (process.env.DENVIG_CLI_LOGS_PATH) {
     return resolve(process.env.DENVIG_CLI_LOGS_PATH)
   }
-  return resolve(homedir(), '.denvig', 'logs', 'cli.jsonl')
+  const date = new Date().toISOString().slice(0, 10)
+  return resolve(homedir(), '.denvig', 'logs', 'cli', `${date}.jsonl`)
 }
 
 /**

--- a/packages/sdk/src/lib/services/manager.test.ts
+++ b/packages/sdk/src/lib/services/manager.test.ts
@@ -1,7 +1,15 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: The print function is overridden for mocking, easier to use any */
 import { ok, strictEqual } from 'node:assert'
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { hostname, tmpdir } from 'node:os'
+import { resolve } from 'node:path'
 import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import { createMockInternalProject } from '../../test/mock.ts'
@@ -186,6 +194,67 @@ describe('ServiceManager', () => {
       ok(path.includes(`.denvig/services/${project.id}.dev-watch/logs`))
       ok(path.includes(`latest.${hostname()}.log`))
       ok(!path.includes(':'))
+    })
+  })
+
+  describe('pruneOldLogFiles()', () => {
+    it('should keep only the 10 most recent log files and preserve symlinks', async () => {
+      const project = createMockInternalProject('workspace/my-app')
+      const manager = new ServiceManager(project)
+
+      const logDir = mkdtempSync(resolve(tmpdir(), 'denvig-prune-'))
+      try {
+        // Create 15 timestamped log files
+        const timestamps = Array.from({ length: 15 }, (_, i) => 1700000000 + i)
+        for (const ts of timestamps) {
+          writeFileSync(resolve(logDir, `${ts}.log`), '')
+        }
+        // Symlinks should always be preserved regardless of count
+        symlinkSync('1700000014.log', resolve(logDir, 'latest.log'))
+        symlinkSync(
+          '1700000014.log',
+          resolve(logDir, `latest.${hostname()}.log`),
+        )
+
+        await (manager as any).pruneOldLogFiles(logDir)
+
+        const remaining = readdirSync(logDir)
+        const logFiles = remaining
+          .filter((name) => /^\d+\.log$/.test(name))
+          .sort()
+        strictEqual(logFiles.length, 10, 'should keep 10 timestamped logs')
+        strictEqual(logFiles[0], '1700000005.log', 'should keep newest 10')
+        strictEqual(logFiles[9], '1700000014.log')
+
+        ok(remaining.includes('latest.log'), 'latest.log preserved')
+        ok(
+          remaining.includes(`latest.${hostname()}.log`),
+          'host symlink preserved',
+        )
+      } finally {
+        rmSync(logDir, { recursive: true, force: true })
+      }
+    })
+
+    it('should leave files untouched when fewer than the limit exist', async () => {
+      const project = createMockInternalProject('workspace/my-app')
+      const manager = new ServiceManager(project)
+
+      const logDir = mkdtempSync(resolve(tmpdir(), 'denvig-prune-'))
+      try {
+        for (const ts of [1700000000, 1700000001, 1700000002]) {
+          writeFileSync(resolve(logDir, `${ts}.log`), '')
+        }
+
+        await (manager as any).pruneOldLogFiles(logDir)
+
+        const logFiles = readdirSync(logDir).filter((name) =>
+          /^\d+\.log$/.test(name),
+        )
+        strictEqual(logFiles.length, 3)
+      } finally {
+        rmSync(logDir, { recursive: true, force: true })
+      }
     })
   })
 

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -3,6 +3,7 @@ import {
   appendFile,
   chmod,
   mkdir,
+  readdir,
   readFile,
   rm,
   symlink,
@@ -1128,7 +1129,31 @@ export class ServiceManager {
       }),
     )
 
+    await this.pruneOldLogFiles(logDir)
+
     return logPath
+  }
+
+  /**
+   * Remove old timestamped log files, keeping only the most recent ones.
+   * Symlinks (latest.log, latest.[hostname].log) are always preserved.
+   */
+  private async pruneOldLogFiles(logDir: string, keep = 10): Promise<void> {
+    try {
+      const entries = await readdir(logDir)
+      const timestamped = entries
+        .filter((name) => /^\d+\.log$/.test(name))
+        .sort()
+        .reverse()
+
+      await Promise.all(
+        timestamped
+          .slice(keep)
+          .map((name) => unlink(resolve(logDir, name)).catch(() => {})),
+      )
+    } catch {
+      // Ignore pruning errors - they should never block service startup
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Logging previously grew unbounded — CLI usage logs accumulated in a single ever-growing `cli.jsonl` (reaching ~1 GB locally) and service logs were never pruned. This branch caps that disk usage in three ways.

## Changes

- **Prune service logs on start** — starting a service now keeps only the 10 most recent timestamped log files and removes older ones. The `latest.log` / `latest.<hostname>.log` symlinks are always preserved, and pruning failures never block startup.
- **CLI logging is now opt-in** — usage logging is disabled by default. Set `DENVIG_CLI_LOGS_ENABLED=true` to enable it (previously it was on unless `=0`).
- **Daily CLI log files** — CLI logs now write to `~/.denvig/logs/cli/{YYYY-MM-DD}.jsonl` (per-day) instead of one single growing file. The `DENVIG_CLI_LOGS_PATH` override still works.

## Notes

These changes affect new logs only; existing oversized files (the old `cli.jsonl` and legacy `*.log` files) are left untouched and can be removed manually.

## Testing

- `pnpm run test` — 568 tests pass (added coverage for log pruning and the new CLI logging defaults)
- `pnpm run lint`, `pnpm run codegen`, `pnpm run build` all clean
- `denvig version` verified after install