### PR TITLE
Replace --random-port with flexible --port at service start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `services start`/`services restart` accept `--domains` to route any domains to a service at launch, replacing the configured ones (e.g. `services start hello --domains hello2.denvig.me`); pairs with `--worktree` to give a worktree its own domain
 - The SDK's `service.start()` accepts a `domains` option matching the CLI's `--domains` flag
+- `services start`/`services restart` accept `--port` to pick a specific port (e.g. `--port 3000`) or `--port random` to allocate a free one; a busy port still falls back to a random one
+- The SDK's `service.start()` accepts a `port` option (`number | 'random'`)
 
 ### Changed
 
@@ -16,6 +18,7 @@
 ### Removed
 
 - The `--claim-domains`/`--no-claim-domains` flags and the `claimDomains` SDK option, along with automatic temporary domains, in favour of the explicit `--domains` flag
+- The `--random-port` flag, replaced by `--port random`
 - Starting a service now keeps only the 10 most recent log files, removing older ones to save disk space
 - CLI usage logging is now disabled by default; set `DENVIG_CLI_LOGS_ENABLED=true` to enable it
 - CLI usage logs are now written to a daily file (`~/.denvig/logs/cli/{YYYY-MM-DD}.jsonl`) instead of a single growing file

--- a/packages/cli/src/commands/services/restart.test.ts
+++ b/packages/cli/src/commands/services/restart.test.ts
@@ -12,7 +12,7 @@ describe('servicesRestartCommand', () => {
   it('should have correct usage', () => {
     ok(
       servicesRestartCommand.usage ===
-        'services restart <name> [--worktree <branch>] [--random-port] [--domains <list>]',
+        'services restart <name> [--worktree <branch>] [--port <port>] [--domains <list>]',
     )
   })
 })

--- a/packages/cli/src/commands/services/restart.ts
+++ b/packages/cli/src/commands/services/restart.ts
@@ -10,7 +10,7 @@ export const servicesRestartCommand = new Command({
   name: 'services:restart',
   description: 'Restart a service',
   usage:
-    'services restart <name> [--worktree <branch>] [--random-port] [--domains <list>]',
+    'services restart <name> [--worktree <branch>] [--port <port>] [--domains <list>]',
   example: 'services restart api',
   args: [
     {
@@ -30,12 +30,11 @@ export const servicesRestartCommand = new Command({
       type: 'string',
     },
     {
-      name: 'random-port',
+      name: 'port',
       description:
-        'Skip the config port and start on a randomly allocated dev port',
+        'Port to start on, or "random" to allocate a free dev port; defaults to the configured port, falling back to a random one when busy',
       required: false,
-      type: 'boolean',
-      defaultValue: false,
+      type: 'string',
     },
     {
       name: 'domains',

--- a/packages/cli/src/commands/services/start.test.ts
+++ b/packages/cli/src/commands/services/start.test.ts
@@ -12,7 +12,7 @@ describe('servicesStartCommand', () => {
   it('should have correct usage', () => {
     ok(
       servicesStartCommand.usage ===
-        'services start <name> [--worktree <branch>] [--random-port] [--domains <list>]',
+        'services start <name> [--worktree <branch>] [--port <port>] [--domains <list>]',
     )
   })
 })

--- a/packages/cli/src/commands/services/start.ts
+++ b/packages/cli/src/commands/services/start.ts
@@ -10,7 +10,7 @@ export const servicesStartCommand = new Command({
   name: 'services:start',
   description: 'Start a service',
   usage:
-    'services start <name> [--worktree <branch>] [--random-port] [--domains <list>]',
+    'services start <name> [--worktree <branch>] [--port <port>] [--domains <list>]',
   example: 'services start api',
   args: [
     {
@@ -30,12 +30,11 @@ export const servicesStartCommand = new Command({
       type: 'string',
     },
     {
-      name: 'random-port',
+      name: 'port',
       description:
-        'Skip the config port and start on a randomly allocated dev port',
+        'Port to start on, or "random" to allocate a free dev port; defaults to the configured port, falling back to a random one when busy',
       required: false,
-      type: 'boolean',
-      defaultValue: false,
+      type: 'string',
     },
     {
       name: 'domains',

--- a/packages/cli/src/lib/services/resolvePort.test.ts
+++ b/packages/cli/src/lib/services/resolvePort.test.ts
@@ -54,18 +54,43 @@ describe('resolveServicePortForCli', () => {
     ok(typeof resolution.port === 'number')
   })
 
-  it('allocates a random port when --random-port is passed', async () => {
+  it('allocates a random port when --port random is passed', async () => {
     const project = createProject('/tmp/wt-random')
     const manager = new ServiceManager(project)
 
     const resolution = await resolveServicePortForCli(manager, 'hello', {
       json: true,
-      'random-port': true,
+      port: 'random',
     })
 
     ok(resolution !== null)
-    ok(resolution.port !== undefined)
+    ok(typeof resolution.port === 'number')
     ok(resolution.port !== 8080)
+  })
+
+  it('resolves a specific --port value', async () => {
+    const project = createProject('/tmp/wt-specific')
+    const manager = new ServiceManager(project)
+
+    const resolution = await resolveServicePortForCli(manager, 'hello', {
+      json: true,
+      port: '8456',
+    })
+
+    ok(resolution !== null)
+    ok(typeof resolution.port === 'number')
+  })
+
+  it('rejects an invalid --port value', async () => {
+    const project = createProject('/tmp/wt-invalid')
+    const manager = new ServiceManager(project)
+
+    const resolution = await resolveServicePortForCli(manager, 'hello', {
+      json: true,
+      port: 'nonsense',
+    })
+
+    strictEqual(resolution, null)
   })
 
   it('returns no port for a service without an http block', async () => {

--- a/packages/cli/src/lib/services/resolvePort.ts
+++ b/packages/cli/src/lib/services/resolvePort.ts
@@ -4,7 +4,7 @@ import type { ServiceManager } from '@denvig/sdk/internal'
 
 type Flags = {
   json?: unknown
-  'random-port'?: unknown
+  port?: unknown
 }
 
 export type CliStartResolution = {
@@ -12,29 +12,72 @@ export type CliStartResolution = {
   port: number | undefined
 }
 
-const isInteractive = (flags: Flags): boolean =>
+/**
+ * Parse the `--port` flag into the shape `resolveServicePort` expects: a
+ * specific number, the literal `'random'`, or `undefined` when the flag was
+ * omitted. Returns an error message for any other value.
+ */
+const parsePortFlag = (
+  value: unknown,
+):
+  | { ok: true; port: number | 'random' | undefined }
+  | { ok: false; message: string } => {
+  if (value === undefined) return { ok: true, port: undefined }
+  if (typeof value !== 'string') {
+    return { ok: false, message: 'Invalid --port value.' }
+  }
+  if (value === 'random') return { ok: true, port: 'random' }
+  const port = Number(value)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    return {
+      ok: false,
+      message: `Invalid --port "${value}". Use a port number (1-65535) or "random".`,
+    }
+  }
+  return { ok: true, port }
+}
+
+const isInteractive = (
+  flags: Flags,
+  requestedPort: number | 'random' | undefined,
+): boolean =>
   !flags.json &&
   process.stdin.isTTY === true &&
   process.stdout.isTTY === true &&
-  !flags['random-port']
+  requestedPort !== 'random'
 
 /**
  * Resolve the port a service should start on, prompting the user when the
- * config port is in use and the session is interactive. In non-interactive
- * contexts (JSON output, no TTY, --random-port) we silently fall back to a
+ * chosen port is in use and the session is interactive. In non-interactive
+ * contexts (JSON output, no TTY, `--port random`) we silently fall back to a
  * randomly allocated port to match the documented automation behaviour.
  *
- * Returns `null` when the user explicitly aborts in an interactive prompt
- * or no free port could be allocated.
+ * Returns `null` when the user explicitly aborts in an interactive prompt,
+ * passes an invalid `--port` value, or no free port could be allocated.
  */
 export const resolveServicePortForCli = async (
   manager: ServiceManager,
   serviceName: string,
   flags: Flags,
 ): Promise<CliStartResolution | null> => {
-  const forceRandom = !!flags['random-port']
+  const parsedPort = parsePortFlag(flags.port)
+  if (!parsedPort.ok) {
+    if (flags.json) {
+      console.log(
+        JSON.stringify({
+          success: false,
+          service: serviceName,
+          message: parsedPort.message,
+        }),
+      )
+    } else {
+      console.error(parsedPort.message)
+    }
+    return null
+  }
+  const requestedPort = parsedPort.port
   const resolved = await manager.resolveServicePort(serviceName, {
-    forceRandom,
+    port: requestedPort,
   })
   if (!resolved.success) {
     if (flags.json) {
@@ -55,7 +98,7 @@ export const resolveServicePortForCli = async (
   const allocated = resolved.source === 'allocated'
 
   if (resolved.conflict) {
-    if (!isInteractive(flags)) {
+    if (!isInteractive(flags, requestedPort)) {
       if (!flags.json) {
         if (allocated && chosenPort !== undefined) {
           console.log(

--- a/packages/sdk/src/lib/services/manager.test.ts
+++ b/packages/sdk/src/lib/services/manager.test.ts
@@ -8,6 +8,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs'
+import { type AddressInfo, createServer } from 'node:net'
 import { hostname, tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { afterEach, beforeEach, describe, it } from 'node:test'
@@ -21,6 +22,20 @@ import {
   setGatewayRoute,
   updateServiceState,
 } from './state.ts'
+
+/** Bind an ephemeral TCP port and return it with a release callback. */
+const occupyPort = async (): Promise<{
+  port: number
+  release: () => Promise<void>
+}> => {
+  const server = createServer()
+  await new Promise<void>((res) => server.listen(0, res))
+  const port = (server.address() as AddressInfo).port
+  return {
+    port,
+    release: () => new Promise<void>((res) => server.close(() => res())),
+  }
+}
 
 describe('ServiceManager', () => {
   describe('listServices()', () => {
@@ -317,7 +332,7 @@ describe('ServiceManager', () => {
       strictEqual(resolved.conflict, false)
     })
 
-    it('returns no port for a non-http service even with forceRandom', async () => {
+    it('returns no port for a non-http service even with port "random"', async () => {
       const project = createMockInternalProject({ path: '/tmp/test-ports' })
       project.config.services = {
         worker: { command: 'node worker.js' },
@@ -325,11 +340,94 @@ describe('ServiceManager', () => {
       const manager = new ServiceManager(project)
 
       const resolved = await manager.resolveServicePort('worker', {
-        forceRandom: true,
+        port: 'random',
       })
 
       ok(resolved.success)
       strictEqual(resolved.port, undefined)
+    })
+
+    it('allocates a random port when port is "random"', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        web: { command: 'node server.js', http: { port: 4000 } },
+      }
+      const manager = new ServiceManager(project)
+
+      const resolved = await manager.resolveServicePort('web', {
+        port: 'random',
+      })
+
+      ok(resolved.success)
+      strictEqual(resolved.source, 'allocated')
+      strictEqual(resolved.conflict, false)
+      ok(resolved.port !== undefined && resolved.port !== 4000)
+    })
+
+    it('uses a requested port when it is free', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        web: { command: 'node server.js', http: { port: 4000 } },
+      }
+      const manager = new ServiceManager(project)
+
+      const resolved = await manager.resolveServicePort('web', { port: 8456 })
+
+      ok(resolved.success)
+      strictEqual(resolved.port, 8456)
+      strictEqual(resolved.source, 'requested')
+      strictEqual(resolved.conflict, false)
+    })
+
+    it('falls back to a random port when the requested port is in use', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        web: { command: 'node server.js', http: { port: 4000 } },
+      }
+      const manager = new ServiceManager(project)
+      const busy = await occupyPort()
+      try {
+        const resolved = await manager.resolveServicePort('web', {
+          port: busy.port,
+        })
+
+        ok(resolved.success)
+        strictEqual(resolved.source, 'allocated')
+        strictEqual(resolved.conflict, true)
+        strictEqual(resolved.configPort, busy.port)
+        ok(resolved.port !== undefined && resolved.port !== busy.port)
+      } finally {
+        await busy.release()
+      }
+    })
+
+    it('keeps a requested port this service already holds (mid-restart)', async () => {
+      const project = createMockInternalProject({ path: '/tmp/test-ports' })
+      project.config.services = {
+        web: { command: 'node server.js', http: { port: 4000 } },
+      }
+      const busy = await occupyPort()
+      // State records the port and the port reads as in use — but it's this
+      // service's own, so it must be kept rather than swapped for a random one.
+      await updateServiceState(project.id, 'web', {
+        cwd: project.path,
+        port: busy.port,
+        domains: [],
+        desiredStatus: 'running',
+      })
+      const manager = new ServiceManager(project)
+      try {
+        const resolved = await manager.resolveServicePort('web', {
+          port: busy.port,
+        })
+
+        ok(resolved.success)
+        strictEqual(resolved.port, busy.port)
+        strictEqual(resolved.source, 'requested')
+        strictEqual(resolved.conflict, false)
+      } finally {
+        await busy.release()
+      }
     })
 
     it('ignores a stale state port for a non-http service', async () => {

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -167,25 +167,32 @@ export class ServiceManager {
    *
    * Resolution order:
    * 1. If the service has no `http` block it never needs a port — return
-   *    no port, ignoring any state entry and the `forceRandom` flag.
-   * 2. If `forceRandom`, always allocate a fresh random port (preferring the
-   *    previously-allocated one when free).
-   * 3. If state already records a port for this service, reuse it. State is
+   *    no port, ignoring any state entry and the requested port.
+   * 2. If `port` is `'random'`, always allocate a fresh random port
+   *    (preferring the previously-allocated one when free).
+   * 3. If `port` is a specific number, use it — unless it's already in use
+   *    by something other than this service, in which case fall back to a
+   *    random port and flag `conflict: true`.
+   * 4. If state already records a port for this service, reuse it. State is
    *    authoritative once allocated so restarts stay on the same port and
    *    don't re-prompt about the config port being busy. Run
    *    `services teardown` to reset.
-   * 4. Otherwise try the config port — falling back to a random port and
+   * 5. Otherwise try the config port — falling back to a random port and
    *    flagging `conflict: true` when it's already in use.
-   * 5. Otherwise (no config port, no state) allocate a random port.
+   * 6. Otherwise (no config port, no state) allocate a random port.
+   *
+   * @param options.port - The requested port: a specific number, the
+   *   string `'random'` to always allocate a free port, or `undefined` to
+   *   fall back to the state/config port.
    */
   async resolveServicePort(
     name: string,
-    options?: { forceRandom?: boolean },
+    options?: { port?: number | 'random' },
   ): Promise<
     | {
         success: true
         port: number | undefined
-        source: 'config' | 'allocated' | 'state' | 'none'
+        source: 'config' | 'allocated' | 'requested' | 'state' | 'none'
         conflict: boolean
         configPort?: number
       }
@@ -214,7 +221,7 @@ export class ServiceManager {
     const configPort = config.http.port
     const previous = await getServiceState(this.project.id, name)
 
-    if (options?.forceRandom) {
+    if (options?.port === 'random') {
       const allocated = await allocateRandomPort({
         preferredPort: previous?.port,
       })
@@ -224,6 +231,31 @@ export class ServiceManager {
         source: allocated === null ? 'none' : 'allocated',
         conflict: false,
         configPort,
+      }
+    }
+
+    // A specific port was requested. Use it directly when free — or when
+    // this service already holds it (e.g. mid-restart the old process is
+    // still bound). Otherwise fall back to a random port and flag the
+    // conflict so the caller can surface it.
+    if (typeof options?.port === 'number') {
+      const requested = options.port
+      if (previous?.port === requested || !(await isPortInUse(requested))) {
+        return {
+          success: true,
+          port: requested,
+          source: 'requested',
+          conflict: false,
+          configPort: requested,
+        }
+      }
+      const fallback = await allocateRandomPort()
+      return {
+        success: true,
+        port: fallback ?? undefined,
+        source: fallback === null ? 'none' : 'allocated',
+        conflict: true,
+        configPort: requested,
       }
     }
 

--- a/packages/sdk/src/operations/services.ts
+++ b/packages/sdk/src/operations/services.ts
@@ -260,6 +260,12 @@ export type StartServiceOptions = ServiceOperationOptions & {
    * this service stops. When omitted, the configured domains are used.
    */
   domains?: string[]
+  /**
+   * The port to start the service on: a specific number, or `'random'` to
+   * always allocate a free port. When omitted, the configured port is used,
+   * falling back to a random port when it's already in use.
+   */
+  port?: number | 'random'
 }
 
 /**
@@ -321,7 +327,9 @@ export const startService = async (
     project: targetProject,
   } = await resolveServiceTarget(project, name, options.worktree)
 
-  const resolution = await manager.resolveServicePort(serviceName, {})
+  const resolution = await manager.resolveServicePort(serviceName, {
+    port: options.port,
+  })
   const result = await manager.startService(serviceName, {
     port: resolution.success ? resolution.port : undefined,
     portResolved: true,
@@ -395,7 +403,9 @@ export const restartService = async (
     project: targetProject,
   } = await resolveServiceTarget(project, name, options.worktree)
 
-  const resolution = await manager.resolveServicePort(serviceName, {})
+  const resolution = await manager.resolveServicePort(serviceName, {
+    port: options.port,
+  })
   const result = await manager.restartService(serviceName, {
     port: resolution.success ? resolution.port : undefined,
     portResolved: true,

--- a/packages/sdk/src/resources/service.ts
+++ b/packages/sdk/src/resources/service.ts
@@ -17,6 +17,12 @@ export type ServiceStartOptions = {
    * this service stops. When omitted, the configured domains are used.
    */
   domains?: string[]
+  /**
+   * The port to start the service on: a specific number, or `'random'` to
+   * always allocate a free port. When omitted, the configured port is used,
+   * falling back to a random port when it's already in use.
+   */
+  port?: number | 'random'
 }
 
 /**
@@ -52,6 +58,7 @@ export class DenvigService {
       startService(this.project, this.serviceName, {
         worktree: this.worktreeName,
         domains: options.domains,
+        port: options.port,
       }),
     )
   }


### PR DESCRIPTION
## Summary

Extends the flexibility idea from #226 to port allocation. The `--random-port` boolean flag is replaced by a `--port` flag that accepts either a specific port number or `"random"`. The SDK gains a matching `port?: number | 'random'` option on `service.start()`.

```sh
denvig services start hello --port 3000    # use a specific port
denvig services start hello --port random  # allocate a free dev port (the old --random-port)
denvig services start hello                # configured port, random fallback when busy
```

## Behaviour

Port resolution (`resolveServicePort`) is now driven by `port?: number | 'random'`:

- **`'random'`** — always allocate a free port (the old `forceRandom`).
- **a specific number** — use it when free; if it's already in use the conflict is still detected and a random port is assigned (`conflict: true`). If this service already holds the port (e.g. mid-restart, when the old process is still bound), the port is kept rather than swapped.
- **omitted** — unchanged: sticky state port → configured port → random.

Invalid `--port` values (non-numeric, out of the 1–65535 range) are rejected with a clear error before any start is attempted.

## Changes

- **`manager.ts`** — `resolveServicePort` option `forceRandom` → `port: number | 'random'`; added the requested-port branch with the mid-restart sticky guard and a new `'requested'` source.
- **SDK `operations`/`resources`** — added `port?: number | 'random'` to start/restart options, plumbed through to the resolver.
- **CLI `resolvePort.ts`** — parses and validates `--port`, maps it to the resolver; `--port random` is treated as non-interactive (no conflict prompt).
- **CLI `start`/`restart`** — `--random-port` → `--port`, updated usage strings.
- Tests updated/added (specific port honoured, busy-port fallback, mid-restart stickiness against a real bound port, invalid-port rejection); CHANGELOG updated.

## Verification

- `pnpm run codegen`, `pnpm run lint` — clean
- `pnpm run test` — 682/682 pass (563 SDK + 119 CLI)
- `pnpm run build` — succeeds (type-checks clean)
- Live CLI: `--port` shows in help; `--port nonsense` is rejected with a JSON error and the service is not started