### PR TITLE
Add CI test guarding against workspace version drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denvig/workspace",
-  "version": "0.7.0-alpha.7",
+  "version": "0.7.0-alpha.6",
   "private": true,
   "packageManager": "pnpm@11.5.2",
   "license": "MIT",

--- a/packages/cli/src/test/workspace-versions.test.ts
+++ b/packages/cli/src/test/workspace-versions.test.ts
@@ -1,0 +1,56 @@
+import { strictEqual } from 'node:assert'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Guards against version drift across the workspace. `bin/tag-release` bumps the
+ * root package.json and every package under packages/* in lockstep, so they must
+ * always share the same version. A mismatch means a release only partially bumped
+ * the versions — the exact failure where the publishable packages were left
+ * behind and pnpm reported "no new packages that should be published".
+ */
+
+const findRepoRoot = (): string => {
+  let dir = dirname(fileURLToPath(import.meta.url))
+  while (!existsSync(join(dir, 'pnpm-workspace.yaml'))) {
+    const parent = dirname(dir)
+    if (parent === dir) throw new Error('could not locate workspace root')
+    dir = parent
+  }
+  return dir
+}
+
+const repoRoot = findRepoRoot()
+
+const readPackage = (path: string): { name: string; version: string } =>
+  JSON.parse(readFileSync(path, 'utf8'))
+
+const rootVersion = readPackage(join(repoRoot, 'package.json')).version
+
+const packagesDir = join(repoRoot, 'packages')
+const workspacePackages = readdirSync(packagesDir)
+  .map((name) => join(packagesDir, name, 'package.json'))
+  .filter((path) => existsSync(path))
+  .map((path) => readPackage(path))
+
+describe('workspace package versions', () => {
+  it('discovers the workspace packages', () => {
+    strictEqual(
+      workspacePackages.length > 0,
+      true,
+      'expected at least one package under packages/*',
+    )
+  })
+
+  for (const pkg of workspacePackages) {
+    it(`${pkg.name} matches the root version (${rootVersion})`, () => {
+      strictEqual(
+        pkg.version,
+        rootVersion,
+        `${pkg.name} is ${pkg.version} but the workspace root is ${rootVersion}; bump every package.json in lockstep (bin/tag-release does this)`,
+      )
+    })
+  }
+})


### PR DESCRIPTION
## Summary

Adds a test that fails if the root `package.json` and any `packages/*/package.json` fall out of version sync. This is the guardrail for the bug behind the botched `v0.7.0-alpha.7` release: only the workspace-root version was bumped, the publishable packages were left behind, and `pnpm -r ... publish` reported "no new packages that should be published."

`bin/tag-release` bumps every `package.json` in lockstep, so they must always share one version — this test enforces that invariant.

## Approach

It runs as part of the **existing** suite (`packages/cli/src/test/workspace-versions.test.ts`), picked up by `turbo run test` which CI already runs — no separate CI step or script. It resolves the repo root by walking up to `pnpm-workspace.yaml`, reads the root and every `packages/*` version, and asserts they all match, with an actionable failure message:

\`\`\`
✖ @denvig/cli matches the root version (0.7.0-alpha.6)
  AssertionError: @denvig/cli is 0.7.0-alpha.5 but the workspace root is
  0.7.0-alpha.6; bump every package.json in lockstep (bin/tag-release does this)
\`\`\`

Also resets the workspace-root version from the stranded `0.7.0-alpha.7` back to `0.7.0-alpha.6`, matching the currently published packages so the workspace is in sync again.