### PR TITLE
Allow starting a service without claiming its configured domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `services start` accepts `--no-domains` to start a service on its port only, leaving any existing domain route owner in place
+- SDK `service.start({ domains: [] })` starts a service without claiming any domain
+
 ## [0.7.0] - 2026-06-17
 
 Git worktree support is the headline of this release: run the same project's services side by side from separate worktrees, target a sibling worktree without changing directories, and have denvig resolve the right config wherever you run it.

--- a/packages/cli/src/commands/services/start.test.ts
+++ b/packages/cli/src/commands/services/start.test.ts
@@ -12,7 +12,13 @@ describe('servicesStartCommand', () => {
   it('should have correct usage', () => {
     ok(
       servicesStartCommand.usage ===
-        'services start <name> [--worktree <branch>] [--port <port>] [--domains <list>]',
+        'services start <name> [--worktree <branch>] [--port <port>] [--domains <list>] [--no-domains]',
     )
+  })
+
+  it('should expose a boolean --no-domains flag', () => {
+    const flag = servicesStartCommand.flags.find((f) => f.name === 'no-domains')
+    ok(flag)
+    ok(flag.type === 'boolean')
   })
 })

--- a/packages/cli/src/commands/services/start.ts
+++ b/packages/cli/src/commands/services/start.ts
@@ -10,7 +10,7 @@ export const servicesStartCommand = new Command({
   name: 'services:start',
   description: 'Start a service',
   usage:
-    'services start <name> [--worktree <branch>] [--port <port>] [--domains <list>]',
+    'services start <name> [--worktree <branch>] [--port <port>] [--domains <list>] [--no-domains]',
   example: 'services start api',
   args: [
     {
@@ -42,6 +42,13 @@ export const servicesStartCommand = new Command({
         'Comma-separated domains to route to this start, replacing the configured ones and claiming them from any current owner (handed back on stop)',
       required: false,
       type: 'string',
+    },
+    {
+      name: 'no-domains',
+      description:
+        'Start without claiming any domain — run on the port only and leave any existing route owner in place (takes precedence over --domains)',
+      required: false,
+      type: 'boolean',
     },
   ],
   completions: ({ project, sdk }) => {
@@ -103,7 +110,11 @@ export const servicesStartCommand = new Command({
     const result = await manager.startService(serviceName, {
       port: portResolution.port,
       portResolved: true,
-      domains: domains && domains.length > 0 ? domains : undefined,
+      domains: flags['no-domains']
+        ? []
+        : domains && domains.length > 0
+          ? domains
+          : undefined,
     })
 
     if (!result.success) {

--- a/packages/sdk/src/lib/services/manager.test.ts
+++ b/packages/sdk/src/lib/services/manager.test.ts
@@ -1,5 +1,5 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: The print function is overridden for mocking, easier to use any */
-import { ok, strictEqual } from 'node:assert'
+import { deepStrictEqual, ok, strictEqual } from 'node:assert'
 import {
   mkdirSync,
   mkdtempSync,
@@ -714,6 +714,76 @@ describe('ServiceManager', () => {
       })
       ok(result.success, result.message)
 
+      const route = await getGatewayRoute('hello.denvig.me')
+      strictEqual(route?.project, worktree.id)
+      strictEqual(route?.port, 9001)
+      strictEqual(
+        await manager.getServiceUrl('hello'),
+        'http://hello.denvig.me',
+      )
+    })
+
+    it('claims nothing when started with an empty domains array', async (t) => {
+      const worktree = createWorktreeProject()
+      const manager = new ServiceManager(worktree)
+      mockLaunchctlStart(t)
+
+      const result = await manager.startService('hello', {
+        port: 9001,
+        portResolved: true,
+        domains: [],
+      })
+      ok(result.success, result.message)
+
+      // The desired state records the empty claim verbatim so the reconciler
+      // keeps re-applying "no domains".
+      const state = await getServiceState(worktree.id, 'hello')
+      deepStrictEqual(state?.domains, [])
+
+      // No gateway route was registered for the configured domain.
+      strictEqual(await getGatewayRoute('hello.denvig.me'), null)
+
+      // The canonical URL falls back to the localhost form.
+      strictEqual(await manager.getServiceUrl('hello'), 'http://localhost:9001')
+    })
+
+    it('does not steal a domain owned by another running service when started with []', async (t) => {
+      const original = createOriginalProject()
+      await seedRunningOriginal(original)
+      const worktree = createWorktreeProject()
+      const manager = new ServiceManager(worktree)
+      mockLaunchctlStart(t)
+
+      const result = await manager.startService('hello', {
+        port: 9001,
+        portResolved: true,
+        domains: [],
+      })
+      ok(result.success, result.message)
+
+      // The original service keeps ownership of the configured domain.
+      const route = await getGatewayRoute('hello.denvig.me')
+      strictEqual(route?.project, original.id)
+      strictEqual(route?.port, 8080)
+      strictEqual(route?.desiredStatus, 'running')
+
+      // The worktree start runs on its port only.
+      strictEqual(await manager.getServiceUrl('hello'), 'http://localhost:9001')
+    })
+
+    it('claims the configured domain when started with omitted domains', async (t) => {
+      const worktree = createWorktreeProject()
+      const manager = new ServiceManager(worktree)
+      mockLaunchctlStart(t)
+
+      const result = await manager.startService('hello', {
+        port: 9001,
+        portResolved: true,
+      })
+      ok(result.success, result.message)
+
+      const state = await getServiceState(worktree.id, 'hello')
+      deepStrictEqual(state?.domains, ['hello.denvig.me'])
       const route = await getGatewayRoute('hello.denvig.me')
       strictEqual(route?.project, worktree.id)
       strictEqual(route?.port, 9001)

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -315,7 +315,9 @@ export class ServiceManager {
    *   replacing the domains declared in the service config. Each domain is
    *   claimed unconditionally — any existing route is taken over and handed
    *   back to a running owner when this service stops. When omitted, the
-   *   configured domains are used.
+   *   configured domains are used. Pass an empty array to start the service
+   *   without claiming any domain (it runs on its port only and does not take
+   *   over an existing route).
    * @param options.reviveIfNotRunning - When the service is already
    *   bootstrapped with an unchanged plist but isn't currently running,
    *   bootout and bootstrap again to kick it (`true`, the default — what an
@@ -392,10 +394,10 @@ export class ServiceManager {
     const configuredDomains = config.http?.domain
       ? [config.http.domain, ...(config.http.cnames ?? [])]
       : []
-    const domains =
-      options?.domains && options.domains.length > 0
-        ? options.domains
-        : configuredDomains
+    // A provided array is honoured verbatim, including an empty one: `[]`
+    // means "claim nothing" (run on the port only, don't take over a route).
+    // Only an omitted `domains` falls back to the configured domains.
+    const domains = options?.domains ?? configuredDomains
     await updateServiceState(this.project.id, name, {
       cwd: this.resolveServiceCwd(config),
       port: effectivePort,
@@ -1138,10 +1140,10 @@ export class ServiceManager {
       const configuredDomains = config.http.domain
         ? [config.http.domain, ...(config.http.cnames ?? [])]
         : []
-      const candidates =
-        state?.domains && state.domains.length > 0
-          ? state.domains
-          : configuredDomains
+      // An explicit empty array in state means "claim nothing" — honour it
+      // verbatim so the canonical URL falls back to the localhost form. Only
+      // an absent `domains` (state never recorded) uses the configured set.
+      const candidates = state?.domains ?? configuredDomains
       for (const domain of candidates) {
         if (await ownsRunningRoute(domain)) {
           return `${protocol}://${domain}`

--- a/packages/sdk/src/lib/services/reconcile.ts
+++ b/packages/sdk/src/lib/services/reconcile.ts
@@ -199,6 +199,11 @@ export const reconcileServices = async (): Promise<ReconcileResult> => {
         // recorded by an older version.
         port: entry.config?.http ? entry.port : undefined,
         portResolved: true,
+        // Re-apply the exact domain claim recorded in state rather than
+        // recomputing from config. This preserves a "no claim" start
+        // (domains: []) — without it, the reconciler would re-expand to the
+        // configured domains and steal a route the user chose not to take.
+        domains: entry.domains,
         // Liveness is launchd's job — only re-bootstrap on a real plist
         // change, never just because the process is momentarily down.
         reviveIfNotRunning: false,

--- a/packages/sdk/src/operations/services.ts
+++ b/packages/sdk/src/operations/services.ts
@@ -257,7 +257,9 @@ export type StartServiceOptions = ServiceOperationOptions & {
    * Explicit domains to route to this start, replacing the domains declared
    * in the service config. Each domain is claimed unconditionally — any
    * existing route is taken over and handed back to a running owner when
-   * this service stops. When omitted, the configured domains are used.
+   * this service stops. When omitted, the configured domains are used. Pass
+   * an empty array to start the service without claiming any domain (it runs
+   * on its port only and does not take over an existing route).
    */
   domains?: string[]
   /**

--- a/packages/sdk/src/resources/service.ts
+++ b/packages/sdk/src/resources/service.ts
@@ -14,7 +14,9 @@ export type ServiceStartOptions = {
    * Explicit domains to route to this start, replacing the domains declared
    * in the service config. Each domain is claimed unconditionally — any
    * existing route is taken over and handed back to a running owner when
-   * this service stops. When omitted, the configured domains are used.
+   * this service stops. When omitted, the configured domains are used. Pass
+   * an empty array to start the service without claiming any domain (it runs
+   * on its port only and does not take over an existing route).
    */
   domains?: string[]
   /**


### PR DESCRIPTION
## Summary

Adds a way to start a service on its port only, **without** taking over its configured domain route. Previously `startService()` always claimed the configured `http.domain` (plus `cnames`) on every start, so starting any worktree's copy of a service stole the domain from whichever checkout currently owned it.

The new contract for the `domains` start option:

| `domains` argument    | Behaviour                                                            |
| --------------------- | ------------------------------------------------------------------- |
| omitted / `undefined` | unchanged — claim the configured domains                            |
| non-empty array       | unchanged — claim exactly those (take over routes)                  |
| **empty array `[]`**  | **new** — claim nothing; run on the port only; don't steal a route  |

## Changes

- **`startService()`** honours an explicit empty `domains` array verbatim (`options?.domains ?? configuredDomains`) instead of treating `[]` the same as omitted.
- **`getServiceUrl()`** had the same length-guard bug — with `domains: []` in state it would coalesce back to the configured domain. Now it falls back to the localhost form, so `url === localUrl` for an empty claim.
- **Reconciler** now re-applies the persisted domain claim from state rather than recomputing from config. Without this, the reconcile that runs right after `services start` would re-expand `[]` back to the configured domain and steal the route. This also fixes explicit `--domains` overrides being reverted on reconcile.
- **CLI**: added a `--no-domains` flag to `services start` (takes precedence over `--domains`).
- Updated the `domains` doc comments in `resources/service.ts`, `operations/services.ts`, and `manager.ts`.

`restartService()` semantics are intentionally unchanged (a restart retains whatever domains the running service already had).

## Tests

- New `manager.test.ts` cases: `[]` claims nothing and registers no gateway route; `[]` does not steal a domain owned by another running service; omitted still claims the configured domains; non-empty override claims exactly those.
- CLI test asserts the new `--no-domains` flag.
- Full suite (SDK + CLI) green; lint, type-check, and build pass.

## Follow-up (separate repo)

This unblocks upvio/devbox toggling a service on without claiming its domain — the "Activate" button remains the explicit takeover.