### PR TITLE
Fix service state sync and make config-change restarts visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 - `services start` accepts `--no-domains` to start a service on its port only, leaving any existing domain route owner in place
 - SDK `service.start({ domains: [] })` starts a service without claiming any domain
+- `services start` and `gateway configure` now print a diff of what config changed whenever they restart a service
+
+### Changed
+
+- `services start` on a service that is already running with matching config now skips straight to its links/ports with an "is already running" message instead of waiting
+- `services start` now uses the same "config changed since last bootstrap" wording (and shows the diff) as the reconciler when it restarts a running service to apply config changes
+
+### Fixed
+
+- `services start` and `gateway configure` no longer report every running service as restarted on each run; running services are now only flagged when their config actually changed
+- A running service whose config changed (e.g. a new port, command or env) is now actually restarted to apply the change, instead of reporting a restart that never happened
 
 ## [0.7.0] - 2026-06-17
 

--- a/packages/cli/src/commands/gateway/configure.ts
+++ b/packages/cli/src/commands/gateway/configure.ts
@@ -34,6 +34,15 @@ export const gatewayConfigureCommand = new Command({
           console.log(
             `${icon} ${action.type} ${action.project}/${action.service} — ${action.reason}`,
           )
+          if (
+            action.type === 'restarted' &&
+            action.diff &&
+            action.diff.length > 0
+          ) {
+            for (const line of action.diff) {
+              console.log(`    ${line}`)
+            }
+          }
         }
         console.log('')
       }

--- a/packages/cli/src/commands/services/start.ts
+++ b/packages/cli/src/commands/services/start.ts
@@ -1,3 +1,4 @@
+import { CONFIG_CHANGED_REASON } from '@denvig/sdk/internal'
 import { z } from 'zod'
 
 import { Command } from '../../lib/command.ts'
@@ -103,10 +104,6 @@ export const servicesStartCommand = new Command({
             .filter(Boolean)
         : undefined
 
-    if (!flags.json) {
-      console.log(`Starting ${projectPrefix}${serviceName}...`)
-    }
-
     const result = await manager.startService(serviceName, {
       port: portResolution.port,
       portResolved: true,
@@ -135,8 +132,30 @@ export const servicesStartCommand = new Command({
       return { success: false, message: result.message }
     }
 
-    // Wait for service to start
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    // An already-running service with matching config was left untouched — it's
+    // already up. A running service whose config changed was restarted in place
+    // to apply it (`configDiff` carries what changed). Anything else is a plain
+    // launch. The wording mirrors the reconciler / `gateway configure` so a
+    // restart reads the same however it was triggered.
+    const alreadyRunning = result.alreadyRunning === true
+    const restartedForConfig =
+      !alreadyRunning && !!result.configDiff && result.configDiff.length > 0
+    if (!alreadyRunning) {
+      if (!flags.json) {
+        if (restartedForConfig) {
+          console.log(
+            `↻ Restarting ${projectPrefix}${serviceName} — ${CONFIG_CHANGED_REASON}`,
+          )
+          for (const line of result.configDiff ?? []) {
+            console.log(`    ${line}`)
+          }
+        } else {
+          console.log(`Starting ${projectPrefix}${serviceName}...`)
+        }
+      }
+      // Wait for service to start
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    }
 
     // Get service response
     const response = await manager.getServiceResponse(serviceName, {
@@ -153,7 +172,11 @@ export const servicesStartCommand = new Command({
       } else {
         const urlInfo = response.url ? ` → ${response.url}` : ''
         console.log(
-          `✓ ${projectPrefix}${serviceName} started successfully${urlInfo}`,
+          alreadyRunning
+            ? `✓ ${projectPrefix}${serviceName} is already running${urlInfo}`
+            : restartedForConfig
+              ? `✓ ${projectPrefix}${serviceName} restarted${urlInfo}`
+              : `✓ ${projectPrefix}${serviceName} started successfully${urlInfo}`,
         )
         const showLocal =
           response.localUrl &&

--- a/packages/cli/src/lib/services/reconcileLogger.ts
+++ b/packages/cli/src/lib/services/reconcileLogger.ts
@@ -26,6 +26,15 @@ export const reconcileAfterCommand = async (options: {
       console.log(
         `${icon} ${action.type} ${action.project}/${action.service} — ${action.reason}`,
       )
+      if (
+        action.type === 'restarted' &&
+        action.diff &&
+        action.diff.length > 0
+      ) {
+        for (const line of action.diff) {
+          console.log(`    ${line}`)
+        }
+      }
     }
     for (const err of result.errors) {
       console.error(`reconcile: ${err.project}/${err.service}: ${err.message}`)

--- a/packages/sdk/src/internal.ts
+++ b/packages/sdk/src/internal.ts
@@ -25,7 +25,10 @@ export { getNginxConfigPath } from './lib/gateway/nginx.ts'
 export { gitPull, isWorkingTreeDirty } from './lib/project/git.ts'
 export { default as launchctl } from './lib/services/launchctl.ts'
 export { ServiceManager } from './lib/services/manager.ts'
-export { reconcileServices } from './lib/services/reconcile.ts'
+export {
+  CONFIG_CHANGED_REASON,
+  reconcileServices,
+} from './lib/services/reconcile.ts'
 export { getGatewayRoute, setGatewayRoute } from './lib/services/state.ts'
 export { brewUpdate, brewUpgrade, getBrewOutdated } from './lib/system/brew.ts'
 export { runDenvig } from './lib/system/denvig.ts'

--- a/packages/sdk/src/lib/services/diff.test.ts
+++ b/packages/sdk/src/lib/services/diff.test.ts
@@ -1,0 +1,35 @@
+import { deepStrictEqual } from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { diffLines } from './diff.ts'
+
+describe('diff', () => {
+  describe('diffLines()', () => {
+    it('returns an empty array for identical input', () => {
+      deepStrictEqual(diffLines('a\nb\nc', 'a\nb\nc'), [])
+    })
+
+    it('marks a changed line with - and + plus surrounding context', () => {
+      deepStrictEqual(diffLines('a\nb\nc', 'a\nB\nc'), [' a', '-b', '+B', ' c'])
+    })
+
+    it('shows additions and removals', () => {
+      deepStrictEqual(diffLines('a\nb', 'a\nb\nc'), [' a', ' b', '+c'])
+      deepStrictEqual(diffLines('a\nb\nc', 'a\nc'), [' a', '-b', ' c'])
+    })
+
+    it('collapses long unchanged runs between changes', () => {
+      const before = ['x', '1', '2', '3', '4', '5', '6', 'y'].join('\n')
+      const after = ['X', '1', '2', '3', '4', '5', '6', 'Y'].join('\n')
+      deepStrictEqual(diffLines(before, after, 1), [
+        '-x',
+        '+X',
+        ' 1',
+        ' …',
+        ' 6',
+        '-y',
+        '+Y',
+      ])
+    })
+  })
+})

--- a/packages/sdk/src/lib/services/diff.ts
+++ b/packages/sdk/src/lib/services/diff.ts
@@ -1,0 +1,79 @@
+/**
+ * Produce a unified-style line diff between two text blocks. Returns the
+ * changed hunks — each changed line prefixed with `-` (removed) or `+`
+ * (added), surrounded by a few lines of unchanged context prefixed with a
+ * space. Long unchanged runs are collapsed to a single `…` marker. Returns an
+ * empty array when the inputs are identical.
+ *
+ * @param before - Previous text.
+ * @param after - New text.
+ * @param context - Unchanged lines to keep around each change (default 2).
+ */
+export function diffLines(
+  before: string,
+  after: string,
+  context = 2,
+): string[] {
+  const a = before.split('\n')
+  const b = after.split('\n')
+  const m = a.length
+  const n = b.length
+
+  // Longest common subsequence table, filled from the bottom-right.
+  const lcs: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array<number>(n + 1).fill(0),
+  )
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      lcs[i][j] =
+        a[i] === b[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1])
+    }
+  }
+
+  // Backtrack into a flat list of edit operations.
+  type Op = { type: ' ' | '-' | '+'; line: string }
+  const ops: Op[] = []
+  let i = 0
+  let j = 0
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      ops.push({ type: ' ', line: a[i] })
+      i++
+      j++
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      ops.push({ type: '-', line: a[i] })
+      i++
+    } else {
+      ops.push({ type: '+', line: b[j] })
+      j++
+    }
+  }
+  while (i < m) ops.push({ type: '-', line: a[i++] })
+  while (j < n) ops.push({ type: '+', line: b[j++] })
+
+  if (!ops.some((op) => op.type !== ' ')) return []
+
+  // Keep changed lines plus `context` unchanged lines on either side.
+  const keep = new Array<boolean>(ops.length).fill(false)
+  ops.forEach((op, idx) => {
+    if (op.type === ' ') return
+    const from = Math.max(0, idx - context)
+    const to = Math.min(ops.length - 1, idx + context)
+    for (let k = from; k <= to; k++) keep[k] = true
+  })
+
+  const out: string[] = []
+  let collapsed = false
+  ops.forEach((op, idx) => {
+    if (keep[idx]) {
+      out.push(`${op.type}${op.line}`)
+      collapsed = false
+    } else if (!collapsed) {
+      out.push(' …')
+      collapsed = true
+    }
+  })
+  return out
+}

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -15,6 +15,7 @@ import { basename, resolve } from 'node:path'
 
 import { findCertForDomain, resolveSslPaths } from '../gateway/certs.ts'
 import { configureGateway } from '../gateway/configure.ts'
+import { diffLines } from './diff.ts'
 import { DEFAULT_ENV_FILES, loadEnvFiles } from './env.ts'
 import launchctl, { type LaunchctlListItem } from './launchctl.ts'
 import { generatePlist, generateServiceScript } from './plist.ts'
@@ -510,8 +511,22 @@ export class ServiceManager {
       // File doesn't exist yet
     }
     const plistChanged = existingPlistContent !== plistContent
-    if (plistChanged) {
-      await writeFile(plistPath, plistContent, 'utf-8')
+    // Diff the rendered config so callers can show *what* changed (and hence
+    // why a running service needs restarting). Only when an earlier plist
+    // existed — a freshly created one has nothing to compare against.
+    const configDiff =
+      plistChanged && existingPlistContent !== null
+        ? diffLines(existingPlistContent, plistContent)
+        : undefined
+
+    // The plist is written only as part of an actual (re)bootstrap below, never
+    // eagerly. Writing it without relaunching would let the on-disk plist run
+    // ahead of the live process: a later reconcile would then see plist ==
+    // desired and skip, leaving the process stuck on its old config forever.
+    // Keeping the write paired with the bootstrap means an unchanged plist is a
+    // reliable signal that the running process is already up to date.
+    const writePlist = async () => {
+      if (plistChanged) await writeFile(plistPath, plistContent, 'utf-8')
     }
 
     // Enable service so launchd will start it (reverses disable from stop)
@@ -521,6 +536,7 @@ export class ServiceManager {
     // The reconciler relies on this being idempotent: if the plist is
     // unchanged and the service is already bootstrapped, do nothing.
     if (!isBootstrapped) {
+      await writePlist()
       const bootstrapResult = await launchctl.bootstrap(plistPath)
       if (!bootstrapResult.success) {
         return {
@@ -529,25 +545,27 @@ export class ServiceManager {
           message: `Failed to bootstrap service: ${bootstrapResult.output}`,
         }
       }
-    } else if (isLive) {
-      // The service is already running — never tear it down on `start`. The
-      // gateway routes (including any newly claimed domains) were updated in
-      // state above and the caller refreshes the gateway, so domain changes
-      // take effect without restarting the process. A changed plist has been
-      // written to disk and applies on the next explicit `services restart`.
+    } else if (isLive && !plistChanged) {
+      // The service is already running with an up-to-date plist. Domains live
+      // in the gateway routes, not the plist, so a domain-only change leaves
+      // the plist untouched: the routes were written to state above and the
+      // caller refreshes the gateway, applying the change without interrupting
+      // the process. Nothing to restart.
       return {
         name,
         success: true,
-        message: plistChanged
-          ? 'Service already running; refreshed gateway (run `services restart` to apply config changes)'
-          : 'Service already running; refreshed gateway',
+        message: 'Service already running; refreshed gateway',
+        alreadyRunning: true,
       }
     } else if (plistChanged || options?.reviveIfNotRunning !== false) {
-      // The service is bootstrapped but no longer running. Bootout and
-      // bootstrap again to give launchd a fresh start — for an explicit start
-      // (revival) or because the plist changed. The reconciler opts out of
-      // revival (`reviveIfNotRunning: false`): a bootstrapped service's
-      // liveness is launchd's to manage, so it leaves an unchanged plist alone.
+      // Restart by booting out and bootstrapping again. This covers a running
+      // service whose plist actually changed (a new port, command or env can
+      // only take effect by relaunching the process), a bootstrapped-but-dead
+      // service being revived on an explicit start, or a dead service whose
+      // plist changed. The reconciler opts out of revival
+      // (`reviveIfNotRunning: false`): a bootstrapped service's liveness is
+      // launchd's to manage, so it leaves an unchanged plist alone — but a
+      // genuine config change is still applied here.
       const bootoutResult = await launchctl.bootout(label)
       if (!bootoutResult.success) {
         return {
@@ -559,6 +577,7 @@ export class ServiceManager {
 
       // sleep for 1 second to allow bootout to complete
       await new Promise((resolve) => setTimeout(resolve, 1000))
+      await writePlist()
       const bootstrapResult = await launchctl.bootstrap(plistPath)
       if (!bootstrapResult.success) {
         return {
@@ -574,6 +593,7 @@ export class ServiceManager {
         name,
         success: true,
         message: 'Service already running with current config',
+        alreadyRunning: true,
       }
     }
 
@@ -589,6 +609,7 @@ export class ServiceManager {
       name,
       success: true,
       message: 'Service started successfully',
+      configDiff,
     }
   }
 

--- a/packages/sdk/src/lib/services/reconcile.ts
+++ b/packages/sdk/src/lib/services/reconcile.ts
@@ -15,7 +15,14 @@ import {
 export type ReconcileAction =
   | { type: 'started'; project: string; service: string; reason: string }
   | { type: 'stopped'; project: string; service: string; reason: string }
-  | { type: 'restarted'; project: string; service: string; reason: string }
+  | {
+      type: 'restarted'
+      project: string
+      service: string
+      reason: string
+      /** Unified-style plist diff explaining the config change. */
+      diff?: string[]
+    }
   | { type: 'skipped'; project: string; service: string; reason: string }
 
 export type ReconcileResult = {
@@ -28,6 +35,13 @@ export type ReconcileResult = {
 }
 
 const LABEL_PREFIX = 'denvig.'
+
+/**
+ * Shared reason text shown whenever a running service is restarted because its
+ * rendered config changed. Used by the reconciler, `gateway configure` and
+ * `services start` so the wording stays identical across every surface.
+ */
+export const CONFIG_CHANGED_REASON = 'config changed since last bootstrap'
 
 /**
  * Parse a launchctl label of the form `denvig.{projectId}.{serviceName}`.
@@ -216,20 +230,30 @@ export const reconcileServices = async (): Promise<ReconcileResult> => {
         })
         continue
       }
-      if (start.message === 'Service already running with current config') {
-        result.actions.push({
-          type: 'skipped',
-          project: project.slug,
-          service: entry.serviceName,
-          reason: 'already running with current config',
-        })
-      } else if (launchctlByLabel.has(label)) {
-        result.actions.push({
-          type: 'restarted',
-          project: project.slug,
-          service: entry.serviceName,
-          reason: 'config changed since last bootstrap',
-        })
+      const configChanged = !!start.configDiff && start.configDiff.length > 0
+      if (launchctlByLabel.has(label)) {
+        // The service was already bootstrapped. Only report a restart when the
+        // rendered plist actually changed — otherwise the service was left
+        // running untouched. Without this guard a running service is reported
+        // as "restarted / config changed" on every reconcile, because the
+        // start path returns a "refreshed gateway" message rather than the
+        // "current config" sentinel.
+        if (configChanged) {
+          result.actions.push({
+            type: 'restarted',
+            project: project.slug,
+            service: entry.serviceName,
+            reason: CONFIG_CHANGED_REASON,
+            diff: start.configDiff,
+          })
+        } else {
+          result.actions.push({
+            type: 'skipped',
+            project: project.slug,
+            service: entry.serviceName,
+            reason: 'already running with current config',
+          })
+        }
       } else {
         result.actions.push({
           type: 'started',

--- a/packages/sdk/src/types/responses.ts
+++ b/packages/sdk/src/types/responses.ts
@@ -28,6 +28,18 @@ export type ServiceResult = {
   name: string
   success: boolean
   message: string
+  /**
+   * Unified-style diff of the launchd plist (the rendered service config) when
+   * starting changed it, explaining why the service was — or needs to be —
+   * restarted. Absent when the plist was unchanged or freshly created.
+   */
+  configDiff?: string[]
+  /**
+   * True when the service was already running with matching config and was
+   * left untouched — nothing was (re)started. Callers can skip the wait for a
+   * launch and report "already running" instead.
+   */
+  alreadyRunning?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a service-state bug where `denvig services start` (and `gateway configure`) reported **every** running service as "restarted / config changed" on every run, while genuine config changes never actually reached the running process.

### What was wrong

1. **False positives:** the reconciler mapped any non-"current config" start result to a `restarted` action, so every running service was flagged as restarted on each reconcile — every single time, even with no change.
2. **Changes never applied:** a running service's plist was written **eagerly** but the process was never restarted. Editing a port in `state.json` updated the plist on disk while the process kept running on the old port.
3. **Drift became invisible:** once the plist ran ahead of the process, the next reconcile saw plist == desired and skipped forever, leaving the process permanently stale.

### Changes

- **Truthful classification** — a service is reported as `restarted` only when its rendered plist actually changed; unchanged running services are `skipped`.
- **Apply changes for real** — a running service whose plist changed is genuinely restarted (bootout + bootstrap) to apply a new port/command/env. Domain-only changes don't touch the plist, so the "don't interrupt for domain claims" guarantee is preserved.
- **No more hidden drift** — the plist is written only as part of an actual (re)bootstrap, so the on-disk plist always mirrors the live process.
- **Show what changed** — `services start`, `gateway configure` and the reconciler print a unified diff of the config change, using shared `config changed since last bootstrap` wording.
- **Already-running shortcut** — `services start` on a service that's already running with matching config skips the launch wait and reports `is already running`, then shows the links/ports.

### Output examples

Already running:
```
✓ hello is already running → https://hello.denvig.me
  ↳ direct: http://localhost:8130
```

Running, config changed:
```
↻ Restarting hello — config changed since last bootstrap
     …
    -    <string>8125</string>
    +    <string>8130</string>
     …
✓ hello restarted → https://hello.denvig.me
  ↳ direct: http://localhost:8130
```

## Testing

- `pnpm run test` — all 695 tests pass (incl. new `diff.ts` unit tests)
- `pnpm run lint` / `pnpm run codegen` — clean
- Verified end-to-end: editing the port in `state.json` + `gateway configure` now actually moves the process to the new port and shows the diff