### PR TITLE
Show worktree services by default in denvig services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- `services` now nests each project's worktree services by default; pass `--no-worktrees` to list only the main project's services
 - `services start` on a service that is already running with matching config now skips straight to its links/ports with an "is already running" message instead of waiting
 - `services start` now uses the same "config changed since last bootstrap" wording (and shows the diff) as the reconciler when it restarts a running service to apply config changes
 

--- a/packages/cli/src/commands/services/list.test.ts
+++ b/packages/cli/src/commands/services/list.test.ts
@@ -12,7 +12,7 @@ describe('servicesListCommand', () => {
   it('should have correct usage', () => {
     ok(
       servicesListCommand.usage ===
-        'services list [--all] [--worktrees] [--global] [--worktree <branch>] [--status <status>]',
+        'services list [--all] [--no-worktrees] [--global] [--worktree <branch>] [--status <status>]',
     )
   })
 })

--- a/packages/cli/src/commands/services/list.ts
+++ b/packages/cli/src/commands/services/list.ts
@@ -22,7 +22,7 @@ export const servicesListCommand = new Command({
   name: 'services:list',
   description: 'List services for the current project',
   usage:
-    'services list [--all] [--worktrees] [--global] [--worktree <branch>] [--status <status>]',
+    'services list [--all] [--no-worktrees] [--global] [--worktree <branch>] [--status <status>]',
   example: 'services list',
   args: [],
   flags: [
@@ -34,9 +34,9 @@ export const servicesListCommand = new Command({
       defaultValue: false,
     },
     {
-      name: 'worktrees',
+      name: 'no-worktrees',
       description:
-        "Nest each project's worktree services beneath it. Pair with --all to show worktrees for every project.",
+        "Only list the current project's services, hiding the worktree services nested beneath them.",
       required: false,
       type: 'boolean',
       defaultValue: false,
@@ -69,11 +69,15 @@ export const servicesListCommand = new Command({
   handler: async ({ project, flags }) => {
     const all = flags.all as boolean
     const globalOnly = flags.global as boolean
-    const showWorktrees = flags.worktrees as boolean
+    const noWorktrees = flags['no-worktrees'] as boolean
     const worktreeFlag =
       typeof flags.worktree === 'string' ? flags.worktree : undefined
     const statusFlag =
       typeof flags.status === 'string' ? flags.status : undefined
+
+    // Worktrees nest by default; --no-worktrees, --global and --worktree each
+    // collapse to a single scope.
+    const showWorktrees = !noWorktrees && !globalOnly && !worktreeFlag
 
     let filteredServices: ServiceRow[]
     try {

--- a/packages/sdk/src/operations/services.ts
+++ b/packages/sdk/src/operations/services.ts
@@ -19,7 +19,11 @@ export type ListServicesOptions = {
   all?: boolean
   /** List only global services. */
   global?: boolean
-  /** Nest each project's worktree services beneath it. */
+  /**
+   * Nest each project's worktree services beneath it. Defaults to `true`;
+   * pass `false` to list only the primary checkout's services. Targeting a
+   * single worktree or the global scope disables nesting on its own.
+   */
   worktrees?: boolean
   /** Target a sibling git worktree by branch name (use "main" for primary). */
   worktree?: string
@@ -75,8 +79,12 @@ export const collectServiceRows = async (
 ): Promise<ServiceRow[]> => {
   const all = !!options.all
   const globalOnly = !!options.global
-  const showWorktrees = !!options.worktrees
   const worktreeFlag = options.worktree ?? null
+  // Worktrees are nested by default. Targeting a single worktree or the global
+  // scope is a narrower view, so it implicitly turns nesting off unless the
+  // caller explicitly asked for it (which is then a contradiction).
+  const showWorktrees =
+    options.worktrees ?? (!globalOnly && worktreeFlag === null)
   const statusFilter = normalizeStatusFilter(options.status)
 
   if ((all || globalOnly) && worktreeFlag !== null) {
@@ -84,7 +92,7 @@ export const collectServiceRows = async (
       'worktree cannot be combined with all or global.',
     )
   }
-  if (showWorktrees && (globalOnly || worktreeFlag !== null)) {
+  if (options.worktrees === true && (globalOnly || worktreeFlag !== null)) {
     throw new DenvigValidationError(
       'worktrees cannot be combined with global or worktree.',
     )


### PR DESCRIPTION
## Summary

Makes worktree services the default view for `denvig services` and the SDK `services.list()`.

Previously worktrees only appeared when `--worktrees` was passed. Now each project's worktree services nest under it by default, and the new `--no-worktrees` flag collapses the view to just the main project's services.

## Changes

- **CLI** (`services list`): replaced `--worktrees` with `--no-worktrees`. Nesting is on by default; `--no-worktrees`, `--global`, and `--worktree` each collapse to a single scope.
- **SDK** (`services.list()`): the `worktrees` option now defaults to `true`, derived as `options.worktrees ?? (!global && !worktree)` so narrower scopes implicitly disable nesting. The contradiction guard only fires when a caller *explicitly* passes `worktrees: true` alongside `global`/`worktree`.
- Updated the usage string, its test, and the changelog.

## Behaviour

| Command | Result |
| --- | --- |
| `denvig services` | nests worktree services under each project (new default) |
| `denvig services --no-worktrees` | only the main project's services |
| `denvig services --global` / `--worktree <branch>` | unchanged single-scope view |
| `denvig services --all` | nests worktrees across all projects |

## Verification

- `pnpm run codegen`, `lint`, `test` (125 pass), and `build` all green
- Manually confirmed each scope above, plus the bare SDK `project.services.list()` returning nested worktree rows
