### PR TITLE
Align status icons to a consistent width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Service and project status icons are now all the same width, so running and stopped rows line up in the list
 - `services start` and `gateway configure` no longer report every running service as restarted on each run; running services are now only flagged when their config actually changed
 - A running service whose config changed (e.g. a new port, command or env) is now actually restarted to apply the change, instead of reporting a restart that never happened
 

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -1,17 +1,7 @@
 import { prettyPath } from '@denvig/sdk/utils'
 
 import { Command } from '../lib/command.ts'
-
-const getStatusIcon = (status: 'running' | 'stopped' | 'none'): string => {
-  switch (status) {
-    case 'running':
-      return '🟢'
-    case 'stopped':
-      return '◯'
-    default:
-      return ''
-  }
-}
+import { statusIcon } from '../lib/formatters/status-icon.ts'
 
 export const infoCommand = new Command({
   name: 'info',
@@ -28,8 +18,8 @@ export const infoCommand = new Command({
       return { success: true }
     }
 
-    const statusIcon = getStatusIcon(info.serviceStatus)
-    const statusText = statusIcon ? `${statusIcon} ` : ''
+    const icon = statusIcon(info.serviceStatus)
+    const statusText = icon ? `${icon} ` : ''
 
     console.log(`${statusText}${info.config?.name || info.slug}`)
     console.log(`   Path: ${prettyPath(info.path)}`)

--- a/packages/cli/src/commands/projects/list.ts
+++ b/packages/cli/src/commands/projects/list.ts
@@ -2,6 +2,7 @@ import { type LaunchctlListItem, launchctl } from '@denvig/sdk/internal'
 import { prettyPath } from '@denvig/sdk/utils'
 
 import { Command } from '../../lib/command.ts'
+import { statusIcon } from '../../lib/formatters/status-icon.ts'
 
 import type {
   DenvigProject,
@@ -10,17 +11,6 @@ import type {
 } from '@denvig/sdk'
 
 type ProjectInfoJSON = Omit<ProjectInfo, 'serviceStatus'>
-
-const getStatusIcon = (status: ProjectServiceStatus): string => {
-  switch (status) {
-    case 'running':
-      return '🟢'
-    case 'stopped':
-      return '◯'
-    default:
-      return ''
-  }
-}
 
 /** A row in the rendered list: a project, or one of its worktrees. */
 type ProjectRow = {
@@ -116,7 +106,7 @@ export const projectsListCommand = new Command({
     for (const r of rows) {
       // Service icon in a fixed left column, one space, the name (padded), one
       // space, then the path.
-      const icon = getStatusIcon(r.status) || ' '
+      const icon = statusIcon(r.status) || ' '
       const name = nameCell(r).padEnd(nameWidth)
       console.log(`${icon} ${name} ${prettyPath(r.path)}`)
     }

--- a/packages/cli/src/commands/services/list.ts
+++ b/packages/cli/src/commands/services/list.ts
@@ -5,18 +5,8 @@ import {
 } from '@denvig/sdk'
 
 import { Command } from '../../lib/command.ts'
+import { statusIcon } from '../../lib/formatters/status-icon.ts'
 import { formatTable } from '../../lib/formatters/table.ts'
-
-const getStatusIcon = (status: 'running' | 'error' | 'stopped'): string => {
-  switch (status) {
-    case 'running':
-      return '🟢'
-    case 'error':
-      return '🔴'
-    default:
-      return '◯'
-  }
-}
 
 export const servicesListCommand = new Command({
   name: 'services:list',
@@ -142,7 +132,7 @@ export const servicesListCommand = new Command({
       columns: [
         {
           header: '',
-          accessor: (r) => getStatusIcon(r.service.status),
+          accessor: (r) => statusIcon(r.service.status),
         },
         ...(showProjectColumn
           ? [

--- a/packages/cli/src/lib/formatters/status-icon.ts
+++ b/packages/cli/src/lib/formatters/status-icon.ts
@@ -1,0 +1,25 @@
+import { COLORS } from './table.ts'
+
+/** Runtime status values rendered across the various list/info commands. */
+export type StatusIconState = 'running' | 'error' | 'stopped' | 'none'
+
+/**
+ * Render a single-width status circle for a service or project.
+ *
+ * All states use the same glyph width so columns stay aligned: a filled
+ * circle (`●`) for active states and a hollow circle (`○`) for stopped.
+ * Colour is applied via ANSI codes rather than wide emoji, which would
+ * otherwise occupy two cells and misalign the running row.
+ */
+export const statusIcon = (status: StatusIconState): string => {
+  switch (status) {
+    case 'running':
+      return `${COLORS.green}●${COLORS.reset}`
+    case 'error':
+      return `${COLORS.red}●${COLORS.reset}`
+    case 'stopped':
+      return `${COLORS.grey}○${COLORS.reset}`
+    default:
+      return ''
+  }
+}


### PR DESCRIPTION
## Summary

Service and project status icons rendered at inconsistent widths: the running/error states used double-width emoji (`🟢`/`🔴`) while the stopped state used a single-width glyph (`◯`). This pushed the running row one cell wider than the others, misaligning the table.

## Changes

- Add a shared `statusIcon` helper (`packages/cli/src/lib/formatters/status-icon.ts`) that renders single-width Unicode circles colored via ANSI:
  - `●` green — running
  - `●` red — error
  - `○` grey — stopped
  - empty — none
- Replace the three duplicated `getStatusIcon` functions in `services list`, `info`, and `projects list` with the shared helper.

Colour comes from the existing `COLORS` helper, which the table formatter already strips when computing column widths, so all states now occupy exactly one cell and rows line up.

## Verification

- `pnpm run lint` — clean
- `pnpm run codegen` — clean
- `pnpm run test` — 125 passing
- `bin/denvig-dev services` renders running/stopped rows aligned