### PR TITLE
Add docker runtime for services

### DIFF
--- a/.denvig.yml
+++ b/.denvig.yml
@@ -17,6 +17,23 @@ services:
       domain: hello.denvig.me
       cnames:
         - hello.denvig.localhost
+  hello-linux:
+    runtime: docker
+    image: node:22-alpine
+    container:
+      mountProject: true
+    command: |
+      node -e "require('http').createServer((req, res) => { res.writeHead(200, {'Content-Type': 'text/plain'}); res.end('Hello from denvig container at ' + process.cwd() + '\n'); }).listen(process.env.PORT, () => console.log('hello-linux listening on ' + process.env.PORT + ' in ' + process.cwd()))"
+    http:
+      port: 8081
+  redis:
+    runtime: docker
+    image: redis:8.8
+    container:
+      mountProject: false
+    http:
+      port: 16379
+      containerPort: 6379
   wontlaunch:
     command: |
       node -e "throw new Error('This service is intended to fail to launch')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Added
 
-- Services can now run in a docker container with `runtime: docker`, mounting the project at `/denvig/project` with the working directory set to the service's location within it (set `image:` to pick the image, defaults to `alpine:3.23`)
-- Container services support `http.containerPort` to map the host port to a different port inside the container (e.g. `port: 16379` → `containerPort: 6379`)
-- Container services support `container.mountProject: false` to run without mounting the project directory (handy for utility services like a database)
-- Container services support `container.volumes` to add bind mounts (relative host paths resolve against the service directory) and `container.ports` to publish extra ports
-- Docker services may omit `command` and use the image's default entrypoint; `command` is still required for host services
+- Services can now run in a docker container with `runtime: docker`, mounting the project at `/denvig/project` with the working directory set to the service's location within it
 
 ## [0.7.1] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Services can now run in a docker container with `runtime: docker`, mounting the project at `/denvig/project` with the working directory set to the service's location within it (set `image:` to pick the image, defaults to `alpine:3.23`)
+- Container services support `http.containerPort` to map the host port to a different port inside the container (e.g. `port: 16379` → `containerPort: 6379`)
+- Container services support `container.mountProject: false` to run without mounting the project directory (handy for utility services like a database)
+
 ## [0.7.1] - 2026-06-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Services can now run in a docker container with `runtime: docker`, mounting the project at `/denvig/project` with the working directory set to the service's location within it (set `image:` to pick the image, defaults to `alpine:3.23`)
 - Container services support `http.containerPort` to map the host port to a different port inside the container (e.g. `port: 16379` → `containerPort: 6379`)
 - Container services support `container.mountProject: false` to run without mounting the project directory (handy for utility services like a database)
+- Container services support `container.volumes` to add bind mounts (relative host paths resolve against the service directory) and `container.ports` to publish extra ports
 - Docker services may omit `command` and use the image's default entrypoint; `command` is still required for host services
 
 ## [0.7.1] - 2026-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Services can now run in a docker container with `runtime: docker`, mounting the project at `/denvig/project` with the working directory set to the service's location within it (set `image:` to pick the image, defaults to `alpine:3.23`)
 - Container services support `http.containerPort` to map the host port to a different port inside the container (e.g. `port: 16379` → `containerPort: 6379`)
 - Container services support `container.mountProject: false` to run without mounting the project directory (handy for utility services like a database)
+- Docker services may omit `command` and use the image's default entrypoint; `command` is still required for host services
 
 ## [0.7.1] - 2026-06-20
 

--- a/packages/sdk/schemas/config.global.json
+++ b/packages/sdk/schemas/config.global.json
@@ -42,6 +42,20 @@
               "mountProject": {
                 "type": "boolean",
                 "description": "Mount the project directory at /denvig/project (default true)"
+              },
+              "volumes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Bind mounts passed to docker run as -v (host:container[:options]); relative host paths resolve against the service directory"
+              },
+              "ports": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Published ports passed to docker run as -p (host:container)"
               }
             },
             "additionalProperties": false,

--- a/packages/sdk/schemas/config.global.json
+++ b/packages/sdk/schemas/config.global.json
@@ -108,7 +108,22 @@
             "description": "Start service automatically when system boots"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "if": {
+          "required": [
+            "runtime"
+          ],
+          "properties": {
+            "runtime": {
+              "const": "docker"
+            }
+          }
+        },
+        "else": {
+          "required": [
+            "command"
+          ]
+        }
       },
       "propertyNames": {
         "type": "string",

--- a/packages/sdk/schemas/config.global.json
+++ b/packages/sdk/schemas/config.global.json
@@ -24,6 +24,29 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
+          "runtime": {
+            "type": "string",
+            "enum": [
+              "host",
+              "docker"
+            ],
+            "description": "How the service runs: directly on the host (default) or in a docker container"
+          },
+          "image": {
+            "type": "string",
+            "description": "Container image to run when runtime is \"docker\" (defaults to alpine:3.23)"
+          },
+          "container": {
+            "type": "object",
+            "properties": {
+              "mountProject": {
+                "type": "boolean",
+                "description": "Mount the project directory at /denvig/project (default true)"
+              }
+            },
+            "additionalProperties": false,
+            "description": "Container runtime options used when runtime is \"docker\""
+          },
           "cwd": {
             "type": "string",
             "description": "Working directory for the service (relative to project root)"
@@ -38,6 +61,10 @@
               "port": {
                 "type": "number",
                 "description": "Port number the service listens on"
+              },
+              "containerPort": {
+                "type": "number",
+                "description": "Port the container listens on when runtime is \"docker\" (defaults to the host port)"
               },
               "domain": {
                 "type": "string",
@@ -81,10 +108,7 @@
             "description": "Start service automatically when system boots"
           }
         },
-        "additionalProperties": false,
-        "required": [
-          "command"
-        ]
+        "additionalProperties": false
       },
       "propertyNames": {
         "type": "string",

--- a/packages/sdk/schemas/config.json
+++ b/packages/sdk/schemas/config.json
@@ -56,6 +56,20 @@
               "mountProject": {
                 "type": "boolean",
                 "description": "Mount the project directory at /denvig/project (default true)"
+              },
+              "volumes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Bind mounts passed to docker run as -v (host:container[:options]); relative host paths resolve against the service directory"
+              },
+              "ports": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Published ports passed to docker run as -p (host:container)"
               }
             },
             "additionalProperties": false,

--- a/packages/sdk/schemas/config.json
+++ b/packages/sdk/schemas/config.json
@@ -122,7 +122,22 @@
             "description": "Start service automatically when system boots"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "if": {
+          "required": [
+            "runtime"
+          ],
+          "properties": {
+            "runtime": {
+              "const": "docker"
+            }
+          }
+        },
+        "else": {
+          "required": [
+            "command"
+          ]
+        }
       },
       "propertyNames": {
         "type": "string",

--- a/packages/sdk/schemas/config.json
+++ b/packages/sdk/schemas/config.json
@@ -38,6 +38,29 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
+          "runtime": {
+            "type": "string",
+            "enum": [
+              "host",
+              "docker"
+            ],
+            "description": "How the service runs: directly on the host (default) or in a docker container"
+          },
+          "image": {
+            "type": "string",
+            "description": "Container image to run when runtime is \"docker\" (defaults to alpine:3.23)"
+          },
+          "container": {
+            "type": "object",
+            "properties": {
+              "mountProject": {
+                "type": "boolean",
+                "description": "Mount the project directory at /denvig/project (default true)"
+              }
+            },
+            "additionalProperties": false,
+            "description": "Container runtime options used when runtime is \"docker\""
+          },
           "cwd": {
             "type": "string",
             "description": "Working directory for the service (relative to project root)"
@@ -52,6 +75,10 @@
               "port": {
                 "type": "number",
                 "description": "Port number the service listens on"
+              },
+              "containerPort": {
+                "type": "number",
+                "description": "Port the container listens on when runtime is \"docker\" (defaults to the host port)"
               },
               "domain": {
                 "type": "string",
@@ -95,10 +122,7 @@
             "description": "Start service automatically when system boots"
           }
         },
-        "additionalProperties": false,
-        "required": [
-          "command"
-        ]
+        "additionalProperties": false
       },
       "propertyNames": {
         "type": "string",

--- a/packages/sdk/src/codegen/schema.test.ts
+++ b/packages/sdk/src/codegen/schema.test.ts
@@ -2,7 +2,11 @@ import { deepStrictEqual, ok, strictEqual } from 'node:assert'
 import { describe, it } from 'node:test'
 import { z } from 'zod'
 
-import { generateConfigSchema, zodToJsonSchema } from './schema.ts'
+import {
+  generateConfigSchema,
+  generateGlobalConfigSchema,
+  zodToJsonSchema,
+} from './schema.ts'
 
 describe('zodToJsonSchema()', () => {
   describe('basic types', () => {
@@ -376,5 +380,30 @@ describe('generateConfigSchema()', () => {
       schema.required === undefined || schema.required?.length === 0,
       'All fields should be optional',
     )
+  })
+
+  it('requires command for host services but not docker services', () => {
+    const schema = generateConfigSchema()
+    const service = schema.properties?.services?.additionalProperties
+    ok(service && typeof service === 'object')
+
+    // command is not unconditionally required...
+    ok(
+      service.required === undefined || !service.required.includes('command'),
+      'command should not be unconditionally required',
+    )
+    // ...but a conditional requires it unless runtime is docker.
+    deepStrictEqual(service.if, {
+      required: ['runtime'],
+      properties: { runtime: { const: 'docker' } },
+    })
+    deepStrictEqual(service.else, { required: ['command'] })
+  })
+
+  it('applies the command conditional to global services too', () => {
+    const schema = generateGlobalConfigSchema()
+    const service = schema.properties?.services?.additionalProperties
+    ok(service && typeof service === 'object')
+    deepStrictEqual(service.else, { required: ['command'] })
   })
 })

--- a/packages/sdk/src/codegen/schema.ts
+++ b/packages/sdk/src/codegen/schema.ts
@@ -8,11 +8,15 @@ import type { z } from 'zod'
 type JsonSchemaIsh = {
   title?: string
   description?: string
-  type: string
+  type?: string
   properties?: Record<string, JsonSchemaIsh>
   additionalProperties?: boolean | JsonSchemaIsh
   required?: string[]
   items?: JsonSchemaIsh
+  enum?: string[]
+  const?: unknown
+  if?: JsonSchemaIsh
+  else?: JsonSchemaIsh
 }
 
 /**
@@ -178,11 +182,33 @@ export const zodToJsonSchema = (schema: z.ZodTypeAny): JsonSchemaIsh => {
 }
 
 /**
+ * Make `command` required for host-runtime services only.
+ *
+ * Docker services fall back to the image entrypoint, so `command` is optional
+ * for them but mandatory otherwise. Zod enforces this with a refinement that
+ * JSON Schema can't read, so we express the same rule with a conditional that
+ * both JSON Schema draft-07 and OpenAPI 3.1 understand: when `runtime` is
+ * `docker` the `if` matches and nothing extra is required, otherwise the `else`
+ * branch requires `command`. (`then` is omitted: with no extra constraint for
+ * docker services, the `if`/`else` pair is enough.)
+ */
+const requireCommandForHostRuntime = (root: JsonSchemaIsh): void => {
+  const service = root.properties?.services?.additionalProperties
+  if (!service || typeof service !== 'object') return
+  service.if = {
+    required: ['runtime'],
+    properties: { runtime: { const: 'docker' } },
+  }
+  service.else = { required: ['command'] }
+}
+
+/**
  * Generate JSON Schema for denvig.yml configuration files
  * Based on ProjectConfigSchema from src/schemas/config.ts
  */
 export function generateConfigSchema() {
   const baseSchema = zodToJsonSchema(ProjectConfigSchema)
+  requireCommandForHostRuntime(baseSchema)
 
   const schema = {
     $schema: 'http://json-schema.org/draft-07/schema#',
@@ -201,6 +227,7 @@ export function generateConfigSchema() {
  */
 export function generateGlobalConfigSchema() {
   const baseSchema = zodToJsonSchema(GlobalConfigSchema)
+  requireCommandForHostRuntime(baseSchema)
 
   const schema = {
     $schema: 'http://json-schema.org/draft-07/schema#',

--- a/packages/sdk/src/lib/config.test.ts
+++ b/packages/sdk/src/lib/config.test.ts
@@ -1,4 +1,7 @@
 import { deepStrictEqual, ok, strictEqual } from 'node:assert'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, it } from 'node:test'
 
 import { getEnvOverrides, getGlobalConfig, getProjectConfig } from './config.ts'
@@ -188,5 +191,54 @@ describe('getProjectConfig()', () => {
     const config = await getProjectConfig(projectPath)
     strictEqual(config.name, undefined)
     strictEqual(config.$sources.length, 0)
+  })
+
+  const writeConfig = (yaml: string): string => {
+    const dir = mkdtempSync(`${tmpdir()}/denvig-config-`)
+    writeFileSync(join(dir, '.denvig.yml'), yaml)
+    return dir
+  }
+
+  it('loads a valid config', async () => {
+    const dir = writeConfig(
+      'name: T\nservices:\n  api:\n    command: echo hi\n',
+    )
+    try {
+      const config = await getProjectConfig(dir)
+      ok(config.services?.api)
+      strictEqual(config.$sources.length, 1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('degrades to an empty config when a host service is missing its command', async () => {
+    // The schema rejects a host service without a command (see config schema
+    // tests and `config verify`). On the hot discovery path the loader degrades
+    // gracefully and silently — it must not emit output here (shell completion
+    // relies on this) — so the invalid config simply yields no services.
+    const dir = writeConfig(
+      'name: T\nservices:\n  broken:\n    http:\n      port: 9999\n',
+    )
+    try {
+      const config = await getProjectConfig(dir)
+      strictEqual(config.$sources.length, 0)
+      strictEqual(config.services, undefined)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts a docker service without a command', async () => {
+    const dir = writeConfig(
+      'name: T\nservices:\n  redis:\n    runtime: docker\n    image: redis:8.8\n',
+    )
+    try {
+      const config = await getProjectConfig(dir)
+      ok(config.services?.redis)
+      strictEqual(config.$sources.length, 1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/sdk/src/lib/config.ts
+++ b/packages/sdk/src/lib/config.ts
@@ -129,8 +129,9 @@ export const getProjectConfig = async (
         $sources: [configPath],
       }
     } catch {
-      // Silently ignore config parsing errors here.
-      // Users can run `denvig config verify` to diagnose config issues.
+      // Silently ignore config parsing errors here — this runs in the hot
+      // discovery path (including shell completion), which must not emit
+      // output. Users can run `denvig config verify` to diagnose config issues.
     }
   }
   return {

--- a/packages/sdk/src/lib/services/docker.test.ts
+++ b/packages/sdk/src/lib/services/docker.test.ts
@@ -7,9 +7,9 @@ import {
   DEFAULT_DOCKER_IMAGE,
 } from './docker.ts'
 
-/** A single project mount used by most cases. */
-const projectMount = (host = '/Users/me/project') => [
-  { host, container: CONTAINER_PROJECT_DIR },
+/** A single project bind-mount spec used by most cases. */
+const projectVolume = (host = '/Users/me/project') => [
+  `${host}:${CONTAINER_PROJECT_DIR}`,
 ]
 
 describe('buildDockerRunCommand', () => {
@@ -17,7 +17,7 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'denvig.abc.redis',
       image: 'redis:8.8',
-      mounts: projectMount('/Users/me/project'),
+      volumes: projectVolume('/Users/me/project'),
       workdir: CONTAINER_PROJECT_DIR,
     })
     match(cmd, /-v "\/Users\/me\/project:\/denvig\/project"/)
@@ -29,7 +29,7 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'c',
       image: 'node:22-alpine',
-      mounts: projectMount(),
+      volumes: projectVolume(),
       workdir: `${CONTAINER_PROJECT_DIR}/.claude/worktrees/feature`,
     })
     match(cmd, /-w \/denvig\/project\/\.claude\/worktrees\/feature/)
@@ -39,17 +39,40 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'c',
       image: 'redis:8.8',
-      mounts: [],
+      volumes: [],
     })
     ok(!cmd.includes('-v '))
     ok(!cmd.includes('-w '))
+  })
+
+  it('renders multiple bind-mount volumes', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'nginx:1.27',
+      volumes: [
+        '/h/nginx.conf:/etc/nginx/nginx.conf',
+        '/h/certs:/etc/nginx/certs:ro',
+      ],
+    })
+    match(cmd, /-v "\/h\/nginx\.conf:\/etc\/nginx\/nginx\.conf"/)
+    match(cmd, /-v "\/h\/certs:\/etc\/nginx\/certs:ro"/)
+  })
+
+  it('renders extra published ports', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'nginx:1.27',
+      ports: ['80:80', '443:443'],
+    })
+    match(cmd, /-p 80:80/)
+    match(cmd, /-p 443:443/)
   })
 
   it('removes any previous container before starting', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'denvig.abc.redis',
       image: 'redis:8.8',
-      mounts: projectMount(),
+      volumes: projectVolume(),
       workdir: CONTAINER_PROJECT_DIR,
     })
     ok(cmd.startsWith('docker rm -f denvig.abc.redis >/dev/null 2>&1; '))
@@ -59,7 +82,7 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'c',
       image: 'redis:8.8',
-      mounts: projectMount(),
+      volumes: projectVolume(),
       hostPort: 16379,
       containerPort: 6379,
     })
@@ -70,7 +93,7 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'c',
       image: 'nginx',
-      mounts: projectMount(),
+      volumes: projectVolume(),
       hostPort: 8080,
     })
     match(cmd, /-p 8080:8080/)
@@ -80,7 +103,7 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'c',
       image: 'alpine',
-      mounts: projectMount(),
+      volumes: projectVolume(),
     })
     ok(!cmd.includes('-p '))
   })
@@ -89,7 +112,7 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'c',
       image: 'alpine',
-      mounts: projectMount(),
+      volumes: projectVolume(),
       envKeys: ['PORT', 'DENVIG_SERVICE', 'DENVIG_PROJECT'],
     })
     match(cmd, /-e DENVIG_PROJECT -e DENVIG_SERVICE -e PORT/)
@@ -99,7 +122,7 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'c',
       image: 'alpine',
-      mounts: projectMount(),
+      volumes: projectVolume(),
       command: 'sh -c "echo hi"',
     })
     match(cmd, /alpine sh -c "echo hi"$/)
@@ -109,7 +132,7 @@ describe('buildDockerRunCommand', () => {
     const cmd = buildDockerRunCommand({
       containerName: 'c',
       image: 'redis:8.8',
-      mounts: projectMount(),
+      volumes: projectVolume(),
     })
     ok(cmd.trim().endsWith('redis:8.8'))
   })

--- a/packages/sdk/src/lib/services/docker.test.ts
+++ b/packages/sdk/src/lib/services/docker.test.ts
@@ -1,0 +1,121 @@
+import { equal, match, ok } from 'node:assert'
+import { describe, it } from 'node:test'
+
+import {
+  buildDockerRunCommand,
+  CONTAINER_PROJECT_DIR,
+  DEFAULT_DOCKER_IMAGE,
+} from './docker.ts'
+
+/** A single project mount used by most cases. */
+const projectMount = (host = '/Users/me/project') => [
+  { host, container: CONTAINER_PROJECT_DIR },
+]
+
+describe('buildDockerRunCommand', () => {
+  it('mounts the project and sets the working directory', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'denvig.abc.redis',
+      image: 'redis:8.8',
+      mounts: projectMount('/Users/me/project'),
+      workdir: CONTAINER_PROJECT_DIR,
+    })
+    match(cmd, /-v "\/Users\/me\/project:\/denvig\/project"/)
+    match(cmd, /-w \/denvig\/project/)
+    match(cmd, /docker run --rm --init --name denvig\.abc\.redis/)
+  })
+
+  it('honours a nested working directory', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'node:22-alpine',
+      mounts: projectMount(),
+      workdir: `${CONTAINER_PROJECT_DIR}/.claude/worktrees/feature`,
+    })
+    match(cmd, /-w \/denvig\/project\/\.claude\/worktrees\/feature/)
+  })
+
+  it('omits mounts and workdir when none are given', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'redis:8.8',
+      mounts: [],
+    })
+    ok(!cmd.includes('-v '))
+    ok(!cmd.includes('-w '))
+  })
+
+  it('removes any previous container before starting', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'denvig.abc.redis',
+      image: 'redis:8.8',
+      mounts: projectMount(),
+      workdir: CONTAINER_PROJECT_DIR,
+    })
+    ok(cmd.startsWith('docker rm -f denvig.abc.redis >/dev/null 2>&1; '))
+  })
+
+  it('maps the host port to the container port', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'redis:8.8',
+      mounts: projectMount(),
+      hostPort: 16379,
+      containerPort: 6379,
+    })
+    match(cmd, /-p 16379:6379/)
+  })
+
+  it('defaults the container port to the host port', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'nginx',
+      mounts: projectMount(),
+      hostPort: 8080,
+    })
+    match(cmd, /-p 8080:8080/)
+  })
+
+  it('omits the port flag when no host port is given', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'alpine',
+      mounts: projectMount(),
+    })
+    ok(!cmd.includes('-p '))
+  })
+
+  it('forwards environment variables by name in a stable order', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'alpine',
+      mounts: projectMount(),
+      envKeys: ['PORT', 'DENVIG_SERVICE', 'DENVIG_PROJECT'],
+    })
+    match(cmd, /-e DENVIG_PROJECT -e DENVIG_SERVICE -e PORT/)
+  })
+
+  it('appends a command override after the image', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'alpine',
+      mounts: projectMount(),
+      command: 'sh -c "echo hi"',
+    })
+    match(cmd, /alpine sh -c "echo hi"$/)
+  })
+
+  it('runs the image default entrypoint when no command is given', () => {
+    const cmd = buildDockerRunCommand({
+      containerName: 'c',
+      image: 'redis:8.8',
+      mounts: projectMount(),
+    })
+    ok(cmd.trim().endsWith('redis:8.8'))
+  })
+
+  it('exposes default image and project mount constants', () => {
+    equal(DEFAULT_DOCKER_IMAGE, 'alpine:3.23')
+    equal(CONTAINER_PROJECT_DIR, '/denvig/project')
+  })
+})

--- a/packages/sdk/src/lib/services/docker.ts
+++ b/packages/sdk/src/lib/services/docker.ts
@@ -1,0 +1,85 @@
+/**
+ * Default image used when a docker-runtime service does not specify one.
+ */
+export const DEFAULT_DOCKER_IMAGE = 'alpine:3.23'
+
+/** Container path the whole project (the primary checkout) is mounted at. */
+export const CONTAINER_PROJECT_DIR = '/denvig/project'
+
+/** A single host→container bind mount. */
+export type DockerMount = {
+  host: string
+  container: string
+}
+
+export type DockerRunOptions = {
+  /** Container name, used so restarts can replace the previous container. */
+  containerName: string
+  /** Image to run. */
+  image: string
+  /** Bind mounts (host directory → container path). */
+  mounts: DockerMount[]
+  /** Working directory inside the container. Omit to use the image default. */
+  workdir?: string
+  /** Host port to expose. Omit when the service has no http port. */
+  hostPort?: number
+  /** Container port the host port maps to. Defaults to the host port. */
+  containerPort?: number
+  /**
+   * Names of environment variables to forward into the container. The values
+   * come from the surrounding process environment (set via the launchd plist),
+   * so no escaping of values is needed here.
+   */
+  envKeys?: string[]
+  /** Command/args run inside the container, overriding the image default. */
+  command?: string
+}
+
+/**
+ * Build a shell command that runs a service inside a docker container in the
+ * foreground, so launchd tracks the `docker run` process exactly like a host
+ * service. The project is bind-mounted at `/denvig/project` (so tools like git
+ * have access to the full checkout) and the working directory is set to the
+ * service's location inside it. Any previous container with the same name is
+ * removed first so a restart doesn't collide on the name.
+ */
+export function buildDockerRunCommand(options: DockerRunOptions): string {
+  // `--init` runs a tiny init (tini) as PID 1 to forward signals and reap
+  // children, so the container shuts down cleanly on stop even when the image's
+  // entrypoint doesn't handle SIGTERM itself (e.g. a bare node process).
+  const args = [
+    'docker',
+    'run',
+    '--rm',
+    '--init',
+    '--name',
+    options.containerName,
+  ]
+
+  for (const mount of options.mounts) {
+    args.push('-v', `"${mount.host}:${mount.container}"`)
+  }
+  if (options.workdir) {
+    args.push('-w', options.workdir)
+  }
+
+  if (options.hostPort !== undefined) {
+    const containerPort = options.containerPort ?? options.hostPort
+    args.push('-p', `${options.hostPort}:${containerPort}`)
+  }
+
+  // Forward env vars by name (value comes from the plist environment). Sorted
+  // so the rendered command is stable across runs and doesn't churn the plist.
+  for (const key of [...(options.envKeys ?? [])].sort()) {
+    args.push('-e', key)
+  }
+
+  args.push(options.image)
+
+  const run = options.command?.trim()
+    ? `${args.join(' ')} ${options.command.trim()}`
+    : args.join(' ')
+
+  // Clear any lingering container from a previous run before starting.
+  return `docker rm -f ${options.containerName} >/dev/null 2>&1; ${run}`
+}

--- a/packages/sdk/src/lib/services/docker.ts
+++ b/packages/sdk/src/lib/services/docker.ts
@@ -6,21 +6,23 @@ export const DEFAULT_DOCKER_IMAGE = 'alpine:3.23'
 /** Container path the whole project (the primary checkout) is mounted at. */
 export const CONTAINER_PROJECT_DIR = '/denvig/project'
 
-/** A single host→container bind mount. */
-export type DockerMount = {
-  host: string
-  container: string
-}
-
 export type DockerRunOptions = {
   /** Container name, used so restarts can replace the previous container. */
   containerName: string
   /** Image to run. */
   image: string
-  /** Bind mounts (host directory → container path). */
-  mounts: DockerMount[]
+  /**
+   * Bind-mount specs rendered as `-v` (e.g. `/host/path:/container/path` or
+   * `/host:/container:ro`). Host paths should already be absolute.
+   */
+  volumes?: string[]
   /** Working directory inside the container. Omit to use the image default. */
   workdir?: string
+  /**
+   * Extra published-port specs rendered as `-p` (e.g. `8025:8025`). Used for
+   * docker services that expose ports directly rather than via the gateway.
+   */
+  ports?: string[]
   /** Host port to expose. Omit when the service has no http port. */
   hostPort?: number
   /** Container port the host port maps to. Defaults to the host port. */
@@ -56,8 +58,8 @@ export function buildDockerRunCommand(options: DockerRunOptions): string {
     options.containerName,
   ]
 
-  for (const mount of options.mounts) {
-    args.push('-v', `"${mount.host}:${mount.container}"`)
+  for (const volume of options.volumes ?? []) {
+    args.push('-v', `"${volume}"`)
   }
   if (options.workdir) {
     args.push('-w', options.workdir)
@@ -66,6 +68,9 @@ export function buildDockerRunCommand(options: DockerRunOptions): string {
   if (options.hostPort !== undefined) {
     const containerPort = options.containerPort ?? options.hostPort
     args.push('-p', `${options.hostPort}:${containerPort}`)
+  }
+  for (const port of options.ports ?? []) {
+    args.push('-p', port)
   }
 
   // Forward env vars by name (value comes from the plist environment). Sorted

--- a/packages/sdk/src/lib/services/manager.test.ts
+++ b/packages/sdk/src/lib/services/manager.test.ts
@@ -1132,5 +1132,42 @@ describe('ServiceManager', () => {
       strictEqual(result.success, false)
       match(result.message, /not inside the project root/)
     })
+
+    it('mounts container.volumes, resolving relative host paths', async (t) => {
+      mockLaunchctlStart(t)
+      const project = createDockerProject({
+        runtime: 'docker',
+        image: 'nginx:1.27',
+        container: {
+          mountProject: false,
+          volumes: [
+            './nginx/nginx.conf:/etc/nginx/nginx.conf',
+            '/abs/certs:/etc/nginx/certs:ro',
+            'named-vol:/data',
+          ],
+          ports: ['80:80', '443:443'],
+        },
+      })
+      const manager = new ServiceManager(project)
+
+      const result = await manager.startService('svc', { portResolved: true })
+      ok(result.success, result.message)
+
+      const script = readFileSync(manager.getServiceScriptPath('svc'), 'utf-8')
+      // Relative host path resolves against the service directory.
+      ok(
+        script.includes(
+          `-v "${project.path}/nginx/nginx.conf:/etc/nginx/nginx.conf"`,
+        ),
+        script,
+      )
+      // Absolute host path and options are preserved.
+      ok(script.includes('-v "/abs/certs:/etc/nginx/certs:ro"'))
+      // Named volume is left untouched.
+      ok(script.includes('-v "named-vol:/data"'))
+      // Extra published ports are passed through.
+      ok(script.includes('-p 80:80'))
+      ok(script.includes('-p 443:443'))
+    })
   })
 })

--- a/packages/sdk/src/lib/services/manager.test.ts
+++ b/packages/sdk/src/lib/services/manager.test.ts
@@ -1,9 +1,10 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: The print function is overridden for mocking, easier to use any */
-import { deepStrictEqual, ok, strictEqual } from 'node:assert'
+import { deepStrictEqual, match, ok, strictEqual } from 'node:assert'
 import {
   mkdirSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -997,6 +998,139 @@ describe('ServiceManager', () => {
         0,
         'disable should not be called',
       )
+    })
+  })
+
+  describe('docker runtime', () => {
+    let originalHome: string | undefined
+    let tmpHome = ''
+
+    beforeEach(() => {
+      originalHome = process.env.HOME
+      tmpHome = mkdtempSync(`${tmpdir()}/denvig-manager-docker-`)
+      process.env.HOME = tmpHome
+      mkdirSync(`${tmpHome}/Library/LaunchAgents`, { recursive: true })
+    })
+    afterEach(() => {
+      if (originalHome !== undefined) process.env.HOME = originalHome
+      else delete process.env.HOME
+      rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    const createDockerProject = (service: any) => {
+      const project = createMockInternalProject({
+        slug: 'github:owner/repo',
+        path: `${tmpHome}/repo`,
+      })
+      project.config.services = { svc: service }
+      return project
+    }
+
+    const mockLaunchctlStart = (t: any) => {
+      t.mock.method(launchctl, 'print', async () => null)
+      t.mock.method(launchctl, 'enable', async () => ({
+        success: true,
+        output: '',
+      }))
+      t.mock.method(launchctl, 'bootstrap', async () => ({
+        success: true,
+        output: '',
+      }))
+    }
+
+    it('summarises the image in the display command', async () => {
+      const manager = new ServiceManager(
+        createDockerProject({ runtime: 'docker', image: 'redis:8.8' }),
+      )
+      const services = await manager.listServices()
+      strictEqual(services[0]?.command, 'docker run redis:8.8')
+    })
+
+    it('mounts the project and runs a container via the wrapper script', async (t) => {
+      mockLaunchctlStart(t)
+      const project = createDockerProject({
+        runtime: 'docker',
+        image: 'redis:8.8',
+        http: { port: 16379, containerPort: 6379 },
+      })
+      const manager = new ServiceManager(project)
+
+      const result = await manager.startService('svc', {
+        port: 16379,
+        portResolved: true,
+      })
+      ok(result.success, result.message)
+
+      const script = readFileSync(manager.getServiceScriptPath('svc'), 'utf-8')
+      ok(script.includes('docker run --rm --init --name'))
+      // This temp project isn't a git checkout, so the project root is the
+      // project path and the working directory is the mount root.
+      ok(script.includes(`-v "${project.path}:/denvig/project"`))
+      ok(script.includes('-w /denvig/project'))
+      ok(script.includes('-p 16379:6379'))
+      ok(script.includes('redis:8.8'))
+
+      // The host port is what the gateway/state sees, not the container port.
+      const state = await getServiceState(project.id, 'svc')
+      strictEqual(state?.port, 16379)
+      strictEqual(state?.config?.runtime, 'docker')
+      strictEqual(state?.config?.image, 'redis:8.8')
+      strictEqual(state?.config?.command, undefined)
+    })
+
+    it('does not mount the project when mountProject is false', async (t) => {
+      mockLaunchctlStart(t)
+      const project = createDockerProject({
+        runtime: 'docker',
+        image: 'redis:8.8',
+        container: { mountProject: false },
+        http: { port: 16379, containerPort: 6379 },
+      })
+      const manager = new ServiceManager(project)
+
+      const result = await manager.startService('svc', {
+        port: 16379,
+        portResolved: true,
+      })
+      ok(result.success, result.message)
+
+      const script = readFileSync(manager.getServiceScriptPath('svc'), 'utf-8')
+      ok(!script.includes('/denvig/project'), 'project should not be mounted')
+      ok(!script.includes('-w '), 'no working directory should be set')
+      ok(script.includes('-p 16379:6379'))
+    })
+
+    it('sets the working directory to a nested service cwd', async (t) => {
+      mockLaunchctlStart(t)
+      const project = createDockerProject({
+        runtime: 'docker',
+        image: 'node:22-alpine',
+        cwd: 'apps/api',
+        command: 'node server.js',
+      })
+      mkdirSync(`${project.path}/apps/api`, { recursive: true })
+      const manager = new ServiceManager(project)
+
+      const result = await manager.startService('svc', { portResolved: true })
+      ok(result.success, result.message)
+
+      const script = readFileSync(manager.getServiceScriptPath('svc'), 'utf-8')
+      ok(script.includes(`-v "${project.path}:/denvig/project"`))
+      ok(script.includes('-w /denvig/project/apps/api'))
+    })
+
+    it('fails when the service directory is outside the project root', async (t) => {
+      mockLaunchctlStart(t)
+      const project = createDockerProject({
+        runtime: 'docker',
+        image: 'redis:8.8',
+        cwd: '../outside',
+      })
+      const manager = new ServiceManager(project)
+
+      const result = await manager.startService('svc', { portResolved: true })
+      strictEqual(result.success, false)
+      match(result.message, /not inside the project root/)
     })
   })
 })

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -11,12 +11,20 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { homedir, hostname } from 'node:os'
-import { basename, resolve } from 'node:path'
+import { basename, isAbsolute, relative, resolve } from 'node:path'
 
 import { findCertForDomain, resolveSslPaths } from '../gateway/certs.ts'
 import { configureGateway } from '../gateway/configure.ts'
+import { detectGitWorktree } from '../project/git.ts'
 import { diffLines } from './diff.ts'
+import {
+  buildDockerRunCommand,
+  CONTAINER_PROJECT_DIR,
+  DEFAULT_DOCKER_IMAGE,
+  type DockerMount,
+} from './docker.ts'
 import { DEFAULT_ENV_FILES, loadEnvFiles } from './env.ts'
+import { isGlobalSlug } from './global.ts'
 import launchctl, { type LaunchctlListItem } from './launchctl.ts'
 import { generatePlist, generateServiceScript } from './plist.ts'
 import { allocateRandomPort, isPortInUse } from './ports.ts'
@@ -82,10 +90,123 @@ export class ServiceManager {
     return Object.entries(services).map(([name, config]) => ({
       name,
       cwd: config.cwd || '.',
-      command: config.command,
+      command: this.getDisplayCommand(config),
       http: config.http,
       startOnBoot: config.startOnBoot,
     }))
+  }
+
+  /**
+   * Whether a service runs in a docker container.
+   */
+  private isDockerService(config: ServiceConfig): boolean {
+    return (config.runtime ?? 'host') === 'docker'
+  }
+
+  /**
+   * Human-readable command shown in list/status output. For docker services
+   * this summarises the image (and any command override) rather than the full
+   * generated `docker run` invocation.
+   */
+  private getDisplayCommand(config: ServiceConfig): string {
+    if (this.isDockerService(config)) {
+      const image = config.image ?? DEFAULT_DOCKER_IMAGE
+      return config.command?.trim()
+        ? `docker run ${image} ${config.command.trim()}`
+        : `docker run ${image}`
+    }
+    return config.command ?? ''
+  }
+
+  /**
+   * Build the actual command launchd executes for a service. Host services
+   * run their command verbatim; docker services run a generated `docker run`
+   * invocation that mounts the project at /denvig/project and forwards the
+   * resolved environment into the container.
+   *
+   * @param options.hostPort - The resolved host port (the one launchd/gateway
+   *   sees). Mapped to the container port for docker services.
+   * @param options.containerPort - The port the container listens on.
+   * @param options.envKeys - Environment variable names to forward into the
+   *   container (their values come from the plist environment).
+   */
+  private buildRunCommand(
+    name: string,
+    config: ServiceConfig,
+    options: {
+      hostPort?: number
+      containerPort?: number
+      envKeys: string[]
+    },
+  ): { ok: true; command: string } | { ok: false; message: string } {
+    if (!this.isDockerService(config)) {
+      return { ok: true, command: config.command ?? '' }
+    }
+    const resolved = this.resolveDockerMounts(config)
+    if (!resolved.ok) {
+      return resolved
+    }
+    return {
+      ok: true,
+      command: buildDockerRunCommand({
+        containerName: this.getServiceLabel(name),
+        image: config.image ?? DEFAULT_DOCKER_IMAGE,
+        mounts: resolved.mounts,
+        workdir: resolved.workdir,
+        hostPort: options.hostPort,
+        containerPort: options.containerPort,
+        envKeys: options.envKeys,
+        command: config.command,
+      }),
+    }
+  }
+
+  /**
+   * Resolve the bind mounts and working directory for a docker service.
+   *
+   * The whole project (the primary checkout) is mounted at `/denvig/project`,
+   * so tools like git inside the container can reach the full project. The
+   * working directory is the service's directory expressed inside that mount:
+   * the project root for the primary checkout, or the worktree's location
+   * within the project for a detached worktree.
+   *
+   * Returns an error when the service directory lives outside the project root
+   * (the code wouldn't be part of the mount), or `mounts: []` with no working
+   * directory when `container.mountProject` is `false`.
+   */
+  private resolveDockerMounts(
+    config: ServiceConfig,
+  ):
+    | { ok: true; mounts: DockerMount[]; workdir?: string }
+    | { ok: false; message: string } {
+    const mountProject = config.container?.mountProject ?? true
+    if (!mountProject) {
+      return { ok: true, mounts: [] }
+    }
+
+    const serviceCwd = this.resolveServiceCwd(config)
+    // Global services have no surrounding project; treat their isolated
+    // working directory as the project root.
+    const projectRoot = isGlobalSlug(this.project.slug)
+      ? serviceCwd
+      : (detectGitWorktree(this.project.path)?.primaryPath ?? this.project.path)
+
+    const rel = relative(projectRoot, serviceCwd)
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      return {
+        ok: false,
+        message: `Service directory "${serviceCwd}" is not inside the project root "${projectRoot}"; a docker service can only mount code within the project`,
+      }
+    }
+
+    const workdir = rel
+      ? `${CONTAINER_PROJECT_DIR}/${rel}`
+      : CONTAINER_PROJECT_DIR
+    return {
+      ok: true,
+      mounts: [{ host: projectRoot, container: CONTAINER_PROJECT_DIR }],
+      workdir,
+    }
   }
 
   /**
@@ -364,8 +485,17 @@ export class ServiceManager {
       effectivePort = resolved.port
     }
 
+    // Docker services bind to the container port inside the container, while
+    // the host port is published to the host via `-p hostPort:containerPort`.
+    // Host services bind directly to the resolved port.
+    const isDocker = this.isDockerService(config)
+    const containerPort = isDocker
+      ? (config.http?.containerPort ?? effectivePort)
+      : undefined
+    const boundPort = isDocker ? containerPort : effectivePort
+
     const envResult = await this.buildServiceEnvironment(name, {
-      port: effectivePort,
+      port: boundPort,
     })
     if (!envResult.success) {
       return {
@@ -375,6 +505,20 @@ export class ServiceManager {
       }
     }
     const label = this.getServiceLabel(name)
+
+    // Resolve the actual command launchd runs. For docker services this is a
+    // generated `docker run` invocation; the snapshot keeps the original
+    // command plus runtime/image so the reconciler can rebuild it identically.
+    const runResult = this.buildRunCommand(name, config, {
+      hostPort: effectivePort,
+      containerPort,
+      envKeys: Object.keys(envResult.env),
+    })
+    if (!runResult.ok) {
+      return { name, success: false, message: runResult.message }
+    }
+    const runCommand = runResult.command
+
     const printInfo = await launchctl.print(label)
     const isBootstrapped = printInfo !== null
     // "Live" means the service has an active PID. A bootstrapped service
@@ -412,6 +556,9 @@ export class ServiceManager {
       },
       serviceName: name,
       config: {
+        runtime: config.runtime,
+        image: config.image,
+        container: config.container,
         command: config.command,
         env: config.env,
         envFiles: config.envFiles,
@@ -476,7 +623,7 @@ export class ServiceManager {
     // Create wrapper script so Login Items shows the script name instead of "zsh"
     const scriptPath = this.getServiceScriptPath(name)
     const scriptContent = generateServiceScript({
-      command: config.command,
+      command: runCommand,
       serviceName: name,
       projectPath: this.project.path,
       projectSlug: this.project.slug,
@@ -760,7 +907,7 @@ export class ServiceManager {
       return {
         name,
         running: false,
-        command: config.command,
+        command: this.getDisplayCommand(config),
         cwd: this.resolveServiceCwd(config),
         logPath: this.getLogPath(name),
       }
@@ -773,7 +920,7 @@ export class ServiceManager {
       name,
       running: info.state === 'running',
       pid: info.pid,
-      command: config.command,
+      command: this.getDisplayCommand(config),
       cwd: this.resolveServiceCwd(config),
       logs,
       logPath: this.getLogPath(name),
@@ -1292,7 +1439,7 @@ export class ServiceManager {
       localUrl: await this.getServiceLocalUrl(name),
       port: effectivePort ?? null,
       configPort: config.http?.port ?? null,
-      command: config.command,
+      command: this.getDisplayCommand(config),
       cwd: this.resolveServiceCwd(config),
       logPath: this.getLogPath(name),
       envFiles: (config.envFiles ?? DEFAULT_ENV_FILES).map((f) =>

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -21,7 +21,6 @@ import {
   buildDockerRunCommand,
   CONTAINER_PROJECT_DIR,
   DEFAULT_DOCKER_IMAGE,
-  type DockerMount,
 } from './docker.ts'
 import { DEFAULT_ENV_FILES, loadEnvFiles } from './env.ts'
 import { isGlobalSlug } from './global.ts'
@@ -151,8 +150,9 @@ export class ServiceManager {
       command: buildDockerRunCommand({
         containerName: this.getServiceLabel(name),
         image: config.image ?? DEFAULT_DOCKER_IMAGE,
-        mounts: resolved.mounts,
+        volumes: resolved.volumes,
         workdir: resolved.workdir,
+        ports: config.container?.ports,
         hostPort: options.hostPort,
         containerPort: options.containerPort,
         envKeys: options.envKeys,
@@ -162,51 +162,77 @@ export class ServiceManager {
   }
 
   /**
-   * Resolve the bind mounts and working directory for a docker service.
+   * Resolve the bind-mount specs and working directory for a docker service.
    *
-   * The whole project (the primary checkout) is mounted at `/denvig/project`,
-   * so tools like git inside the container can reach the full project. The
-   * working directory is the service's directory expressed inside that mount:
-   * the project root for the primary checkout, or the worktree's location
-   * within the project for a detached worktree.
+   * Unless `container.mountProject` is `false`, the whole project (the primary
+   * checkout) is mounted at `/denvig/project`, with the working directory set
+   * to the service's location within it (the project root for the primary
+   * checkout, or the worktree's path within the project for a detached
+   * worktree). Any `container.volumes` are appended, with relative host paths
+   * resolved against the service directory.
    *
-   * Returns an error when the service directory lives outside the project root
-   * (the code wouldn't be part of the mount), or `mounts: []` with no working
-   * directory when `container.mountProject` is `false`.
+   * Returns an error when the project mount is requested but the service
+   * directory lives outside the project root (the code wouldn't be part of the
+   * mount).
    */
   private resolveDockerMounts(
     config: ServiceConfig,
   ):
-    | { ok: true; mounts: DockerMount[]; workdir?: string }
+    | { ok: true; volumes: string[]; workdir?: string }
     | { ok: false; message: string } {
+    const volumes: string[] = []
+    let workdir: string | undefined
+
     const mountProject = config.container?.mountProject ?? true
-    if (!mountProject) {
-      return { ok: true, mounts: [] }
-    }
+    if (mountProject) {
+      const serviceCwd = this.resolveServiceCwd(config)
+      // Global services have no surrounding project; treat their isolated
+      // working directory as the project root.
+      const projectRoot = isGlobalSlug(this.project.slug)
+        ? serviceCwd
+        : (detectGitWorktree(this.project.path)?.primaryPath ??
+          this.project.path)
 
-    const serviceCwd = this.resolveServiceCwd(config)
-    // Global services have no surrounding project; treat their isolated
-    // working directory as the project root.
-    const projectRoot = isGlobalSlug(this.project.slug)
-      ? serviceCwd
-      : (detectGitWorktree(this.project.path)?.primaryPath ?? this.project.path)
-
-    const rel = relative(projectRoot, serviceCwd)
-    if (rel.startsWith('..') || isAbsolute(rel)) {
-      return {
-        ok: false,
-        message: `Service directory "${serviceCwd}" is not inside the project root "${projectRoot}"; a docker service can only mount code within the project`,
+      const rel = relative(projectRoot, serviceCwd)
+      if (rel.startsWith('..') || isAbsolute(rel)) {
+        return {
+          ok: false,
+          message: `Service directory "${serviceCwd}" is not inside the project root "${projectRoot}"; a docker service can only mount code within the project`,
+        }
       }
+
+      volumes.push(`${projectRoot}:${CONTAINER_PROJECT_DIR}`)
+      workdir = rel ? `${CONTAINER_PROJECT_DIR}/${rel}` : CONTAINER_PROJECT_DIR
     }
 
-    const workdir = rel
-      ? `${CONTAINER_PROJECT_DIR}/${rel}`
-      : CONTAINER_PROJECT_DIR
-    return {
-      ok: true,
-      mounts: [{ host: projectRoot, container: CONTAINER_PROJECT_DIR }],
-      workdir,
+    // User-defined volumes: resolve relative host paths against the service
+    // directory (matching docker-compose semantics), leaving absolute paths
+    // and named volumes untouched.
+    const baseDir = this.resolveServiceCwd(config)
+    for (const spec of config.container?.volumes ?? []) {
+      volumes.push(this.resolveVolumeSpec(spec, baseDir))
     }
+
+    return { ok: true, volumes, workdir }
+  }
+
+  /**
+   * Resolve a docker volume spec (`host:container[:options]`), turning a
+   * filesystem-style host path into an absolute path relative to `baseDir`.
+   * Named volumes (a host that isn't a path) are returned unchanged.
+   */
+  private resolveVolumeSpec(spec: string, baseDir: string): string {
+    const colon = spec.indexOf(':')
+    if (colon <= 0) return spec
+    const host = spec.slice(0, colon)
+    const rest = spec.slice(colon + 1)
+    const looksLikePath =
+      host.startsWith('.') || host.startsWith('/') || host.startsWith('~')
+    if (!looksLikePath) return spec
+    const expanded = host.startsWith('~/')
+      ? resolve(homedir(), host.slice(2))
+      : host
+    return `${resolve(baseDir, expanded)}:${rest}`
   }
 
   /**

--- a/packages/sdk/src/lib/services/reconcile.ts
+++ b/packages/sdk/src/lib/services/reconcile.ts
@@ -81,6 +81,9 @@ const projectFromStateEntry = (
           // state cwd works because `resolve()` returns the second arg
           // unchanged when it's already absolute.
           cwd: entry.cwd,
+          runtime: entry.config.runtime,
+          image: entry.config.image,
+          container: entry.config.container,
           command: entry.config.command,
           env: entry.config.env,
           envFiles: entry.config.envFiles,

--- a/packages/sdk/src/lib/services/state.ts
+++ b/packages/sdk/src/lib/services/state.ts
@@ -22,12 +22,16 @@ export const ProjectSnapshotSchema = z.object({
  * and tolerates older entries.
  */
 export const ServiceConfigSnapshotSchema = z.object({
-  command: z.string(),
+  runtime: z.enum(['host', 'docker']).optional(),
+  image: z.string().optional(),
+  container: z.object({ mountProject: z.boolean().optional() }).optional(),
+  command: z.string().optional(),
   env: z.record(z.string(), z.string()).optional(),
   envFiles: z.array(z.string()).optional(),
   http: z
     .object({
       port: z.number().optional(),
+      containerPort: z.number().optional(),
       domain: z.string().optional(),
       cnames: z.array(z.string()).optional(),
       secure: z.boolean().optional(),

--- a/packages/sdk/src/lib/services/state.ts
+++ b/packages/sdk/src/lib/services/state.ts
@@ -24,7 +24,13 @@ export const ProjectSnapshotSchema = z.object({
 export const ServiceConfigSnapshotSchema = z.object({
   runtime: z.enum(['host', 'docker']).optional(),
   image: z.string().optional(),
-  container: z.object({ mountProject: z.boolean().optional() }).optional(),
+  container: z
+    .object({
+      mountProject: z.boolean().optional(),
+      volumes: z.array(z.string()).optional(),
+      ports: z.array(z.string()).optional(),
+    })
+    .optional(),
   command: z.string().optional(),
   env: z.record(z.string(), z.string()).optional(),
   envFiles: z.array(z.string()).optional(),

--- a/packages/sdk/src/schemas/config.test.ts
+++ b/packages/sdk/src/schemas/config.test.ts
@@ -244,6 +244,104 @@ describe('ProjectConfigSchema - services', () => {
     ok(!result.success)
   })
 
+  it('should parse a docker service without a command', () => {
+    const config = {
+      name: 'my-project',
+      services: {
+        redis: {
+          runtime: 'docker',
+          image: 'redis:8.8',
+          http: {
+            port: 16379,
+            containerPort: 6379,
+          },
+        },
+      },
+    }
+
+    const result = ProjectConfigSchema.safeParse(config)
+    ok(result.success)
+  })
+
+  it('should parse a docker service with a command override', () => {
+    const config = {
+      name: 'my-project',
+      services: {
+        worker: {
+          runtime: 'docker',
+          image: 'node:22',
+          command: 'node worker.js',
+        },
+      },
+    }
+
+    const result = ProjectConfigSchema.safeParse(config)
+    ok(result.success)
+  })
+
+  it('should parse a docker service with container.mountProject', () => {
+    const config = {
+      name: 'my-project',
+      services: {
+        redis: {
+          runtime: 'docker',
+          image: 'redis:8.8',
+          container: { mountProject: false },
+          http: { port: 16379, containerPort: 6379 },
+        },
+      },
+    }
+
+    const result = ProjectConfigSchema.safeParse(config)
+    ok(result.success)
+  })
+
+  it('should reject a non-boolean container.mountProject', () => {
+    const config = {
+      name: 'my-project',
+      services: {
+        redis: {
+          runtime: 'docker',
+          image: 'redis:8.8',
+          container: { mountProject: 'nope' },
+        },
+      },
+    }
+
+    const result = ProjectConfigSchema.safeParse(config)
+    ok(!result.success)
+  })
+
+  it('should reject a host service without a command', () => {
+    const config = {
+      name: 'my-project',
+      services: {
+        api: {
+          runtime: 'host',
+          http: { port: 3000 },
+        },
+      },
+    }
+
+    const result = ProjectConfigSchema.safeParse(config)
+    ok(!result.success)
+  })
+
+  it('should reject an unknown runtime', () => {
+    const config = {
+      name: 'my-project',
+      services: {
+        api: {
+          runtime: 'podman',
+          command: 'echo test',
+        },
+      },
+    }
+
+    const result = ProjectConfigSchema.safeParse(config)
+    ok(!result.success)
+  })
+
   it('should reject invalid field types in service', () => {
     const invalidConfig = {
       name: 'my-project',

--- a/packages/sdk/src/schemas/config.ts
+++ b/packages/sdk/src/schemas/config.ts
@@ -49,6 +49,18 @@ export const ServiceConfigSchema = z
           .describe(
             'Mount the project directory at /denvig/project (default true)',
           ),
+        volumes: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Bind mounts passed to docker run as -v (host:container[:options]); relative host paths resolve against the service directory',
+          ),
+        ports: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Published ports passed to docker run as -p (host:container)',
+          ),
       })
       .optional()
       .describe('Container runtime options used when runtime is "docker"'),

--- a/packages/sdk/src/schemas/config.ts
+++ b/packages/sdk/src/schemas/config.ts
@@ -27,44 +27,86 @@ export const ServiceNameSchema = z
 /**
  * Schema for a single service configuration entry.
  */
-export const ServiceConfigSchema = z.object({
-  cwd: z
-    .string()
-    .optional()
-    .describe('Working directory for the service (relative to project root)'),
-  command: z.string().describe('Shell command to execute'),
-  http: z
-    .object({
-      port: z
-        .number()
-        .optional()
-        .describe('Port number the service listens on'),
-      domain: z
-        .string()
-        .optional()
-        .describe('Domain to use for the service URL'),
-      cnames: z
-        .array(z.string())
-        .optional()
-        .describe('Additional hosts that can be used via gateway'),
-      secure: z.boolean().optional().describe('Use HTTPS instead of HTTP'),
-    })
-    .optional()
-    .describe('HTTP configuration for the service URL'),
-  envFiles: z
-    .array(z.string())
-    .optional()
-    .describe('Paths to .env files (relative to service cwd)'),
-  env: z
-    .record(z.string(), z.string())
-    .optional()
-    .describe('Environment variables'),
-  keepAlive: z.boolean().optional().describe('Restart service if it exits'),
-  startOnBoot: z
-    .boolean()
-    .optional()
-    .describe('Start service automatically when system boots'),
-})
+export const ServiceConfigSchema = z
+  .object({
+    runtime: z
+      .enum(['host', 'docker'])
+      .optional()
+      .describe(
+        'How the service runs: directly on the host (default) or in a docker container',
+      ),
+    image: z
+      .string()
+      .optional()
+      .describe(
+        'Container image to run when runtime is "docker" (defaults to alpine:3.23)',
+      ),
+    container: z
+      .object({
+        mountProject: z
+          .boolean()
+          .optional()
+          .describe(
+            'Mount the project directory at /denvig/project (default true)',
+          ),
+      })
+      .optional()
+      .describe('Container runtime options used when runtime is "docker"'),
+    cwd: z
+      .string()
+      .optional()
+      .describe('Working directory for the service (relative to project root)'),
+    command: z.string().optional().describe('Shell command to execute'),
+    http: z
+      .object({
+        port: z
+          .number()
+          .optional()
+          .describe('Port number the service listens on'),
+        containerPort: z
+          .number()
+          .optional()
+          .describe(
+            'Port the container listens on when runtime is "docker" (defaults to the host port)',
+          ),
+        domain: z
+          .string()
+          .optional()
+          .describe('Domain to use for the service URL'),
+        cnames: z
+          .array(z.string())
+          .optional()
+          .describe('Additional hosts that can be used via gateway'),
+        secure: z.boolean().optional().describe('Use HTTPS instead of HTTP'),
+      })
+      .optional()
+      .describe('HTTP configuration for the service URL'),
+    envFiles: z
+      .array(z.string())
+      .optional()
+      .describe('Paths to .env files (relative to service cwd)'),
+    env: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe('Environment variables'),
+    keepAlive: z.boolean().optional().describe('Restart service if it exits'),
+    startOnBoot: z
+      .boolean()
+      .optional()
+      .describe('Start service automatically when system boots'),
+  })
+  .superRefine((config, ctx) => {
+    // Host services run an explicit command. Docker services may omit it and
+    // rely on the image's default entrypoint instead.
+    const runtime = config.runtime ?? 'host'
+    if (runtime !== 'docker' && !config.command?.trim()) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['command'],
+        message: 'command is required for host runtime services',
+      })
+    }
+  })
 
 /**
  * Schema for the services record (name → config).


### PR DESCRIPTION
## Summary

Adds a `docker` runtime for services so containers can be managed by denvig the same way as host processes, with enough flexibility to replace docker-compose service definitions.

All container services are still managed through `launchctl` — the `docker run` process runs in the foreground, so its PID is tracked for stop/restart just like a host service. Containers run with `--rm --init` (tini as PID 1) so they shut down cleanly on stop even when the image entrypoint doesn't handle `SIGTERM`.

## New config

```yaml
services:
  redis:
    runtime: docker          # "host" (default) or "docker"
    image: redis:8.8         # defaults to alpine:3.23
    command: --some-flag     # optional for docker (falls back to image entrypoint)
    container:
      mountProject: false    # default true → mounts the project at /denvig/project
      volumes:               # extra -v bind mounts (relative paths resolve against the service dir)
        - "./data:/data"
      ports:                 # extra -p publish mappings
        - "6379:6379"
    env:                     # forwarded into the container via -e (works for host too)
      KEY: value
    http:
      port: 16379            # host port (random-allocation logic applies)
      containerPort: 6379    # maps -p hostPort:containerPort
```

### Mounts
- The project (primary checkout) is mounted at `/denvig/project`, with the working directory set to the service's location within it (a worktree's path resolves under the project). A service directory outside the project root fails to start with a clear error.
- `container.mountProject: false` skips the project mount (handy for utility services like a database).
- `container.volumes` adds bind mounts; relative host paths resolve against the service directory like compose.

### Validation
- `command` is required for host services but optional for docker. This is enforced by the zod schema **and** the generated JSON schema (a draft-07 / OpenAPI 3.1 `if`/`else` conditional), so editors validating `.denvig.yml` flag it too.

## Replacing docker-compose

Verified against a real project by porting `gateway` (nginx), `mongodb`, and `mailpit` from a `docker-compose.yml`. Live test of `mailpit` confirmed volumes, ports, env, and the image default entrypoint all work (web UI 200, SMTP ready, env values inside the container, volume persisted to disk); `mongodb`'s `command` override generated correctly.

Healthchecks are intentionally **not** included yet (compose still needed for the mongodb `rs.initiate` seed) — native healthchecks are planned separately.

## Commits
- Add docker runtime for services
- Require command for host services in the generated config schema
- Add container.volumes and container.ports for docker services

## Tests
SDK suite passes (600 tests, incl. new docker/codegen/config coverage). Lint, type-check, and codegen are clean. The 4 failing CLI tests are pre-existing network-dependent example tests unrelated to this change.
