### PR TITLE
Stop rotating service logs on no-op reconciles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Services can now run in a docker container with `runtime: docker`, mounting the project at `/denvig/project` with the working directory set to the service's location within it
 
+### Fixed
+
+- `services logs` no longer shows an empty log after running an unrelated services command; a service's `latest.log` is now only rotated when the service is actually started or restarted, not on every reconcile
+
 ## [0.7.1] - 2026-06-20
 
 ### Added

--- a/packages/sdk/src/lib/services/manager.test.ts
+++ b/packages/sdk/src/lib/services/manager.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -271,6 +272,129 @@ describe('ServiceManager', () => {
       } finally {
         rmSync(logDir, { recursive: true, force: true })
       }
+    })
+  })
+
+  describe('log rotation on start', () => {
+    let originalHome: string | undefined
+    let tmpHome = ''
+
+    beforeEach(() => {
+      originalHome = process.env.HOME
+      tmpHome = mkdtempSync(`${tmpdir()}/denvig-manager-logs-`)
+      process.env.HOME = tmpHome
+      mkdirSync(`${tmpHome}/Library/LaunchAgents`, { recursive: true })
+    })
+    afterEach(() => {
+      if (originalHome !== undefined) process.env.HOME = originalHome
+      else delete process.env.HOME
+      rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    const createProject = () => {
+      const project = createMockInternalProject({
+        slug: 'github:owner/repo',
+        path: `${tmpHome}/repo`,
+      })
+      project.config.services = { api: { command: 'node server.js' } }
+      return project
+    }
+
+    const timestampedLogs = (logDir: string) =>
+      readdirSync(logDir)
+        .filter((name) => /^\d+\.log$/.test(name))
+        .sort()
+
+    it('rotates the log and repoints both symlinks on a real start', async (t) => {
+      const project = createProject()
+      const manager = new ServiceManager(project)
+      t.mock.method(launchctl, 'print', async () => null)
+      t.mock.method(launchctl, 'enable', async () => ({
+        success: true,
+        output: '',
+      }))
+      t.mock.method(launchctl, 'bootstrap', async () => ({
+        success: true,
+        output: '',
+      }))
+
+      const result = await manager.startService('api', { portResolved: true })
+      ok(result.success, result.message)
+
+      const logDir = manager.getServiceLogDir('api')
+      const logs = timestampedLogs(logDir)
+      strictEqual(logs.length, 1, 'one timestamped log after first start')
+      // Both the stable (plist) symlink and the host symlink point at the new run.
+      strictEqual(readlinkSync(manager.getStableLogPath('api')), logs[0])
+      strictEqual(readlinkSync(manager.getLogPath('api')), logs[0])
+    })
+
+    it('leaves the log symlink untouched when a live service is re-started with an unchanged plist', async (t) => {
+      const project = createProject()
+      const manager = new ServiceManager(project)
+
+      // Initial start lays down the plist and the first log file.
+      t.mock.method(launchctl, 'print', async () => null)
+      t.mock.method(launchctl, 'enable', async () => ({
+        success: true,
+        output: '',
+      }))
+      t.mock.method(launchctl, 'bootstrap', async () => ({
+        success: true,
+        output: '',
+      }))
+      await manager.startService('api', { portResolved: true })
+
+      const logDir = manager.getServiceLogDir('api')
+      const stableLink = manager.getStableLogPath('api')
+      const liveTarget = readlinkSync(stableLink)
+
+      // Re-run while the service is live with an unchanged plist — exactly what
+      // the reconciler does after every command, for every running service in
+      // every project and worktree. The symlink must keep pointing at the file
+      // the live process is still writing to, not a fresh empty file.
+      t.mock.restoreAll()
+      t.mock.method(launchctl, 'print', async () => ({
+        label: 'test',
+        pid: 123,
+        state: 'running',
+        status: 'running',
+      }))
+      const bootout = t.mock.method(launchctl, 'bootout', async () => ({
+        success: true,
+        output: '',
+      }))
+      const bootstrap = t.mock.method(launchctl, 'bootstrap', async () => ({
+        success: true,
+        output: '',
+      }))
+      t.mock.method(launchctl, 'enable', async () => ({
+        success: true,
+        output: '',
+      }))
+
+      const result = await manager.startService('api', {
+        portResolved: true,
+        reviveIfNotRunning: false,
+      })
+      ok(result.success, result.message)
+      strictEqual(bootout.mock.callCount(), 0, 'live service is not booted out')
+      strictEqual(
+        bootstrap.mock.callCount(),
+        0,
+        'live service is not bootstrapped',
+      )
+
+      strictEqual(
+        readlinkSync(stableLink),
+        liveTarget,
+        'latest.log still points at the live log',
+      )
+      strictEqual(
+        timestampedLogs(logDir).length,
+        1,
+        'no extra empty log file was created',
+      )
     })
   })
 

--- a/packages/sdk/src/lib/services/manager.ts
+++ b/packages/sdk/src/lib/services/manager.ts
@@ -636,8 +636,14 @@ export class ServiceManager {
     // Ensure denvig directories exist
     await this.ensureDenvigDirectories()
 
-    // Create a new timestamped log file for this service run
-    const logFilePath = await this.createLogFile(name)
+    // A fresh timestamped log file (and the `latest.log` / `latest.<host>.log`
+    // symlinks pointing at it) is created only when launchd actually (re)opens
+    // it below — on a genuine bootstrap or restart. A no-op start (an
+    // already-running service whose plist is unchanged, which the reconciler
+    // performs after every command for every running service) must leave the
+    // existing symlinks pointing at the file the live process is still writing
+    // to, rather than swapping them for a fresh empty file it will never touch.
+    let logFilePath: string | undefined
 
     // Ensure plist file exists
     const plistPath = this.getPlistPath(name)
@@ -645,6 +651,12 @@ export class ServiceManager {
 
     // Ensure working directory exists (e.g. global services use auto-generated paths)
     await mkdir(workingDirectory, { recursive: true })
+
+    // The service directory holds the wrapper script (written below) and the
+    // log files. It must exist on every start, including no-op reconciles that
+    // skip creating a fresh log, so create it explicitly rather than relying on
+    // `createLogFile()` to make it as a side effect.
+    await mkdir(this.getServiceDir(name), { recursive: true })
 
     // Create wrapper script so Login Items shows the script name instead of "zsh"
     const scriptPath = this.getServiceScriptPath(name)
@@ -709,6 +721,7 @@ export class ServiceManager {
     // The reconciler relies on this being idempotent: if the plist is
     // unchanged and the service is already bootstrapped, do nothing.
     if (!isBootstrapped) {
+      logFilePath = await this.createLogFile(name)
       await writePlist()
       const bootstrapResult = await launchctl.bootstrap(plistPath)
       if (!bootstrapResult.success) {
@@ -750,6 +763,7 @@ export class ServiceManager {
 
       // sleep for 1 second to allow bootout to complete
       await new Promise((resolve) => setTimeout(resolve, 1000))
+      logFilePath = await this.createLogFile(name)
       await writePlist()
       const bootstrapResult = await launchctl.bootstrap(plistPath)
       if (!bootstrapResult.success) {
@@ -771,11 +785,17 @@ export class ServiceManager {
     }
 
     // Append Service Started entry to the new log file
-    try {
-      const timestamp = new Date().toISOString()
-      await appendFile(logFilePath, `[${timestamp}] Service Started\n`, 'utf-8')
-    } catch {
-      // ignore logging errors
+    if (logFilePath) {
+      try {
+        const timestamp = new Date().toISOString()
+        await appendFile(
+          logFilePath,
+          `[${timestamp}] Service Started\n`,
+          'utf-8',
+        )
+      } catch {
+        // ignore logging errors
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary

Fixes service `latest.log` symlinks being repointed to a fresh **empty** file on every `startService` call — including the no-op starts the reconciler performs for every running service after every command — while the live launchd process kept writing to the now-orphaned old file. The result was `services logs` showing an empty/wrong log, and it looked worktree-specific because the reconciler processes every project's worktree services by default (#234), so a command in one worktree truncated the visible logs of services in every other worktree.

Service log directories are already unique per worktree (each checkout has a distinct `id` → its own `~/.denvig/services/<id>.<service>/logs/`), so worktrees never shared a directory. The defect was purely the unconditional log rotation.

## Changes

- `startService` now creates a fresh timestamped log and repoints the `latest.log` / `latest.<host>.log` symlinks **only when launchd actually (re)opens the file** — a genuine bootstrap or restart. An already-running service with an unchanged plist (every reconcile) keeps its existing log.
- Added an explicit `mkdir` of the service directory, which previously relied on `createLogFile()` creating it as a side effect.
- Added tests: a real start rotates and repoints both symlinks; a live re-start with an unchanged plist leaves the symlink and log files untouched.

## Testing

- `pnpm run test` — full SDK suite passes (602/602).
- `pnpm run lint` clean, `pnpm run codegen` no diffs, `bin/denvig-dev version` works.
