### PR TITLE
Make gateway commands consistent with state.json as source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - The gateway now writes every service into a single `~/.denvig/nginx.conf` (sorted by domain, each block annotated with its service details and log location) instead of one hashed file per service, making the running config easier to inspect
+- `denvig gateway` now lists every running service routed through the gateway across all projects, matching what `gateway configure` reports
+- `gateway` and `gateway configure` now display each service in the same format
 
 ## [0.7.2] - 2026-06-23
 

--- a/packages/cli/src/commands/gateway/configure.ts
+++ b/packages/cli/src/commands/gateway/configure.ts
@@ -1,4 +1,5 @@
 import { Command } from '../../lib/command.ts'
+import { formatGatewayService } from '../../lib/formatters/gateway-service.ts'
 
 export const gatewayConfigureCommand = new Command({
   name: 'gateway:configure',
@@ -61,33 +62,26 @@ export const gatewayConfigureCommand = new Command({
       }
 
       if (result.services.length === 0) {
-        console.log('No services with http.domain and http.port configured.')
+        console.log('No running services are routed through the gateway')
       } else {
-        console.log('Gateway Configuration:')
+        console.log('Services:')
         console.log('')
 
         for (const service of result.services) {
-          const certIcon = service.certStatus === 'valid' ? '✓' : '✗'
-          const configIcon = service.configStatus === 'written' ? '✓' : '✗'
-          const cnamesInfo =
-            service.cnames.length > 0
-              ? ` + ${service.cnames.length} cname${service.cnames.length > 1 ? 's' : ''}`
-              : ''
-
-          console.log(`  ${service.projectSlug}/${service.serviceName}:`)
           console.log(
-            `    Domain: ${service.domain}${cnamesInfo} -> localhost:${service.port}`,
-          )
-          const certDetail = service.certDir
-            ? ` (${service.certDir.split('/').pop()})`
-            : service.certMessage
-              ? ` (${service.certMessage})`
-              : ''
-          console.log(
-            `    Certs:  ${certIcon} ${service.certStatus}${certDetail}`,
-          )
-          console.log(
-            `    Nginx:  ${configIcon} ${service.configStatus}${service.configMessage ? ` (${service.configMessage})` : ''}`,
+            formatGatewayService({
+              projectSlug: service.projectSlug,
+              serviceName: service.serviceName,
+              domains: [service.domain, ...service.cnames],
+              port: service.port,
+              certStatus: service.certStatus,
+              certDir: service.certDir,
+              certMessage: service.certMessage,
+              nginxOk: service.configStatus === 'written',
+              nginxLabel:
+                service.configStatus === 'written' ? 'configured' : 'error',
+              nginxMessage: service.configMessage,
+            }),
           )
           console.log('')
         }

--- a/packages/cli/src/commands/gateway/status.ts
+++ b/packages/cli/src/commands/gateway/status.ts
@@ -1,4 +1,5 @@
 import { Command } from '../../lib/command.ts'
+import { formatGatewayService } from '../../lib/formatters/gateway-service.ts'
 
 export const gatewayStatusCommand = new Command({
   name: 'gateway:status',
@@ -40,9 +41,9 @@ export const gatewayStatusCommand = new Command({
     console.log('')
 
     if (status.services.length === 0) {
-      console.log('No services configured with http.domain')
+      console.log('No running services are routed through the gateway')
       console.log('')
-      console.log('To configure a service for gateway, add http.domain:')
+      console.log('Start a service with an http.domain to add a route:')
       console.log('')
       console.log('  services:')
       console.log('    my-service:')
@@ -51,28 +52,25 @@ export const gatewayStatusCommand = new Command({
       console.log('        port: 3000')
       console.log('        domain: my-service.denvig.localhost')
       console.log('')
-      return { success: true, message: 'No gateway services configured' }
+      return { success: true, message: 'No gateway services running' }
     }
 
     console.log('Services:')
     console.log('')
 
     for (const service of status.services) {
-      const allDomains = [service.domain, ...service.cnames]
-      const certStatus = !service.secure ? '-' : service.certFound ? '✓' : '✗'
-      const certLabel = !service.secure
-        ? 'not enabled'
-        : service.certFound
-          ? 'found'
-          : 'missing'
-      const nginxStatus = service.nginxConfigExists ? '✓' : '✗'
-
-      console.log(`  ${service.name}:`)
-      console.log(`    Domains: ${allDomains.join(', ')}`)
-      console.log(`    Port:    ${service.port || '(not set)'}`)
-      console.log(`    Certs:   ${certStatus} ${certLabel}`)
       console.log(
-        `    Nginx:   ${nginxStatus} ${service.nginxConfigExists ? 'configured' : 'not generated'}`,
+        formatGatewayService({
+          projectSlug: service.projectSlug,
+          serviceName: service.name,
+          domains: [service.domain, ...service.cnames],
+          port: service.port,
+          certStatus: service.certStatus,
+          certDir: service.certDir,
+          certMessage: service.certMessage,
+          nginxOk: service.nginxConfigExists,
+          nginxLabel: service.nginxConfigExists ? 'configured' : 'missing',
+        }),
       )
       console.log('')
     }

--- a/packages/cli/src/lib/formatters/gateway-service.ts
+++ b/packages/cli/src/lib/formatters/gateway-service.ts
@@ -1,0 +1,47 @@
+/** Normalized view of one gateway service, rendered the same everywhere. */
+export type GatewayServiceView = {
+  projectSlug: string
+  serviceName: string
+  /** Primary domain first, then any cnames. */
+  domains: string[]
+  port: number
+  certStatus: 'valid' | 'missing' | 'not_configured'
+  certDir?: string | null
+  certMessage?: string
+  /** Whether the service's server block is present in / written to nginx. */
+  nginxOk: boolean
+  /** Short nginx state label, e.g. `configured`, `missing`, `error`. */
+  nginxLabel: string
+  nginxMessage?: string
+}
+
+const certIcon = (status: GatewayServiceView['certStatus']): string =>
+  status === 'valid' ? '✓' : status === 'missing' ? '✗' : '-'
+
+/**
+ * Render a gateway service as an indented block. Shared by `gateway status`
+ * and `gateway configure` so both commands present the data identically:
+ *
+ * ```
+ *   slug/service
+ *     Domains: a.localhost, b.localhost -> localhost:3000
+ *     Certs:   ✓ valid (wildcard)
+ *     Nginx:   ✓ configured
+ * ```
+ */
+export const formatGatewayService = (view: GatewayServiceView): string => {
+  const certDetail =
+    view.certStatus === 'valid' && view.certDir
+      ? ` (${view.certDir.split('/').pop()})`
+      : view.certStatus === 'missing' && view.certMessage
+        ? ` (${view.certMessage})`
+        : ''
+  const nginxMessage = view.nginxMessage ? ` (${view.nginxMessage})` : ''
+
+  return [
+    `  ${view.projectSlug}/${view.serviceName}`,
+    `    Domains: ${view.domains.join(', ')} -> localhost:${view.port}`,
+    `    Certs:   ${certIcon(view.certStatus)} ${view.certStatus}${certDetail}`,
+    `    Nginx:   ${view.nginxOk ? '✓' : '✗'} ${view.nginxLabel}${nginxMessage}`,
+  ].join('\n')
+}

--- a/packages/sdk/src/lib/gateway/configure.ts
+++ b/packages/sdk/src/lib/gateway/configure.ts
@@ -1,8 +1,5 @@
 import { getGlobalConfig } from '../config.ts'
-import { resolveProjectCheckouts } from '../projects.ts'
-import { createGlobalProject } from '../services/global.ts'
 import { getServiceStableLogPath } from '../services/paths.ts'
-import { readState } from '../services/state.ts'
 import { writeGatewayHtmlFiles } from './html.ts'
 import {
   type NginxConfigOptions,
@@ -11,8 +8,7 @@ import {
   writeDenvigNginxConfig,
   writeNginxMainConfig,
 } from './nginx.ts'
-
-import type { Cert } from '../services/state.ts'
+import { resolveGatewayServices } from './routes.ts'
 
 export type ConfigureServiceResult = {
   projectSlug: string
@@ -36,26 +32,15 @@ export type ConfigureGatewayResult = {
   message?: string
 }
 
-type RouteGroup = {
-  projectId: string
-  serviceName: string
-  port: number
-  secure: boolean
-  /** Order: first entry is the primary domain, the rest are cnames. */
-  domains: string[]
-  /** Key into `state.certs` shared by all routes in this group, if any. */
-  certKey?: string
-}
-
 /**
  * Remove all denvig nginx configs and rebuild from the runtime gateway
  * routes recorded in `~/.denvig/state.json`.
  *
- * The state's `gatewayRoutes` map is the source of truth: each running
- * route generates an nginx server block that proxies the domain to the
- * service's allocated port. Routes for the same `(project, service)`
- * pair are merged into a single nginx config so cnames sit alongside
- * the primary domain in the same `server_name` directive.
+ * The state's `gatewayRoutes` map is the source of truth (resolved via
+ * `resolveGatewayServices`): each running route generates an nginx server
+ * block that proxies the domain to the service's allocated port. Routes for
+ * the same `(project, service)` pair are merged into a single nginx config so
+ * cnames sit alongside the primary domain in the same `server_name` directive.
  */
 export async function configureGateway(): Promise<ConfigureGatewayResult> {
   const globalConfig = await getGlobalConfig()
@@ -86,98 +71,37 @@ export async function configureGateway(): Promise<ConfigureGatewayResult> {
     }
   }
 
-  // Resolve project metadata (slug + path) by ID. The route only stores
-  // the project ID, but the nginx template wants the slug and absolute
-  // path for comments and the document root. Routes are keyed by the
-  // checkout's id, so this maps every worktree back to its slug and path.
-  const projectsById = await resolveProjectCheckouts()
-  const globalProject = await createGlobalProject()
-  projectsById.set(globalProject.id, {
-    slug: globalProject.slug,
-    path: globalProject.path,
-  })
-
-  // Group routes by (projectId, serviceName) so cnames stay co-located.
-  const state = await readState()
-  const groups = new Map<string, RouteGroup>()
-  for (const [domain, route] of Object.entries(state.gatewayRoutes)) {
-    if (route.desiredStatus !== 'running') continue
-    const key = `${route.project}.${route.service}`
-    const existing = groups.get(key)
-    if (existing) {
-      existing.domains.push(domain)
-      // Routes inside a group should all reference the same cert, but
-      // tolerate one missing the key by preferring whichever does carry one.
-      if (!existing.certKey && route.cert) existing.certKey = route.cert
-    } else {
-      groups.set(key, {
-        projectId: route.project,
-        serviceName: route.service,
-        port: route.port,
-        secure: route.secure,
-        domains: [domain],
-        certKey: route.cert,
-      })
-    }
-  }
+  // state.json is the single source of truth — the same resolved routes that
+  // `gateway status` reports are rendered into nginx here.
+  const routes = await resolveGatewayServices()
 
   const services: ConfigureServiceResult[] = []
   const serverConfigs: NginxConfigOptions[] = []
-  for (const group of groups.values()) {
-    const projectMeta = projectsById.get(group.projectId)
-    if (!projectMeta) continue
-
-    const [primary, ...cnames] = group.domains
-    const secure = group.secure
-
-    let sslCertPath: string | undefined
-    let sslKeyPath: string | undefined
-    let certStatus: ConfigureServiceResult['certStatus'] = 'not_configured'
-    let resolvedCertDir: string | undefined
-    let certMessage: string | undefined
-
-    if (secure) {
-      const cert: Cert | undefined = group.certKey
-        ? state.certs[group.certKey]
-        : undefined
-      if (cert) {
-        sslCertPath = cert.certPath
-        sslKeyPath = cert.keyPath
-        certStatus = 'valid'
-        resolvedCertDir = cert.dir
-      } else {
-        certStatus = 'missing'
-        certMessage = group.certKey
-          ? `cert "${group.certKey}" referenced by route is not in state.certs`
-          : 'route has no cert reference; restart the service to refresh state.certs'
-      }
-    }
-
-    const result: ConfigureServiceResult = {
-      projectSlug: projectMeta.slug,
-      serviceName: group.serviceName,
-      domain: primary,
-      cnames,
-      port: group.port,
-      certStatus,
-      certDir: resolvedCertDir,
-      certMessage,
+  for (const route of routes) {
+    services.push({
+      projectSlug: route.projectSlug,
+      serviceName: route.serviceName,
+      domain: route.domain,
+      cnames: route.cnames,
+      port: route.port,
+      certStatus: route.certStatus,
+      certDir: route.certDir,
+      certMessage: route.certMessage,
       configStatus: 'written',
-    }
+    })
 
     serverConfigs.push({
-      projectId: group.projectId,
-      projectPath: projectMeta.path,
-      projectSlug: projectMeta.slug,
-      serviceName: group.serviceName,
-      port: group.port,
-      domain: primary,
-      cnames,
-      sslCertPath,
-      sslKeyPath,
-      logPath: getServiceStableLogPath(group.projectId, group.serviceName),
+      projectId: route.projectId,
+      projectPath: route.projectPath,
+      projectSlug: route.projectSlug,
+      serviceName: route.serviceName,
+      port: route.port,
+      domain: route.domain,
+      cnames: route.cnames,
+      sslCertPath: route.sslCertPath,
+      sslKeyPath: route.sslKeyPath,
+      logPath: getServiceStableLogPath(route.projectId, route.serviceName),
     })
-    services.push(result)
   }
 
   // Write every server block into the single combined denvig nginx config.

--- a/packages/sdk/src/lib/gateway/routes.test.ts
+++ b/packages/sdk/src/lib/gateway/routes.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+
+import { createGlobalProject } from '../services/global.ts'
+import { setCert, setGatewayRoute } from '../services/state.ts'
+import { resolveGatewayServices } from './routes.ts'
+
+let originalHome: string | undefined
+let tmpHome = ''
+
+/**
+ * Routes are keyed to the deterministic global project id so they resolve to a
+ * real checkout (slug `global`) without registering external projects.
+ */
+const globalId = async () => (await createGlobalProject()).id
+
+describe('resolveGatewayServices', () => {
+  beforeEach(() => {
+    originalHome = process.env.HOME
+    tmpHome = mkdtempSync(`${tmpdir()}/denvig-routes-`)
+    process.env.HOME = tmpHome
+  })
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome
+    else delete process.env.HOME
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('returns no services when state has no routes', async () => {
+    assert.deepStrictEqual(await resolveGatewayServices(), [])
+  })
+
+  it('groups cnames with their primary domain for one service', async () => {
+    const project = await globalId()
+    await setGatewayRoute('api.denvig.localhost', {
+      project,
+      service: 'api',
+      port: 3000,
+      defaultService: true,
+      secure: false,
+      desiredStatus: 'running',
+    })
+    await setGatewayRoute('api-alt.denvig.localhost', {
+      project,
+      service: 'api',
+      port: 3000,
+      defaultService: false,
+      secure: false,
+      desiredStatus: 'running',
+    })
+
+    const services = await resolveGatewayServices()
+    assert.strictEqual(services.length, 1)
+    assert.strictEqual(services[0].serviceName, 'api')
+    assert.strictEqual(services[0].domain, 'api.denvig.localhost')
+    assert.deepStrictEqual(services[0].cnames, ['api-alt.denvig.localhost'])
+    assert.strictEqual(services[0].certStatus, 'not_configured')
+  })
+
+  it('excludes routes whose desiredStatus is not running', async () => {
+    const project = await globalId()
+    await setGatewayRoute('running.denvig.localhost', {
+      project,
+      service: 'up',
+      port: 3000,
+      defaultService: true,
+      secure: false,
+      desiredStatus: 'running',
+    })
+    await setGatewayRoute('stopped.denvig.localhost', {
+      project,
+      service: 'down',
+      port: 3001,
+      defaultService: true,
+      secure: false,
+      desiredStatus: 'stopped',
+    })
+
+    const services = await resolveGatewayServices()
+    assert.deepStrictEqual(
+      services.map((s) => s.serviceName),
+      ['up'],
+    )
+  })
+
+  it('resolves a secure route to its cert and marks a missing one', async () => {
+    const project = await globalId()
+    await setCert('wildcard', {
+      dir: '/certs/wildcard',
+      certPath: '/certs/wildcard/fullchain.pem',
+      keyPath: '/certs/wildcard/privkey.pem',
+      domains: ['secure.denvig.localhost'],
+    })
+    await setGatewayRoute('secure.denvig.localhost', {
+      project,
+      service: 'secure',
+      port: 3000,
+      defaultService: true,
+      secure: true,
+      desiredStatus: 'running',
+      cert: 'wildcard',
+    })
+    await setGatewayRoute('nocert.denvig.localhost', {
+      project,
+      service: 'nocert',
+      port: 3001,
+      defaultService: true,
+      secure: true,
+      desiredStatus: 'running',
+      cert: 'absent',
+    })
+
+    const services = await resolveGatewayServices()
+    const secure = services.find((s) => s.serviceName === 'secure')
+    const noCert = services.find((s) => s.serviceName === 'nocert')
+
+    assert.strictEqual(secure?.certStatus, 'valid')
+    assert.strictEqual(secure?.sslCertPath, '/certs/wildcard/fullchain.pem')
+    assert.strictEqual(secure?.sslKeyPath, '/certs/wildcard/privkey.pem')
+    assert.strictEqual(noCert?.certStatus, 'missing')
+  })
+
+  it('sorts services alphabetically by primary domain', async () => {
+    const project = await globalId()
+    for (const [domain, service] of [
+      ['web.denvig.localhost', 'web'],
+      ['api.denvig.localhost', 'api'],
+      ['mail.denvig.localhost', 'mail'],
+    ]) {
+      await setGatewayRoute(domain, {
+        project,
+        service,
+        port: 3000,
+        defaultService: true,
+        secure: false,
+        desiredStatus: 'running',
+      })
+    }
+
+    const services = await resolveGatewayServices()
+    assert.deepStrictEqual(
+      services.map((s) => s.domain),
+      ['api.denvig.localhost', 'mail.denvig.localhost', 'web.denvig.localhost'],
+    )
+  })
+})

--- a/packages/sdk/src/lib/gateway/routes.ts
+++ b/packages/sdk/src/lib/gateway/routes.ts
@@ -1,0 +1,132 @@
+import { resolveProjectCheckouts } from '../projects.ts'
+import { createGlobalProject } from '../services/global.ts'
+import { readState } from '../services/state.ts'
+
+import type { Cert } from '../services/state.ts'
+
+/**
+ * A running gateway route resolved from `~/.denvig/state.json`, with the
+ * project metadata and cert it references already looked up. This is the
+ * single source of truth shared by `gateway status` and `gateway configure`
+ * so both commands describe exactly the same set of services.
+ */
+export type GatewayServiceRoute = {
+  projectId: string
+  projectSlug: string
+  projectPath: string
+  serviceName: string
+  port: number
+  secure: boolean
+  /** Primary domain (first claimed); cnames follow in `cnames`. */
+  domain: string
+  cnames: string[]
+  certStatus: 'valid' | 'missing' | 'not_configured'
+  sslCertPath?: string
+  sslKeyPath?: string
+  certDir?: string
+  certMessage?: string
+}
+
+type RouteGroup = {
+  projectId: string
+  serviceName: string
+  port: number
+  secure: boolean
+  /** Order: first entry is the primary domain, the rest are cnames. */
+  domains: string[]
+  /** Key into `state.certs` shared by all routes in this group, if any. */
+  certKey?: string
+}
+
+/**
+ * Resolve every running gateway route into a fully-described service.
+ *
+ * Routes for the same `(project, service)` pair are merged so cnames sit
+ * alongside the primary domain. The project id recorded on each route is
+ * mapped back to its checkout (slug + path); routes whose project checkout no
+ * longer exists are orphaned and dropped. Secure routes resolve their cert
+ * from `state.certs`. Results are sorted by primary domain for stable output.
+ */
+export async function resolveGatewayServices(): Promise<GatewayServiceRoute[]> {
+  // The route only stores a project id; resolve it to the checkout's slug and
+  // path. The global project isn't in this map, so add it explicitly.
+  const projectsById = await resolveProjectCheckouts()
+  const globalProject = await createGlobalProject()
+  projectsById.set(globalProject.id, {
+    slug: globalProject.slug,
+    path: globalProject.path,
+  })
+
+  const state = await readState()
+  const groups = new Map<string, RouteGroup>()
+  for (const [domain, route] of Object.entries(state.gatewayRoutes)) {
+    if (route.desiredStatus !== 'running') continue
+    const key = `${route.project}.${route.service}`
+    const existing = groups.get(key)
+    if (existing) {
+      existing.domains.push(domain)
+      // Routes inside a group should all reference the same cert, but
+      // tolerate one missing the key by preferring whichever does carry one.
+      if (!existing.certKey && route.cert) existing.certKey = route.cert
+    } else {
+      groups.set(key, {
+        projectId: route.project,
+        serviceName: route.service,
+        port: route.port,
+        secure: route.secure,
+        domains: [domain],
+        certKey: route.cert,
+      })
+    }
+  }
+
+  const resolved: GatewayServiceRoute[] = []
+  for (const group of groups.values()) {
+    const projectMeta = projectsById.get(group.projectId)
+    if (!projectMeta) continue
+
+    const [primary, ...cnames] = group.domains
+
+    let sslCertPath: string | undefined
+    let sslKeyPath: string | undefined
+    let certDir: string | undefined
+    let certMessage: string | undefined
+    let certStatus: GatewayServiceRoute['certStatus'] = 'not_configured'
+
+    if (group.secure) {
+      const cert: Cert | undefined = group.certKey
+        ? state.certs[group.certKey]
+        : undefined
+      if (cert) {
+        sslCertPath = cert.certPath
+        sslKeyPath = cert.keyPath
+        certDir = cert.dir
+        certStatus = 'valid'
+      } else {
+        certStatus = 'missing'
+        certMessage = group.certKey
+          ? `cert "${group.certKey}" referenced by route is not in state.certs`
+          : 'route has no cert reference; restart the service to refresh state.certs'
+      }
+    }
+
+    resolved.push({
+      projectId: group.projectId,
+      projectSlug: projectMeta.slug,
+      projectPath: projectMeta.path,
+      serviceName: group.serviceName,
+      port: group.port,
+      secure: group.secure,
+      domain: primary,
+      cnames,
+      certStatus,
+      sslCertPath,
+      sslKeyPath,
+      certDir,
+      certMessage,
+    })
+  }
+
+  resolved.sort((a, b) => a.domain.localeCompare(b.domain))
+  return resolved
+}

--- a/packages/sdk/src/operations/gateway.ts
+++ b/packages/sdk/src/operations/gateway.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'node:child_process'
 
 import { getGlobalConfig } from '../lib/config.ts'
-import { resolveProjectContext } from '../lib/context.ts'
-import { findCertForDomain, resolveSslPaths } from '../lib/gateway/certs.ts'
 import {
   type ConfigureGatewayResult,
   configureGateway,
@@ -11,6 +9,7 @@ import {
   getDenvigNginxConfPath,
   getNginxConfPath,
 } from '../lib/gateway/nginx.ts'
+import { resolveGatewayServices } from '../lib/gateway/routes.ts'
 import { safeReadTextFile } from '../lib/safeReadFile.ts'
 import {
   type ReconcileResult,
@@ -42,17 +41,21 @@ const getNginxProcessStatus = (): NginxProcessStatus => {
   }
 }
 
-/** Gateway status for a single service with an `http.domain`. */
+/** Gateway status for a single running route, as recorded in state.json. */
 export type GatewayServiceStatus = {
   name: string
+  /** Slug of the project (checkout) that owns the route. */
+  projectSlug: string
   domain: string
   cnames: string[]
-  port: number | undefined
+  port: number
   secure: boolean
-  /** Whether usable SSL key/cert files were resolved for the domain. */
-  certFound: boolean
+  /** Cert resolution for a secure route; `not_configured` when not secure. */
+  certStatus: 'valid' | 'missing' | 'not_configured'
   /** The certificate directory backing the domain, if any. */
   certDir: string | null
+  /** Explanation when `certStatus` is `missing`. */
+  certMessage?: string
   /** The nginx config path for this service. */
   nginxConfigPath: string
   nginxConfigExists: boolean
@@ -67,61 +70,42 @@ export type GatewayStatus = {
   nginxConf: string
   /** The nginx process state. */
   nginx: NginxProcessStatus
-  /** Gateway-configured services for the resolved project. */
+  /** Every running gateway service recorded in state.json. */
   services: GatewayServiceStatus[]
 }
 
-export type GatewayStatusOptions = {
-  /** Working directory used to resolve the project whose services are listed. */
-  cwd?: string
-}
-
 /**
- * Report the gateway's global state (enabled flag, nginx process, paths) plus
- * the gateway-configured services of the project resolved from `cwd`. This is
- * the shared data path behind `denvig gateway status` and `sdk.gateway.status()`.
+ * Report the gateway's global state (handler, nginx process, paths) plus every
+ * running gateway service recorded in `~/.denvig/state.json`. This reads the
+ * same resolved routes that `gateway configure` renders into nginx, so the two
+ * commands always describe the identical set of services.
  */
-export const getGatewayStatus = async (
-  options: GatewayStatusOptions = {},
-): Promise<GatewayStatus> => {
+export const getGatewayStatus = async (): Promise<GatewayStatus> => {
   const globalConfig = await getGlobalConfig()
   const gateway = globalConfig.gateway
-
-  const services: GatewayServiceStatus[] = []
-  const { project } = await resolveProjectContext({
-    cwd: options.cwd ?? process.cwd(),
-  })
 
   // Every service shares the single combined denvig config; read it once and
   // detect a service's presence by its upstream block.
   const nginxConfigPath = getDenvigNginxConfPath()
   const nginxConfigContent = await safeReadTextFile(nginxConfigPath)
 
-  if (project) {
-    const worktree = project.activeWorktree
-    const configured = worktree.config.services || {}
-    for (const [name, config] of Object.entries(configured)) {
-      const domain = config.http?.domain
-      if (!domain) continue
-
-      const secure = config.http?.secure ?? false
-      const certDir = secure ? await findCertForDomain(domain) : null
-      const sslPaths = certDir ? await resolveSslPaths(certDir) : null
-      const upstreamName = `denvig-${worktree.id}--${name}`
-
-      services.push({
-        name,
-        domain,
-        cnames: config.http?.cnames || [],
-        port: config.http?.port,
-        secure,
-        certFound: !!sslPaths,
-        certDir,
-        nginxConfigPath,
-        nginxConfigExists: nginxConfigContent?.includes(upstreamName) ?? false,
-      })
+  const routes = await resolveGatewayServices()
+  const services: GatewayServiceStatus[] = routes.map((route) => {
+    const upstreamName = `denvig-${route.projectId}--${route.serviceName}`
+    return {
+      name: route.serviceName,
+      projectSlug: route.projectSlug,
+      domain: route.domain,
+      cnames: route.cnames,
+      port: route.port,
+      secure: route.secure,
+      certStatus: route.certStatus,
+      certDir: route.certDir ?? null,
+      certMessage: route.certMessage,
+      nginxConfigPath,
+      nginxConfigExists: nginxConfigContent?.includes(upstreamName) ?? false,
     }
-  }
+  })
 
   return {
     handler: gateway.handler,

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -203,13 +203,11 @@ export class DenvigSDK {
 
   gateway = {
     /**
-     * Report the gateway's global state plus the gateway-configured services of
-     * the project resolved from the SDK's `cwd`.
+     * Report the gateway's global state plus every running gateway service
+     * recorded in state.json.
      */
     status: (): Promise<GatewayStatus> =>
-      track(this.ctx, 'gateway.status', null, () =>
-        getGatewayStatus({ cwd: this.ctx.cwd }),
-      ),
+      track(this.ctx, 'gateway.status', null, () => getGatewayStatus()),
 
     /** Reconcile services and rebuild every nginx config from runtime state. */
     configure: (): Promise<ConfigureGatewayOutput> =>


### PR DESCRIPTION
## Summary

`denvig gateway` (status) and `denvig gateway configure` disagreed about what the gateway was serving: status listed only the **current project's configured services** (often just one), while configure listed **every running route from state.json**. They also rendered each service in different formats, making them hard to compare when debugging.

This makes `~/.denvig/state.json` the single source of truth for all gateway commands, and gives them one standard way of displaying the data.

## What changed

- **Single source of truth**: new `resolveGatewayServices()` reads `state.gatewayRoutes` and returns fully-resolved services — groups cnames with their primary domain, maps each route's project id back to its checkout (slug + path), resolves certs from `state.certs`, and sorts by domain. Both `gateway status` and `gateway configure` now resolve through it, so they always describe the identical set of services.
- **Consistent output**: a shared `formatGatewayService()` formatter renders each service the same way in both commands:
  ```
    slug/service
      Domains: a.localhost, b.localhost -> localhost:3000
      Certs:   ✓ valid (wildcard)
      Nginx:   ✓ configured
  ```
  Previously the two diverged on header style, domain/port layout, cert vocabulary (`found` vs `valid`), and indentation.
- `gateway status` now reflects **what is actually routed** (running routes in state) rather than what is merely configured in the current project; a configured-but-stopped service no longer appears. It also gained a `Project:`/slug per service so routes across projects are unambiguous.
- Status cert info now carries `certStatus` + `certMessage` (mirroring configure) instead of a bare boolean, so both show the same cert detail and failure reason.

## Verification

- Live diff of the service blocks from both commands: 28 lines each, **byte-for-byte identical**.
- Both commands report the identical 7 running services across all projects (verified via JSON).
- Added `routes.test.ts` (5 tests) covering grouping, stopped-route exclusion, cert resolution, and sorting.
- `check-types`, `lint`, and `build` pass; gateway tests 26/26 green.

## Notes

- The only intentional per-command difference is the `Nginx:` verb in failure cases — status says `missing` (block absent from the generated config), configure says `error (message)` (the write failed) — since they report different moments. The success case is `configured` in both.
- Pre-existing unrelated test failures remain (`examples/npm` + `examples/pnpm` sandbox tests; a parallel-run flake in `git.test.ts` that passes in isolation).