### PR TITLE
Update pnpm to 11.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@denvig/workspace",
   "version": "0.7.2",
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.11.0",
   "license": "MIT",
   "description": "Workspace root for the denvig CLI and its packages",
   "type": "module",


### PR DESCRIPTION
## Summary

Updates the `packageManager` field from `pnpm@11.5.2` to `pnpm@11.11.0`.

Deliberately locked to **11.11.0** rather than the latest **11.12.x** release, which contains a known bug.

## Notable changes (11.6.0 → 11.11.0)

- New commands: `pnpm access` (registry visibility/collaborators) and `pnpm prefix`
- `pnpm install --dry-run` to preview changes without writing to disk
- `frozenStore` setting for installs against read-only package stores (Nix, bind mounts, OCI layers)
- Support for installing the pnpm v12 (Rust port) native binaries
- ~30% lower peak memory during cold-cache dependency resolution
- Multiple path-traversal security fixes in lockfile handling
- Deterministic peer dependency resolution and `pnpm audit` optimized from quadratic to linear time

## Verification

- `pnpm install` runs cleanly on `v11.11.0` (`Done in 344ms using pnpm v11.11.0`)
